### PR TITLE
Refactor apmhttp, improve transport/transporttest

### DIFF
--- a/contrib/apmhttp/handler.go
+++ b/contrib/apmhttp/handler.go
@@ -2,7 +2,6 @@ package apmhttp
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/model"
@@ -48,47 +47,110 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	tx := t.StartTransaction(name, "request")
 	ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 	req = req.WithContext(ctx)
+	defer tx.Done(-1)
 
+	// TODO(axw) optionally request capture body
 	// TODO(axw) optimise allocations
 
-	rw := newResponseWriter(w)
-	w = wrapResponseWriter(rw)
-
-	var finished bool
+	finished := false
+	w, resp := WrapResponseWriter(w)
 	defer func() {
-		duration := time.Since(tx.Timestamp)
 		if h.Recovery != nil {
 			if v := recover(); v != nil {
-				h.Recovery(rw, req, tx, v)
+				h.Recovery(w, req, tx, v)
+				finished = true
 			}
 		}
-		tx.Result = StatusCodeString(rw.statusCode)
-		if tx.Sampled() {
-			tx.Context = RequestContext(req)
-			tx.Context.Response = &model.Response{
-				StatusCode:  rw.statusCode,
-				Headers:     ResponseHeaders(rw),
-				HeadersSent: &rw.written,
-				Finished:    &finished,
-			}
-		}
-		tx.Done(duration)
+		SetTransactionContext(tx, w, req, resp, finished)
 	}()
 	h.Handler.ServeHTTP(w, req)
 	finished = true
 }
 
