### PR TITLE
contrib/apmgorilla: gorilla/mux middleware

### DIFF
--- a/contrib/apmgorilla/LICENSE.gorillamux.txt
+++ b/contrib/apmgorilla/LICENSE.gorillamux.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2012 Rodrigo Moraes. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+	 * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+	 * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+	 * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/contrib/apmgorilla/context.go
+++ b/contrib/apmgorilla/context.go
@@ -1,0 +1,59 @@
+package apmgorilla
+
+import (
+	"bytes"
+	"strings"
+)
+
+// massageTemplate removes the regexp patterns from template variables.
+func massageTemplate(tpl string) string {
+	braces := braceIndices(tpl)
+	if len(braces) == 0 {
+		return tpl
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, len(tpl)))
+	for i := 0; i < len(tpl); {
+		var j int
+		if i < braces[0] {
+			j = braces[0]
+			buf.WriteString(tpl[i:j])
+		} else {
+			j = braces[1]
+			field := tpl[i:j]
+			if colon := strings.IndexRune(field, ':'); colon >= 0 {
+				buf.WriteString(field[:colon])
+				buf.WriteRune('}')
+			} else {
+				buf.WriteString(field)
+			}
+			braces = braces[2:]
+			if len(braces) == 0 {
+				buf.WriteString(tpl[j:])
+				break
+			}
+		}
+		i = j
+	}
+	return buf.String()
+}
+
+// Copied/adapted from gorilla/mux. The original version checks
+// that the braces are matched up correctly; we assume they are,
+// as otherwise the path wouldn't have been registered correctly.
+func braceIndices(s string) []int {
+	var level, idx int
+	var idxs []int
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			if level++; level == 1 {
+				idx = i
+			}
+		case '}':
+			if level--; level == 0 {
+				idxs = append(idxs, idx, i+1)
+			}
+		}
+	}
+	return idxs
+}

--- a/contrib/apmgorilla/context_test.go
+++ b/contrib/apmgorilla/context_test.go
@@ -1,0 +1,12 @@
+package apmgorilla
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMassageTemplate(t *testing.T) {
+	out := massageTemplate("/articles/{category}/{id:[0-9]+}")
+	assert.Equal(t, "/articles/{category}/{id}", out)
+}

--- a/contrib/apmgorilla/middleware.go
+++ b/contrib/apmgorilla/middleware.go
@@ -1,0 +1,40 @@
+package apmgorilla
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmhttp"
+)
+
+// Middleware returns a new gorilla/mux middleware handler
+// for tracing requests and reporting errors, using the
+// given tracer, or elasticapm.DefaultTracer if the tracer
+// is nil.
+//
+// This middleware will recover and report panics, so it can
+// be used instead of the gorilla/middleware.RecoveryHandler
+// middleware.
+func Middleware(t *elasticapm.Tracer) mux.MiddlewareFunc {
+	return func(h http.Handler) http.Handler {
+		return &apmhttp.Handler{
+			Handler:     h,
+			Recovery:    apmhttp.NewTraceRecovery(t),
+			RequestName: routeRequestName,
+			Tracer:      t,
+		}
+	}
+}
+
+func routeRequestName(req *http.Request) string {
+	route := mux.CurrentRoute(req)
+	if route != nil {
+		tpl, err := route.GetPathTemplate()
+		if err == nil {
+			return req.Method + " " + massageTemplate(tpl)
+		}
+	}
+	return apmhttp.RequestName(req)
+}

--- a/contrib/apmgorilla/middleware_test.go
+++ b/contrib/apmgorilla/middleware_test.go
@@ -1,0 +1,91 @@
+package apmgorilla_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmgorilla"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestMuxMiddleware(t *testing.T) {
+	tracer, transport := newRecordingTracer()
+	defer tracer.Close()
+
+	r := mux.NewRouter()
+	r.Use(apmgorilla.Middleware(tracer))
+	sub := r.PathPrefix("/prefix").Subrouter()
+	sub.Path("/articles/{category}/{id:[0-9]+}").Handler(http.HandlerFunc(articleHandler))
+
+	w := doRequest(r, "GET", "http://server.testing/prefix/articles/fiction/123?foo=123")
+	assert.Equal(t, "fiction:123", w.Body.String())
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	require.Len(t, payloads, 1)
+	assert.Contains(t, payloads[0], "transactions")
+
+	transactions := payloads[0]["transactions"].([]interface{})
+	require.Len(t, transactions, 1)
+	transaction := transactions[0].(map[string]interface{})
+	assert.Equal(t, "GET /prefix/articles/{category}/{id}", transaction["name"])
+	assert.Equal(t, "request", transaction["type"])
+	assert.Equal(t, "200", transaction["result"])
+
+	context := transaction["context"].(map[string]interface{})
+	assert.Equal(t, map[string]interface{}{
+		"request": map[string]interface{}{
+			"socket": map[string]interface{}{
+				"remote_address": "client.testing",
+			},
+			"url": map[string]interface{}{
+				"full":     "http://server.testing/prefix/articles/fiction/123?foo=123",
+				"protocol": "http",
+				"hostname": "server.testing",
+				"pathname": "/prefix/articles/fiction/123",
+				"search":   "foo=123",
+			},
+			"headers":      map[string]interface{}{},
+			"method":       "GET",
+			"http_version": "1.1",
+		},
+		"response": map[string]interface{}{
+			"status_code":  float64(200),
+			"finished":     true,
+			"headers_sent": true,
+			"headers": map[string]interface{}{
+				"content-type": "text/plain; charset=utf-8",
+			},
+		},
+	}, context)
+}
+
+func articleHandler(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	w.Write([]byte(fmt.Sprintf("%s:%s", vars["category"], vars["id"])))
+}
+
+func newRecordingTracer() (*elasticapm.Tracer, *transporttest.RecorderTransport) {
+	var transport transporttest.RecorderTransport
+	tracer, err := elasticapm.NewTracer("apmgorilla_test", "0.1")
+	if err != nil {
+		panic(err)
+	}
+	tracer.Transport = &transport
+	return tracer, &transport
+}
+
+func doRequest(h http.Handler, method, url string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(method, url, nil)
+	req.Header.Set("X-Real-IP", "client.testing")
+	h.ServeHTTP(w, req)
+	return w
+}


### PR DESCRIPTION
Introduce middleware for gorilla/mux, for tracing requests and reporting errors. We remove the regexp 
 portion of variables in the path template for formatting the transaction name.