### PR TITLE
trace: more tests

### DIFF
--- a/trace/env.go
+++ b/trace/env.go
@@ -33,7 +33,7 @@ func initialFlushInterval() (time.Duration, error) {
 	return d, nil
 }
 
-func initialMaxQueueSize() (int, error) {
+func initialMaxTransactionQueueSize() (int, error) {
 	value := os.Getenv(envMaxQueueSize)
 	if value == "" {
 		return defaultMaxQueueSize, nil

--- a/trace/processor.go
+++ b/trace/processor.go
@@ -32,6 +32,21 @@ type TransactionProcessor interface {
 	ProcessTransaction(*model.Transaction)
 }
 
+// ErrorProcessorFunc is a function type implementing ErrorProcessor.
+type ErrorProcessorFunc func(*model.Error)
+
+func (f ErrorProcessorFunc) ProcessError(e *model.Error) {
+	f(e)
+}
+
+// TransactionProcessorFunc is a function type implementing
+// TransactionProcessor.
+type TransactionProcessorFunc func(*model.Transaction)
+
+func (f TransactionProcessorFunc) ProcessTransaction(t *model.Transaction) {
+	f(t)
+}
+
 // Processors is a slice of Processors; each entry's Process methods
 // will be invoked in series.
 type Processors []Processor

--- a/trace/tracer_test.go
+++ b/trace/tracer_test.go
@@ -1,7 +1,7 @@
 package trace_test
 
 import (
-	"log"
+	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -9,15 +9,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/trace"
 	"github.com/elastic/apm-agent-go/transport/transporttest"
 )
 
 func TestTracerStats(t *testing.T) {
 	tracer, err := trace.NewTracer("tracer.testing", "")
-	if err != nil {
-		log.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = transporttest.Discard
 
@@ -30,11 +29,20 @@ func TestTracerStats(t *testing.T) {
 	}, tracer.Stats())
 }
 
+func TestTracerClosedSendNonblocking(t *testing.T) {
+	tracer, err := trace.NewTracer("tracer.testing", "")
+	assert.NoError(t, err)
+	tracer.Close()
+
+	for i := 0; i < 1001; i++ {
+		tracer.StartTransaction("name", "type").Done(-1)
+	}
+	assert.Equal(t, uint64(1), tracer.Stats().TransactionsDropped)
+}
+
 func TestTracerFlushInterval(t *testing.T) {
 	tracer, err := trace.NewTracer("tracer.testing", "")
-	if err != nil {
-		log.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = transporttest.Discard
 
@@ -52,9 +60,7 @@ func TestTracerFlushInterval(t *testing.T) {
 
 func TestTracerMaxQueueSize(t *testing.T) {
 	tracer, err := trace.NewTracer("tracer.testing", "")
-	if err != nil {
-		log.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer tracer.Close()
 
 	// Prevent any transactions from being sent.
@@ -62,7 +68,7 @@ func TestTracerMaxQueueSize(t *testing.T) {
 
 	// Enqueue 10 transactions with a queue size of 5;
 	// we should see 5 transactons dropped.
-	tracer.SetMaxQueueSize(5)
+	tracer.SetMaxTransactionQueueSize(5)
 	for i := 0; i < 10; i++ {
 		tracer.StartTransaction("name", "type").Done(-1)
 	}
@@ -79,9 +85,7 @@ func TestTracerMaxQueueSize(t *testing.T) {
 
 func TestTracerRetryTimer(t *testing.T) {
 	tracer, err := trace.NewTracer("tracer.testing", "")
-	if err != nil {
-		log.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer tracer.Close()
 
 	// Prevent any transactions from being sent.
@@ -89,7 +93,7 @@ func TestTracerRetryTimer(t *testing.T) {
 
 	interval := time.Second
 	tracer.SetFlushInterval(interval)
-	tracer.SetMaxQueueSize(1)
+	tracer.SetMaxTransactionQueueSize(1)
 
 	before := time.Now()
 	tracer.StartTransaction("name", "type").Done(-1)
@@ -121,9 +125,7 @@ func TestTracerRetryTimer(t *testing.T) {
 func TestTracerMaxSpans(t *testing.T) {
 	var r transporttest.RecorderTransport
 	tracer, err := trace.NewTracer("tracer.testing", "")
-	if err != nil {
-		log.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = &r
 
@@ -154,9 +156,7 @@ func TestTracerMaxSpans(t *testing.T) {
 func TestTracerErrors(t *testing.T) {
 	var r transporttest.RecorderTransport
 	tracer, err := trace.NewTracer("tracer.testing", "")
-	if err != nil {
-		log.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = &r
 
@@ -184,8 +184,126 @@ func TestTracerErrors(t *testing.T) {
 }
 
 func TestTracerErrorsBuffered(t *testing.T) {
-	// TODO(axw) show that errors are buffered,
-	// dropped when full, and sent when possible.
+	tracer, err := trace.NewTracer("tracer.testing", "")
+	assert.NoError(t, err)
+	defer tracer.Close()
+	errors := make(chan transporttest.SendErrorsRequest)
+	tracer.Transport = &transporttest.ChannelTransport{Errors: errors}
+
+	tracer.SetMaxErrorQueueSize(10)
+	sendError := func(msg string) {
+		e := tracer.NewError()
+		e.SetException(fmt.Errorf("%s", msg))
+		e.Send()
+	}
+
+	// Send an initial error, which should send a request
+	// on the transport's errors channel.
+	sendError("0")
+	var req transporttest.SendErrorsRequest
+	select {
+	case req = <-errors:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for errors payload")
+	}
+	assert.Len(t, req.Payload.Errors, 1)
+
+	// While we're still sending the first error, try to
+	// enqueue another 1010. The first 1000 should be
+	// buffered in the channel, but the internal queue
+	// will not be filled until the send has completed,
+	// so the additional 10 will be dropped.
+	for i := 1; i <= 1010; i++ {
+		sendError(fmt.Sprint(i))
+	}
+	req.Result <- fmt.Errorf("nope")
+
+	stats := tracer.Stats()
+	assert.Equal(t, stats.ErrorsDropped, uint64(10))
+
+	// The tracer should send 100 lots of 10 errors.
+	for i := 0; i < 100; i++ {
+		select {
+		case req = <-errors:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for errors payload")
+		}
+		assert.Len(t, req.Payload.Errors, 10)
+		for j, e := range req.Payload.Errors {
+			assert.Equal(t, e.Exception.Message, fmt.Sprintf("%d", i*10+j))
+		}
+		req.Result <- nil
+	}
+}
+
+func TestTracerProcessor(t *testing.T) {
+	tracer, err := trace.NewTracer("tracer.testing", "")
+	assert.NoError(t, err)
+	defer tracer.Close()
+	tracer.Transport = transporttest.Discard
+
+	e_ := tracer.NewError()
+	tx_ := tracer.StartTransaction("name", "type")
+
+	var processedError bool
+	var processedTransaction bool
+	processError := func(e *model.Error) {
+		processedError = true
+		assert.Equal(t, &e_.Error, e)
+	}
+	processTransaction := func(tx *model.Transaction) {
+		processedTransaction = true
+		assert.Equal(t, &tx_.Transaction, tx)
+	}
+	tracer.SetProcessor(struct {
+		trace.ErrorProcessor
+		trace.TransactionProcessor
+	}{
+		trace.ErrorProcessorFunc(processError),
+		trace.TransactionProcessorFunc(processTransaction),
+	})
+
+	e_.Send()
+	tx_.Done(-1)
+	tracer.Flush(nil)
+	assert.True(t, processedError)
+	assert.True(t, processedTransaction)
+}
+
+func TestTracerRecover(t *testing.T) {
+	var r transporttest.RecorderTransport
+	tracer, err := trace.NewTracer("tracer.testing", "")
+	assert.NoError(t, err)
+	defer tracer.Close()
+	tracer.Transport = &r
+
+	capturePanic(tracer, "blam")
+	tracer.Flush(nil)
+
+	payloads := r.Payloads()
+	assert.Len(t, payloads, 2)
+
+	assert.Contains(t, payloads[0], "errors")
+	errors := payloads[0]["errors"].([]interface{})
+	assert.Len(t, errors, 1)
+	error0 := errors[0].(map[string]interface{})
+	exception := error0["exception"].(map[string]interface{})
+	assert.Equal(t, "blam", exception["message"])
+
+	assert.Contains(t, payloads[1], "transactions")
+	transactions := payloads[1]["transactions"].([]interface{})
+	assert.Len(t, transactions, 1)
+	transaction0 := transactions[0].(map[string]interface{})
+
+	errorTransaction := error0["transaction"].(map[string]interface{})
+	assert.Equal(t, transaction0["id"], errorTransaction["id"])
+}
+
+func capturePanic(tracer *trace.Tracer, v interface{}) {
+	tx := tracer.StartTransaction("name", "type")
+	defer tx.Done(-1)
+	defer tracer.Recover(tx)
+	panic(v)
 }
 
 type testLogger struct {

--- a/transport/transporttest/chan.go
+++ b/transport/transporttest/chan.go
@@ -1,0 +1,57 @@
+package transporttest
+
+import (
+	"context"
+
+	"github.com/elastic/apm-agent-go/model"
+)
+
+// ChannelTransport implements transport.Transport,
+// sending payloads to the provided channels as
+// request objects. Once a request object has been
+// received, an error should be sent to its Result
+// channel to unblock the tracer.
+type ChannelTransport struct {
+	Transactions chan<- SendTransactionsRequest
+	Errors       chan<- SendErrorsRequest
+}
+
+type SendTransactionsRequest struct {
+	Payload *model.TransactionsPayload
+	Result  chan<- error
+}
+
+type SendErrorsRequest struct {
+	Payload *model.ErrorsPayload
+	Result  chan<- error
+}
+
+func (c *ChannelTransport) SendTransactions(ctx context.Context, payload *model.TransactionsPayload) error {
+	result := make(chan error, 1)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.Transactions <- SendTransactionsRequest{payload, result}:
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-result:
+			return err
+		}
+	}
+}
+
+func (c *ChannelTransport) SendErrors(ctx context.Context, payload *model.ErrorsPayload) error {
+	result := make(chan error, 1)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.Errors <- SendErrorsRequest{payload, result}:
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-result:
+			return err
+		}
+	}
+}

--- a/transport/transporttest/err.go
+++ b/transport/transporttest/err.go
@@ -1,0 +1,26 @@
+package transporttest
+
+import (
+	"context"
+
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/transport"
+)
+
+// Discard is a transport.Transport which discards
+// all payloads, and returns no errors.
+var Discard transport.Transport = ErrorTransport{}
+
+// ErrorTransport is a transport that returns the stored error
+// for each method call.
+type ErrorTransport struct {
+	Error error
+}
+
+func (t ErrorTransport) SendTransactions(context.Context, *model.TransactionsPayload) error {
+	return t.Error
+}
+
+func (t ErrorTransport) SendErrors(context.Context, *model.ErrorsPayload) error {
+	return t.Error
+}

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -1,0 +1,48 @@
+package transporttest
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/elastic/apm-agent-go/model"
+)
+
+// RecorderTransport implements transport.Transport,
+// recording the payloads sent. The payloads can be
+// retrieved using the Payloads method.
+type RecorderTransport struct {
+	mu       sync.Mutex
+	payloads []map[string]interface{}
+}
+
+func (r *RecorderTransport) SendTransactions(ctx context.Context, payload *model.TransactionsPayload) error {
+	return r.record(payload)
+}
+
+func (r *RecorderTransport) SendErrors(ctx context.Context, payload *model.ErrorsPayload) error {
+	return r.record(payload)
+}
+
+// Payloads returns the payloads recorded by SendTransactions and SendErrors.
+func (r *RecorderTransport) Payloads() []map[string]interface{} {
+	r.mu.Lock()
+	payloads := r.payloads[:]
+	r.mu.Unlock()
+	return payloads
+}
+
+func (r *RecorderTransport) record(payload interface{}) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		panic(err)
+	}
+	r.mu.Lock()
+	r.payloads = append(r.payloads, m)
+	r.mu.Unlock()
+	return nil
+}


### PR DESCRIPTION
- error buffering (also: make error queue size configurable)
- error/transaction processing
- client-side dropping of transactions when channel is full
- panic recovery (Tracer.Recover)