### PR TITLE
contrib/apmlambda: intercept/trace AWS lambda 

### DIFF
--- a/contrib/apmlambda/example.go
+++ b/contrib/apmlambda/example.go
@@ -1,0 +1,24 @@
+// +build ignore
+
+package main
+
+import (
+	"context"
+
+	// Trace lambda function invocations.
+	_ "github.com/elastic/apm-agent-go/contrib/apmlambda"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type Request struct {
+	Name string `json:"name"`
+}
+
+func Handler(ctx context.Context, req Request) (string, error) {
+	return "Hello, " + req.Name, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/contrib/apmlambda/lambda.go
+++ b/contrib/apmlambda/lambda.go
@@ -1,0 +1,150 @@
+package apmlambda
+
+import (
+	"log"
+	"net"
+	"net/rpc"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/stacktrace"
+
+	"github.com/aws/aws-lambda-go/lambda/messages"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+)
+
+const (
+	// TODO(axw) make this configurable via environment
+	payloadLimit = 1024
+)
+
+var (
+	// nonBlocking is passed to Tracer.Flush so it does not block functions.
+	nonBlocking = make(chan struct{})
+
+	// Globals below used during tracing, to avoid reallocating for each
+	// invocation. Only one invocation will happen at a time.
+	txContext     model.Context
+	lambdaContext struct {
+		RequestID       string `json:"request_id,omitempty"`
+		Region          string `json:"region,omitempty"`
+		XAmznTraceID    string `json:"x_amzn_trace_id,omitempty"`
+		FunctionVersion string `json:"function_version,omitempty"`
+		MemoryLimit     int    `json:"memory_limit,omitempty"`
+		Request         string `json:"request,omitempty"`
+		Response        string `json:"response,omitempty"`
+	}
+)
+
+func init() {
+	close(nonBlocking)
+	txContext.Custom = map[string]interface{}{
+		"lambda": &lambdaContext,
+	}
+	lambdaContext.FunctionVersion = lambdacontext.FunctionVersion
+	lambdaContext.MemoryLimit = lambdacontext.MemoryLimitInMB
+	lambdaContext.Region = os.Getenv("AWS_REGION")
+
+	if elasticapm.DefaultTracer.Service.Framework == nil {
+		executionEnv := os.Getenv("AWS_EXECUTION_ENV")
+		version := strings.TrimPrefix(executionEnv, "AWS_Lambda_")
+		elasticapm.DefaultTracer.Service.Framework = &model.Framework{
+			Name:    "AWS Lambda",
+			Version: version,
+		}
+	}
+}
+
+type Function struct {
+	client *rpc.Client
+	tracer *elasticapm.Tracer
+}
+
+func (f *Function) Ping(req *messages.PingRequest, response *messages.PingResponse) error {
+	return f.client.Call("Function.Ping", req, response)
+}
+
+func (f *Function) Invoke(req *messages.InvokeRequest, response *messages.InvokeResponse) error {
+	tx := f.tracer.StartTransaction(lambdacontext.FunctionName, "function")
+	defer f.tracer.Flush(nonBlocking)
+	defer tx.Done(-1)
+	defer f.tracer.Recover(tx)
+	tx.Context = &txContext
+
+	lambdaContext.RequestID = req.RequestId
+	lambdaContext.XAmznTraceID = req.XAmznTraceId
+	lambdaContext.Request = formatPayload(req.Payload)
+	lambdaContext.Response = ""
+
+	err := f.client.Call("Function.Invoke", req, response)
+	if err != nil {
+		e := f.tracer.NewError()
+		e.Transaction = tx
+		e.SetException(err)
+		e.Send()
+		return err
+	}
+
+	if response.Payload != nil {
+		lambdaContext.Response = formatPayload(response.Payload)
+	}
+
+	if response.Error != nil {
+		e := f.tracer.NewError()
+		e.Transaction = tx
+		e.Exception = &model.Exception{
+			Message: response.Error.Message,
+			Type:    response.Error.Type,
+		}
+		frames := make([]model.StacktraceFrame, len(response.Error.StackTrace))
+		for i, f := range response.Error.StackTrace {
+			packagePath, functionName := stacktrace.SplitFunctionName(f.Label)
+			frames[i].File = filepath.Base(f.Path)
+			frames[i].Line = int(f.Line)
+			frames[i].Module = packagePath
+			frames[i].Function = functionName
+			frames[i].LibraryFrame = stacktrace.IsLibraryPackage(packagePath)
+		}
+	}
+	return nil
+}
+
+func formatPayload(payload []byte) string {
+	if len(payload) > payloadLimit {
+		payload = payload[:payloadLimit]
+	}
+	if !utf8.Valid(payload) {
+		return ""
+	}
+	return string(payload)
+}
+
+func init() {
+	pipeClient, pipeServer := net.Pipe()
+	rpcClient := rpc.NewClient(pipeClient)
+	go rpc.DefaultServer.ServeConn(pipeServer)
+
+	origPort := os.Getenv("_LAMBDA_SERVER_PORT")
+	lis, err := net.Listen("tcp", "localhost:"+origPort)
+	if err != nil {
+		log.Fatal(err)
+	}
+	srv := rpc.NewServer()
+	srv.Register(&Function{
+		client: rpcClient,
+		tracer: elasticapm.DefaultTracer,
+	})
+	go srv.Accept(lis)
+
+	// Setting _LAMBDA_SERVER_PORT causes lambda.Start
+	// to listen on any free port. We don't care which;
+	// we don't use it.
+	os.Setenv("_LAMBDA_SERVER_PORT", "0")
+}
+
+// TODO(axw) Start() function, which wraps a given function
+// such that its context is updated with the transaction.

--- a/env.go
+++ b/env.go
@@ -15,9 +15,9 @@ const (
 	envMaxSpans              = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
 	envTransactionSampleRate = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
 
-	defaultFlushInterval = 10 * time.Second
-	defaultMaxQueueSize  = 500
-	defaultMaxSpans      = 500
+	defaultFlushInterval           = 10 * time.Second
+	defaultMaxTransactionQueueSize = 500
+	defaultMaxSpans                = 500
 )
 
 func initialFlushInterval() (time.Duration, error) {
@@ -45,7 +45,7 @@ func initialFlushInterval() (time.Duration, error) {
 func initialMaxTransactionQueueSize() (int, error) {
 	value := os.Getenv(envMaxQueueSize)
 	if value == "" {
-		return defaultMaxQueueSize, nil
+		return defaultMaxTransactionQueueSize, nil
 	}
 	size, err := strconv.Atoi(value)
 	if err != nil {

--- a/stacktrace/generate_library.bash
+++ b/stacktrace/generate_library.bash
@@ -13,7 +13,9 @@ var libraryPackages = map[string]struct{}{
 $_PKGS
 }
 
-func isLibraryPackage(pkg string) bool {
+// IsLibraryPackage reports whether or not the given package path is
+// a well-known library path (stdlib or apm-agent-go).
+func IsLibraryPackage(pkg string) bool {
 	_, ok := libraryPackages[pkg]
 	return ok
 }

--- a/stacktrace/library.go
+++ b/stacktrace/library.go
@@ -204,7 +204,9 @@ var libraryPackages = map[string]struct{}{
 	"github.com/elastic/apm-agent-go/transport/transporttest":           {},
 }
 
-func isLibraryPackage(pkg string) bool {
+// IsLibraryPackage reports whether or not the given package path is
+// a well-known library path (stdlib or apm-agent-go).
+func IsLibraryPackage(pkg string) bool {
 	_, ok := libraryPackages[pkg]
 	return ok
 }

--- a/stacktrace/library.go
+++ b/stacktrace/library.go
@@ -191,6 +191,7 @@ var libraryPackages = map[string]struct{}{
 	"github.com/elastic/apm-agent-go":                                   {},
 	"github.com/elastic/apm-agent-go/contrib/apmgin":                    {},
 	"github.com/elastic/apm-agent-go/contrib/apmhttp":                   {},
+	"github.com/elastic/apm-agent-go/contrib/apmlambda":                 {},
 	"github.com/elastic/apm-agent-go/contrib/apmsql":                    {},
 	"github.com/elastic/apm-agent-go/contrib/apmsql/dsn":                {},
 	"github.com/elastic/apm-agent-go/contrib/apmsql/pq":                 {},

--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -93,7 +93,7 @@ func RuntimeStacktraceFrame(in *runtime.Frame) model.StacktraceFrame {
 		Line:         in.Line,
 		Function:     function,
 		Module:       packagePath,
-		LibraryFrame: isLibraryPackage(packagePath),
+		LibraryFrame: IsLibraryPackage(packagePath),
 	}
 }
 

--- a/transport/transporttest/callback.go
+++ b/transport/transporttest/callback.go
@@ -1,0 +1,24 @@
+package transporttest
+
+import (
+	"context"
+
+	"github.com/elastic/apm-agent-go/model"
+)
+
+// CallbackTransport is a transport that invokes the given
+// callbacks for the payloads for each method call.
+type CallbackTransport struct {
+	Transactions func(context.Context, *model.TransactionsPayload) error
+	Errors       func(context.Context, *model.ErrorsPayload) error
+}
+
+// SendTransactions returns t.Transactions(ctx, p).
+func (t CallbackTransport) SendTransactions(ctx context.Context, p *model.TransactionsPayload) error {
+	return t.Transactions(ctx, p)
+}
+
+// SendErrors returns t.Errors(ctx, p).
+func (t CallbackTransport) SendErrors(ctx context.Context, p *model.ErrorsPayload) error {
+	return t.Errors(ctx, p)
+}

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package elasticapm
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -62,7 +63,7 @@ func getEnvironmentFramework() *model.Framework {
 func getEnvironmentService() *model.Service {
 	name := os.Getenv(envServiceName)
 	if name == "" {
-		return nil
+		name = filepath.Base(os.Args[0])
 	}
 	return newService(name, "")
 }


### PR DESCRIPTION
Importing this package will run our own net/rpc
listener/server, and override the environment
variable such that lambda.Start will not attempt
to listen on the same port. We then proxy the
requests through to the function registered with
lambda.Start, tracing them on the way.

Still TODO: provide an apmlambda.Start function
which can be used to add the transaction to the
context provided by lambda.