### PR TITLE
trace: add sampling

### DIFF
--- a/trace/sampler.go
+++ b/trace/sampler.go
@@ -1,0 +1,53 @@
+package trace
+
+import (
+	"math/rand"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Sampler provides a means of sampling transactions.
+type Sampler interface {
+	// Sample indicates whether or not the transaction
+	// should be sampled. This method will be invoked
+	// by calls to Tracer.StartTransaction, so it must
+	// be goroutine-safe, and should avoid synchronization
+	// as far as possible.
+	Sample(*Transaction) bool
+}
+
+// RatioSampler is a Sampler that samples probabilistically
+// based on the given ratio within the range [0,1.0].
+//
+// A ratio of 1.0 samples 100% of transactions, a ratio of 0.5
+// samples ~50%, and so on.
+type RatioSampler struct {
+	mu  sync.Mutex
+	rng *rand.Rand
+	r   float64
+}
+
+// NewRatioSampler returns a new RatioSampler with the given ratio
+// and math/rand.Source. The source will be called from multiple
+// goroutines, but the sampler will internally synchronise access
+// to it; the source should not be used by any other goroutines.
+//
+// If the ratio provided does not lie within the range [0,1.0],
+// NewRatioSampler will panic.
+func NewRatioSampler(r float64, source rand.Source) *RatioSampler {
+	if r < 0 || r > 1.0 {
+		panic(errors.Errorf("ratio %v out of range [0,1.0]", r))
+	}
+	return &RatioSampler{
+		rng: rand.New(source),
+		r:   r,
+	}
+}
+
+func (s *RatioSampler) Sample(*Transaction) bool {
+	s.mu.Lock()
+	v := s.rng.Float64()
+	s.mu.Unlock()
+	return s.r > v
+}

--- a/trace/sampler_test.go
+++ b/trace/sampler_test.go
@@ -1,0 +1,43 @@
+package trace_test
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/elastic/apm-agent-go/trace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRatioSampler(t *testing.T) {
+	ratio := 0.75
+	source := rand.NewSource(0) // fixed seed for test
+	s := trace.NewRatioSampler(ratio, source)
+
+	const (
+		numGoroutines = 100
+		numIterations = 1000
+	)
+
+	sampled := make([]int, numGoroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				if s.Sample(nil) {
+					sampled[i]++
+				}
+			}
+
+		}(i)
+	}
+	wg.Wait()
+
+	var total int
+	for i := 0; i < numGoroutines; i++ {
+		total += sampled[i]
+	}
+	assert.InDelta(t, ratio, float64(total)/(numGoroutines*numIterations), 0.1)
+}

--- a/trace/transaction.go
+++ b/trace/transaction.go
@@ -33,9 +33,12 @@ func (t *Tracer) newTransaction(name, type_ string) *Transaction {
 	tx.maxSpans = t.maxSpans
 	t.maxSpansMu.RUnlock()
 
-	// TODO(axw) sampling
+	t.samplerMu.RLock()
+	sampler := t.sampler
+	t.samplerMu.RUnlock()
 	tx.sampled = true
-	if !tx.sampled {
+	if sampler != nil && !sampler.Sample(tx) {
+		tx.sampled = false
 		tx.Transaction.Sampled = &tx.sampled
 	}
 	return tx


### PR DESCRIPTION
If no configuration is specified, a Tracer defaults
to sampling all transactions. Otherwise, if the
ELASTIC_APM_TRANSACTION_SAMPLE_RATE environment is
specified, it is expected to be a ratio in the range
[0,1.0], and a sampler will be constructed that
samples pseudo-randomly (with a uniform distribution)
based on that ratio.

It is possible to change the sampler after the tracer
has been constructed using its SetSampler method.