+// SetTransactionContext sets tx.Result and, if the transaction is being
+// sampled, sets tx.Context with information from w, req, resp, and
+// finished.
+//
+// The finished property indicates that the response was not completely
+// written, e.g. because the handler panicked and we did not recover the
+// panic.
+func SetTransactionContext(tx *elasticapm.Transaction, w http.ResponseWriter, req *http.Request, resp *Response, finished bool) {
+	tx.Result = StatusCodeString(resp.StatusCode)
+	if !tx.Sampled() {
+		return
+	}
+	tx.Context = RequestContext(req)
+	tx.Context.Response = &model.Response{
+		StatusCode: resp.StatusCode,
+		Headers:    ResponseHeaders(w),
+	}
+	if finished {
+		// Responses are always "finished" unless the handler panics
+		// and it is not recovered. Since we can't tell whether a panic
+		// will be recovered up the stack (but before reaching the
+		// net/http server code), we omit the Finished context if we
+		// don't know for sure it finished.
+		tx.Context.Response.Finished = &finished
+	}
+	if resp.HeadersWritten || len(w.Header()) != 0 {
+		// We only set headers_sent if we know for sure
+		// that headers have been sent. Otherwise we
+		// leave it to indicate that we don't know.
+		tx.Context.Response.HeadersSent = &resp.HeadersWritten
+	}
+}
+
+// WrapResponseWriter wraps an http.ResponseWriter and returns the wrapped
+// value along with a *Response which will be filled in when the handler
+// is called. The *Response value must not be inspected until after the
+// request has been handled, to avoid data races.
+//
+// The returned http.ResponseWriter implements http.Pusher and http.Hijacker
+// if and only if the provided http.ResponseWriter does.
+func WrapResponseWriter(w http.ResponseWriter) (http.ResponseWriter, *Response) {
+	rw := newResponseWriter(w)
+	h, _ := w.(http.Hijacker)
+	p, _ := w.(http.Pusher)
+	switch {
+	case h != nil && p != nil:
+		return responseWriterHijackerPusher{
+			responseWriter: rw,
+			Hijacker:       h,
+			Pusher:         p,
+		}, &rw.resp
+	case h != nil:
+		return responseWriterHijacker{
+			responseWriter: rw,
+			Hijacker:       h,
+		}, &rw.resp
+	case p != nil:
+		return responseWriterPusher{
+			responseWriter: rw,
+			Pusher:         p,
+		}, &rw.resp
+	}
+	return rw, &rw.resp
+}
+
+// Response records details of the HTTP response.
+type Response struct {
+	// StatusCode records the HTTP status code set via WriteHeader.
+	StatusCode int
+
+	// HeadersWritten records whether or not headers were written.
+	HeadersWritten bool
+}
+
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
-	written    bool
+	resp Response
 
 	closeNotify func() <-chan bool
 	flush       func()
 }
 
 func newResponseWriter(in http.ResponseWriter) *responseWriter {
-	out := &responseWriter{ResponseWriter: in, statusCode: http.StatusOK}
+	out := &responseWriter{ResponseWriter: in, resp: Response{StatusCode: http.StatusOK}}
 	if in, ok := in.(http.CloseNotifier); ok {
 		out.closeNotify = in.CloseNotify
 	}
@@ -98,18 +160,20 @@ func newResponseWriter(in http.ResponseWriter) *responseWriter {
 	return out
 }
 
-// WriteHeader sets w.statusCode and w.written, and calls through
-// to the embedded ResponseWriter.
+// WriteHeader sets w.resp.StatusCode, and w.resp.HeadersWritten if there
+// are any headers set on the ResponseWriter, and calls through to the
+// embedded ResponseWriter.
 func (w *responseWriter) WriteHeader(statusCode int) {
 	w.ResponseWriter.WriteHeader(statusCode)
-	w.statusCode = statusCode
-	w.written = true
+	w.resp.StatusCode = statusCode
+	w.resp.HeadersWritten = len(w.ResponseWriter.Header()) != 0
 }
 
-// Write sets w.written, and calls through to the embedded ResponseWriter.
+// Write sets w.resp.HeadersWritten if there are any headers set on the
+// ResponseWriter, and calls through to the embedded ResponseWriter.
 func (w *responseWriter) Write(data []byte) (int, error) {
 	n, err := w.ResponseWriter.Write(data)
-	w.written = true
+	w.resp.HeadersWritten = len(w.ResponseWriter.Header()) != 0
 	return n, err
 }
 
@@ -128,33 +192,6 @@ func (w *responseWriter) Flush() {
 	if w.flush != nil {
 		w.flush()
 	}
-}
-
-// wrapResponseWriter wraps a responseWriter so that the Pusher and Hijacker
-// interfaces remain implemented by the http.ResponseWriter presented to
-// the underlying http.Handler.
-func wrapResponseWriter(w *responseWriter) http.ResponseWriter {
-	h, _ := w.ResponseWriter.(http.Hijacker)
-	p, _ := w.ResponseWriter.(http.Pusher)
-	switch {
-	case h != nil && p != nil:
-		return responseWriterHijackerPusher{
-			responseWriter: w,
-			Hijacker:       h,
-			Pusher:         p,
-		}
-	case h != nil:
-		return responseWriterHijacker{
-			responseWriter: w,
-			Hijacker:       h,
-		}
-	case p != nil:
-		return responseWriterPusher{
-			responseWriter: w,
-			Pusher:         p,
-		}
-	}
-	return w
 }
 
 type responseWriterHijacker struct {

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/apm-agent-go/internal/fastjson"
 	"github.com/elastic/apm-agent-go/model"
@@ -24,10 +25,6 @@ func TestMarshalTransaction(t *testing.T) {
 	if err := json.Unmarshal(w.Bytes(), &in); err != nil {
 		t.Fatalf("unmarshalling result failed: %v", err)
 	}
-
-	// NOTE(axw) best practice would be to do a round-trip,
-	// marshal/unmarshal into the same struct type, but we
-	// do not implement unmarshalling in this package.
 
 	expect := map[string]interface{}{
 		"id":        "d51ae41d-93da-4984-bba3-ae15e9b2247f",
@@ -380,6 +377,17 @@ func TestMarshalResponse(t *testing.T) {
 	)
 }
 
+func TestUnmarshalJSON(t *testing.T) {
+	tp := fakeTransactionsPayload(1)
+	var w fastjson.Writer
+	tp.MarshalFastJSON(&w)
+
+	var out model.TransactionsPayload
+	err := json.Unmarshal(w.Bytes(), &out)
+	require.NoError(t, err)
+	assert.Equal(t, &tp, &out)
+}
+
 func fakeTransaction() *model.Transaction {
 	return &model.Transaction{
 		ID:        "d51ae41d-93da-4984-bba3-ae15e9b2247f",
@@ -428,7 +436,7 @@ func fakeTransaction() *model.Transaction {
 			Custom: map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": "baz",
-					"qux": 123,
+					"qux": float64(123),
 				},
 			},
 			Tags: map[string]string{

--- a/stacktrace/library.go
+++ b/stacktrace/library.go
@@ -191,6 +191,7 @@ var libraryPackages = map[string]struct{}{
 	"github.com/elastic/apm-agent-go":                                   {},
 	"github.com/elastic/apm-agent-go/contrib/apmecho":                   {},
 	"github.com/elastic/apm-agent-go/contrib/apmgin":                    {},
+	"github.com/elastic/apm-agent-go/contrib/apmgorilla":                {},
 	"github.com/elastic/apm-agent-go/contrib/apmhttp":                   {},
 	"github.com/elastic/apm-agent-go/contrib/apmlambda":                 {},
 	"github.com/elastic/apm-agent-go/contrib/apmsql":                    {},


### PR DESCRIPTION
- refactor apmhttp so we can reuse parts of it
  in middleware for frameworks/routers/toolkits
- change transport/transporttest.RecorderTransport
  to record the actual payload types by marshalling
  to JSON and then unmarshalling back into the same
  types. This is made possible by adding unmarshal
  methods for a few model types, since we simplified
  most types.