### PR TITLE
trace: signal Flush after retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# apm-agent-go: APM Agent for Go (pre-alpha) [![GoDoc](https://godoc.org/github.com/elastic/apm-agent-go/trace?status.svg)](http://godoc.org/github.com/elastic/apm-agent-go/trace) [![Travis-CI](https://travis-ci.org/elastic/apm-agent-go.svg)](https://travis-ci.org/elastic/apm-agent-go)
+# apm-agent-go: APM Agent for Go (pre-alpha) [![GoDoc](https://godoc.org/github.com/elastic/apm-agent-go/trace?status.svg)](http://godoc.org/github.com/elastic/apm-agent-go/trace) [![Travis-CI](https://travis-ci.org/elastic/apm-agent-go.svg)](https://travis-ci.org/elastic/apm-agent-go) [![Go Report Card](https://goreportcard.com/badge/github.com/elastic/apm-agent-go)](https://goreportcard.com/report/github.com/elastic/apm-agent-go)
 
 This is the official Go package for [Elastic APM][].
 

--- a/trace/example_test.go
+++ b/trace/example_test.go
@@ -122,7 +122,7 @@ func (api *api) handleOrder(ctx context.Context, product string) {
 }
 
 func storeOrder(ctx context.Context, product string) {
-	span, ctx := trace.StartSpan(ctx, "store_order", "rpc")
+	span, _ := trace.StartSpan(ctx, "store_order", "rpc")
 	if span != nil {
 		defer span.Done(-1)
 	}

--- a/trace/tracer.go
+++ b/trace/tracer.go
@@ -275,6 +275,7 @@ func (t *Tracer) loop() {
 	}()
 
 	var flushInterval time.Duration
+	var flushed chan<- struct{}
 	var maxTransactionQueueSize int
 	var maxErrorQueueSize int
 	var flushC <-chan time.Time
@@ -324,7 +325,6 @@ func (t *Tracer) loop() {
 
 	for {
 		var sendTransactions bool
-		var flushed chan<- struct{}
 		statsUpdates = TracerStats{}
 
 		select {


### PR DESCRIPTION
If Flush is called, and SendTransactions/SendErrors fails,
then we should unblock the Flush method after retrying and
succeeding.

Found with https://goreportcard.com / ineffasign.