### PR TITLE
contrib/apmhttprouter: add handler wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,54 @@ func main() {
 The apmgin middleware will recover panics and send them to Elastic APM,
 so you do not need to install the gin.Recovery middleware.
 
+### gorilla/mux
+
+Package `contrib/apmgorilla` provides middleware for [gorilla/mux](https://github.com/gorilla/mux):
+
+```go
+import (
+	"github.com/gorilla/mux"
+
+	"github.com/elastic/apm-agent-go/contrib/apmgorilla"
+)
+
+func main() {
+	router := mux.NewRouter()
+	router.Use(apmgorilla.Middleware(nil)) // nil for default tracer
+	...
+}
+```
+
+The apmgorilla middleware will recover panics and send them to Elastic APM,
+so you do not need to install any other recovery middleware.
+
+### httprouter
+
+Package `contrib/apmhttprouter` provides a handler wrapper for [httprouter](https://github.com/julienschmidt/httprouter):
+
+```go
+import (
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmhttp"
+	"github.com/elastic/apm-agent-go/contrib/apmhttprouter"
+)
+
+func main() {
+	router := httprouter.New()
+
+	const route = "/my/route"
+	tracer := elasticapm.DefaultTracer
+	recovery := apmhttp.NewTraceRecovery(tracer) // optional panic recovery
+	router.GET(route, apmhttprouter.WrapHandle(h, tracer, route, recovery))
+	...
+}
+```
+
+httprouter [does not provide a means of obtaining the matched route](https://github.com/julienschmidt/httprouter/pull/139),
+hence the route must be passed into the wrapper.
+
 ### Echo
 
 Package `contrib/apmecho` provides middleware for [Echo](https://github.com/labstack/echo):

--- a/contrib/apmhttprouter/handler.go
+++ b/contrib/apmhttprouter/handler.go
@@ -1,0 +1,49 @@
+package apmhttprouter
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmhttp"
+)
+
+// WrapHandle wraps h such that it will trace requests to the handler using
+// tracer t, or elasticapm.DefaultTracer if t is nil, and an optional recovery
+// function.
+//
+// Transactions will be reported with route as the transaction name.
+//
+// If recovery is non-nil, the wrapped handler will recover panics and
+// report them to Elastic APM.
+func WrapHandle(
+	h httprouter.Handle,
+	t *elasticapm.Tracer,
+	route string,
+	recovery apmhttp.RecoveryFunc,
+) httprouter.Handle {
+	if t == nil {
+		t = elasticapm.DefaultTracer
+	}
+	return func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+		tx := t.StartTransaction(req.Method+" "+route, "request")
+		ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
+		req = req.WithContext(ctx)
+		defer tx.Done(-1)
+
+		finished := false
+		w, resp := apmhttp.WrapResponseWriter(w)
+		defer func() {
+			if recovery != nil {
+				if v := recover(); v != nil {
+					recovery(w, req, tx, v)
+					finished = true
+				}
+			}
+			apmhttp.SetTransactionContext(tx, w, req, resp, finished)
+		}()
+		h(w, req, p)
+		finished = true
+	}
+}

--- a/contrib/apmhttprouter/handler_test.go
+++ b/contrib/apmhttprouter/handler_test.go
@@ -1,0 +1,120 @@
+package apmhttprouter_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmhttp"
+	"github.com/elastic/apm-agent-go/contrib/apmhttprouter"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestWrapHandle(t *testing.T) {
+	tracer, transport := newRecordingTracer()
+	defer tracer.Close()
+
+	router := httprouter.New()
+
+	const route = "/hello/:name/go/*wild"
+	router.GET(route, apmhttprouter.WrapHandle(
+		func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+			w.WriteHeader(http.StatusTeapot)
+			w.Write([]byte(fmt.Sprintf("%s:%s", p.ByName("name"), p.ByName("wild"))))
+		},
+		tracer, route,
+		nil, // no recovery
+	))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://server.testing/hello/go/go/bananas", nil)
+	req.Header.Set("User-Agent", "apmhttp_test")
+	req.RemoteAddr = "client.testing:1234"
+	router.ServeHTTP(w, req)
+	tracer.Flush(nil)
+	assert.Equal(t, "go:/bananas", w.Body.String())
+
+	payloads := transport.Payloads()
+	transactions := payloads[0].Transactions()
+	transaction := transactions[0]
+	assert.Equal(t, "GET /hello/:name/go/*wild", transaction.Name)
+	assert.Equal(t, "request", transaction.Type)
+	assert.Equal(t, "418", transaction.Result)
+
+	true_ := true
+	assert.Equal(t, &model.Context{
+		Request: &model.Request{
+			Socket: &model.RequestSocket{
+				RemoteAddress: "client.testing",
+			},
+			URL: model.URL{
+				Full:     "http://server.testing/hello/go/go/bananas",
+				Protocol: "http",
+				Hostname: "server.testing",
+				Path:     "/hello/go/go/bananas",
+			},
+			Method: "GET",
+			Headers: &model.RequestHeaders{
+				UserAgent: "apmhttp_test",
+			},
+			HTTPVersion: "1.1",
+		},
+		Response: &model.Response{
+			StatusCode: 418,
+			Finished:   &true_,
+		},
+	}, transaction.Context)
+}
+
+func TestRecovery(t *testing.T) {
+	tracer, transport := newRecordingTracer()
+	defer tracer.Close()
+
+	router := httprouter.New()
+
+	const route = "/panic"
+	router.GET(route, apmhttprouter.WrapHandle(
+		panicHandler, tracer, route,
+		apmhttp.NewTraceRecovery(tracer),
+	))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://server.testing/panic", nil)
+	router.ServeHTTP(w, req)
+	tracer.Flush(nil)
+	assert.Equal(t, http.StatusTeapot, w.Code)
+
+	payloads := transport.Payloads()
+	error0 := payloads[0].Errors()[0]
+	transaction := payloads[1].Transactions()[0]
+
+	assert.Equal(t, "panicHandler", error0.Culprit)
+	assert.Equal(t, "foo", error0.Exception.Message)
+
+	true_ := true
+	assert.Equal(t, &model.Response{
+		Finished:   &true_,
+		StatusCode: 418,
+	}, transaction.Context.Response)
+}
+
+func panicHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	w.WriteHeader(http.StatusTeapot)
+	panic("foo")
+}
+
+func newRecordingTracer() (*elasticapm.Tracer, *transporttest.RecorderTransport) {
+	var transport transporttest.RecorderTransport
+	tracer, err := elasticapm.NewTracer("apmhttp_test", "0.1")
+	if err != nil {
+		panic(err)
+	}
+	tracer.Transport = &transport
+	return tracer, &transport
+}

--- a/stacktrace/library.go
+++ b/stacktrace/library.go
@@ -193,6 +193,7 @@ var libraryPackages = map[string]struct{}{
 	"github.com/elastic/apm-agent-go/contrib/apmgin":                    {},
 	"github.com/elastic/apm-agent-go/contrib/apmgorilla":                {},
 	"github.com/elastic/apm-agent-go/contrib/apmhttp":                   {},
+	"github.com/elastic/apm-agent-go/contrib/apmhttprouter":             {},
 	"github.com/elastic/apm-agent-go/contrib/apmlambda":                 {},
 	"github.com/elastic/apm-agent-go/contrib/apmsql":                    {},
 	"github.com/elastic/apm-agent-go/contrib/apmsql/dsn":                {},


### PR DESCRIPTION
Introduce a handler wrapper for httprouter, for
tracing requests and reporting errors. Because
httprouter provides no way of obtaining the matched
route, the route must be passed into the WrapHandle
function as well as when registering the route
handler.