### PR TITLE
Fixes for Go 1.8/1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# apm-agent-go: APM Agent for Go (pre-alpha) [![GoDoc](https://godoc.org/github.com/elastic/apm-agent-go/trace?status.svg)](http://godoc.org/github.com/elastic/apm-agent-go/trace)
+# apm-agent-go: APM Agent for Go (pre-alpha) [![GoDoc](https://godoc.org/github.com/elastic/apm-agent-go/trace?status.svg)](http://godoc.org/github.com/elastic/apm-agent-go/trace) [![Travis-CI](https://travis-ci.org/elastic/apm-agent-go.svg)](https://travis-ci.org/elastic/apm-agent-go)
 
 This is the official Go package for [Elastic APM][].
 

--- a/contrib/apmgin/apmgin_test.go
+++ b/contrib/apmgin/apmgin_test.go
@@ -42,7 +42,6 @@ func BenchmarkWithMiddleware(b *testing.B) {
 }
 
 func benchmarkEngine(b *testing.B, path string, addMiddleware func(*gin.Engine)) {
-	b.Helper()
 	w := httptest.NewRecorder()
 	r := testRouter(addMiddleware)
 	b.ResetTimer()

--- a/contrib/apmsql/conn_go110.go
+++ b/contrib/apmsql/conn_go110.go
@@ -1,0 +1,24 @@
+// +build go1.10
+
+package apmsql
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+// Support for Conn interfaces introduced in Go 1.10 and later.
+type connGo110 struct {
+	sessionResetter driver.SessionResetter
+}
+
+func (c *connGo110) init(in driver.Conn) {
+	c.sessionResetter, _ = in.(driver.SessionResetter)
+}
+
+func (c *connGo110) ResetSession(ctx context.Context) error {
+	if c.sessionResetter != nil {
+		return c.sessionResetter.ResetSession(ctx)
+	}
+	return nil
+}

--- a/contrib/apmsql/conn_pre_go110.go
+++ b/contrib/apmsql/conn_pre_go110.go
@@ -1,0 +1,9 @@
+// +build !go1.10
+
+package apmsql
+
+import "database/sql/driver"
+
+type connGo110 struct{}
+
+func (connGo110) init(in driver.Conn) {}

--- a/contrib/apmsql/driver_go110.go
+++ b/contrib/apmsql/driver_go110.go
@@ -1,0 +1,46 @@
+// +build go1.10
+
+package apmsql
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"github.com/elastic/apm-agent-go/trace"
+)
+
+func (d *tracingDriver) OpenConnector(name string) (driver.Connector, error) {
+	if dc, ok := d.Driver.(driver.DriverContext); ok {
+		oc, err := dc.OpenConnector(name)
+		if err != nil {
+			return nil, err
+		}
+		return &driverConnector{oc.Connect, d, name}, nil
+	}
+	connect := func(context.Context) (driver.Conn, error) {
+		return d.Driver.Open(name)
+	}
+	return &driverConnector{connect, d, name}, nil
+}
+
+type driverConnector struct {
+	connect func(context.Context) (driver.Conn, error)
+	driver  *tracingDriver
+	name    string
+}
+
+func (d *driverConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	span, ctx := trace.StartSpan(ctx, "connect", d.driver.spanType("connect"))
+	if span != nil {
+		defer span.Done(-1)
+	}
+	conn, err := d.connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(conn, d.driver, d.name), nil
+}
+
+func (d *driverConnector) Driver() driver.Driver {
+	return d.driver
+}

--- a/contrib/apmsql/stmt_go19.go
+++ b/contrib/apmsql/stmt_go19.go
@@ -1,0 +1,20 @@
+// +build go1.9
+
+package apmsql
+
+import "database/sql/driver"
+
+type stmtGo19 struct {
+	namedValueChecker driver.NamedValueChecker
+}
+
+func (s *stmtGo19) init(in driver.Stmt) {
+	s.namedValueChecker, _ = in.(driver.NamedValueChecker)
+}
+
+func (s *stmt) CheckNamedValue(nv *driver.NamedValue) error {
+	if s.namedValueChecker != nil {
+		return s.namedValueChecker.CheckNamedValue(nv)
+	}
+	return driver.ErrSkip
+}

--- a/contrib/apmsql/stmt_pre_go19.go
+++ b/contrib/apmsql/stmt_pre_go19.go
@@ -1,0 +1,9 @@
+// +build !go1.9
+
+package apmsql
+
+import "database/sql/driver"
+
+type stmtGo19 struct{}
+
+func (stmtGo19) init(in driver.Stmt) {}

--- a/stacktrace/context_test.go
+++ b/stacktrace/context_test.go
@@ -65,7 +65,6 @@ func testSetContext(
 	nPre, nPost int,
 	expectedContext string, expectedPre, expectedPost []string,
 ) {
-	t.Helper()
 	frames := []model.StacktraceFrame{frame}
 	err := stacktrace.SetContext(setter, frames, nPre, nPost)
 	if err != nil {

--- a/stacktrace/stacktrace_test.go
+++ b/stacktrace/stacktrace_test.go
@@ -70,14 +70,12 @@ func TestSplitFunctionNameUnescape(t *testing.T) {
 }
 
 func assertModule(t *testing.T, got, expect string) {
-	t.Helper()
 	if got != expect {
 		t.Errorf("got module %q, expected %q", got, expect)
 	}
 }
 
 func assertFunction(t *testing.T, got, expect string) {
-	t.Helper()
 	if got != expect {
 		t.Errorf("got function %q, expected %q", got, expect)
 	}


### PR DESCRIPTION
In Go 1.9 and older, os.PathError and os.SyscallError
lack the Timeout method. To simplify things, just use
the interface assertion in all error type cases.

Also, add Travis CI badge to the README.