### PR TITLE
 contrib/apmgrpc: add gRPC interceptors

### DIFF
--- a/contrib/apmecho/middleware_test.go
+++ b/contrib/apmecho/middleware_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/contrib/apmecho"
 	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/transport/transporttest"
 )
 
 func TestEchoMiddleware(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	e := echo.New()
@@ -65,7 +64,7 @@ func TestEchoMiddleware(t *testing.T) {
 }
 
 func TestEchoMiddlewarePanic(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	e := echo.New()
@@ -79,7 +78,7 @@ func TestEchoMiddlewarePanic(t *testing.T) {
 }
 
 func TestEchoMiddlewareError(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	e := echo.New()
@@ -113,16 +112,6 @@ func handlePanic(c echo.Context) error {
 
 func handleError(c echo.Context) error {
 	return errors.New("wot")
-}
-
-func newRecordingTracer() (*elasticapm.Tracer, *transporttest.RecorderTransport) {
-	var transport transporttest.RecorderTransport
-	tracer, err := elasticapm.NewTracer("apmecho_test", "0.1")
-	if err != nil {
-		panic(err)
-	}
-	tracer.Transport = &transport
-	return tracer, &transport
 }
 
 func doRequest(e *echo.Echo, method, url string) *httptest.ResponseRecorder {

--- a/contrib/apmgorilla/middleware_test.go
+++ b/contrib/apmgorilla/middleware_test.go
@@ -9,14 +9,13 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/contrib/apmgorilla"
 	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/transport/transporttest"
 )
 
 func TestMuxMiddleware(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	r := mux.NewRouter()
@@ -66,16 +65,6 @@ func TestMuxMiddleware(t *testing.T) {
 func articleHandler(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	w.Write([]byte(fmt.Sprintf("%s:%s", vars["category"], vars["id"])))
-}
-
-func newRecordingTracer() (*elasticapm.Tracer, *transporttest.RecorderTransport) {
-	var transport transporttest.RecorderTransport
-	tracer, err := elasticapm.NewTracer("apmgorilla_test", "0.1")
-	if err != nil {
-		panic(err)
-	}
-	tracer.Transport = &transport
-	return tracer, &transport
 }
 
 func doRequest(h http.Handler, method, url string) *httptest.ResponseRecorder {

--- a/contrib/apmgrpc/client.go
+++ b/contrib/apmgrpc/client.go
@@ -1,0 +1,42 @@
+package apmgrpc
+
+import (
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"github.com/elastic/apm-agent-go"
+)
+
+// NewUnaryClientInterceptor returns a grpc.UnaryClientInterceptor that
+// traces gRPC requests with the given options.
+//
+// The interceptor will trace spans with the "grpc" type for each request
+// made, for any client method presented with a context containing a sampled
+// elasticapm.Transaction.
+func NewUnaryClientInterceptor(o ...ClientOption) grpc.UnaryClientInterceptor {
+	opts := clientOptions{}
+	for _, o := range o {
+		o(&opts)
+	}
+	return func(
+		ctx context.Context,
+		method string,
+		req, resp interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		span, ctx := elasticapm.StartSpan(ctx, method, "grpc")
+		if span != nil {
+			defer span.Done(-1)
+		}
+		return invoker(ctx, method, req, resp, cc, opts...)
+	}
+}
+
+type clientOptions struct {
+	tracer *elasticapm.Tracer
+}
+
+// ClientOption sets options for client-side tracing.
+type ClientOption func(*clientOptions)

--- a/contrib/apmgrpc/client_test.go
+++ b/contrib/apmgrpc/client_test.go
@@ -1,0 +1,43 @@
+package apmgrpc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestClientSpan(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	s, _, addr := newServer(t, nil) // no server tracing
+	defer s.GracefulStop()
+
+	conn, client := newClient(t, addr)
+	defer conn.Close()
+	resp, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "birita"})
+	require.NoError(t, err)
+	assert.Equal(t, resp, &pb.HelloReply{"hello, birita"})
+
+	// The client interceptor starts no transactions, only spans.
+	tracer.Flush(nil)
+	require.Len(t, transport.Payloads(), 0)
+
+	tx := tracer.StartTransaction("name", "type")
+	ctx := elasticapm.ContextWithTransaction(context.Background(), tx)
+	resp, err = client.SayHello(ctx, &pb.HelloRequest{Name: "birita"})
+	require.NoError(t, err)
+	assert.Equal(t, resp, &pb.HelloReply{"hello, birita"})
+	tx.Done(-1)
+
+	tracer.Flush(nil)
+	out := transport.Payloads()[0].Transactions()[0]
+	require.Len(t, out.Spans, 1)
+	assert.Equal(t, "/helloworld.Greeter/SayHello", out.Spans[0].Name)
+}

--- a/contrib/apmgrpc/doc.go
+++ b/contrib/apmgrpc/doc.go
@@ -1,0 +1,2 @@
+// Package apmgrpc provides interceptors for tracing gRPC.
+package apmgrpc

--- a/contrib/apmgrpc/packages.go
+++ b/contrib/apmgrpc/packages.go
@@ -1,0 +1,10 @@
+package apmgrpc
+
+import "github.com/elastic/apm-agent-go/stacktrace"
+
+func init() {
+	stacktrace.RegisterLibraryPackage(
+		"google.golang.org/grpc",
+		"github.com/grpc-ecosystem",
+	)
+}

--- a/contrib/apmgrpc/server.go
+++ b/contrib/apmgrpc/server.go
@@ -1,0 +1,123 @@
+package apmgrpc
+
+import (
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/model"
+)
+
+// NewUnaryServerInterceptor returns a grpc.UnaryServerInterceptor that
+// traces gRPC requests with the given options.
+//
+// The interceptor will trace transactions with the "grpc" type for each
+// incoming request. The transaction will be added to the context, so
+// server methods can use elasticapm.StartSpan with the provided context.
+//
+// By default, the interceptor will trace with elasticapm.DefaultTracer,
+// and will not recover any panics. Use WithTracer to specify an
+// alternative tracer, and WithRecovery to enable panic recovery.
+func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
+	opts := serverOptions{
+		tracer:  elasticapm.DefaultTracer,
+		recover: false,
+	}
+	for _, o := range o {
+		o(&opts)
+	}
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp interface{}, err error) {
+		tx := opts.tracer.StartTransaction(info.FullMethod, "grpc")
+		ctx = elasticapm.ContextWithTransaction(ctx, tx)
+		defer tx.Done(-1)
+
+		if tx.Sampled() {
+			p, ok := peer.FromContext(ctx)
+			if ok {
+				grpcContext := map[string]interface{}{
+					"peer.address": p.Addr.String(),
+				}
+				tx.Context = &model.Context{
+					Custom: map[string]interface{}{
+						"grpc": grpcContext,
+					},
+				}
+				if p.AuthInfo != nil {
+					grpcContext["auth"] = map[string]interface{}{
+						"type": p.AuthInfo.AuthType(),
+					}
+				}
+			}
+		}
+
+		defer func() {
+			r := recover()
+			if r != nil {
+				e := opts.tracer.Recovered(r, tx)
+				if e.Exception.Stacktrace == nil {
+					e.SetExceptionStacktrace(1)
+				}
+				e.Exception.Handled = opts.recover
+				e.Send()
+				if opts.recover {
+					err = status.Errorf(codes.Internal, "%s", r)
+				} else {
+					panic(r)
+				}
+			}
+		}()
+
+		resp, err = handler(ctx, req)
+		if err == nil {
+			tx.Result = codes.OK.String()
+		} else {
+			statusCode := codes.Unknown
+			s, ok := status.FromError(err)
+			if ok {
+				statusCode = s.Code()
+			}
+			tx.Result = statusCode.String()
+		}
+		return resp, err
+	}
+}
+
+type serverOptions struct {
+	tracer  *elasticapm.Tracer
+	recover bool
+}
+
+// ServerOption sets options for server-side tracing.
+type ServerOption func(*serverOptions)
+
+// WithTracer returns a ServerOption which sets t as the tracer
+// to use for tracing server requests.
+func WithTracer(t *elasticapm.Tracer) ServerOption {
+	if t == nil {
+		panic("t == nil")
+	}
+	return func(o *serverOptions) {
+		o.tracer = t
+	}
+}
+
+// WithRecovery returns a ServerOption which enables panic recovery
+// in the gRPC server interceptor.
+//
+// The interceptor will report panics as errors to Elastic APM,
+// but unless this is enabled, they will still cause the server to
+// be terminated. With recovery enabled, panics will be translated
+// to gRPC errors with the code gprc/codes.Internal.
+func WithRecovery() ServerOption {
+	return func(o *serverOptions) {
+		o.recover = true
+	}
+}

--- a/contrib/apmgrpc/server_test.go
+++ b/contrib/apmgrpc/server_test.go
@@ -1,0 +1,214 @@
+package apmgrpc_test
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+	"google.golang.org/grpc/status"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmgrpc"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/stacktrace"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func init() {
+	// Register this test package as an application package so we can
+	// check "culprit".
+	type foo struct{}
+	stacktrace.RegisterApplicationPackage(reflect.TypeOf(foo{}).PkgPath())
+}
+
+func TestServerTransaction(t *testing.T) {
+	adaptTest := func(f func(*testing.T, testParams)) func(*testing.T) {
+		return func(t *testing.T) {
+			tracer, transport := transporttest.NewRecorderTracer()
+			defer tracer.Close()
+
+			s, server, addr := newServer(t, tracer)
+			defer s.GracefulStop()
+
+			conn, client := newClient(t, addr)
+			defer conn.Close()
+
+			f(t, testParams{
+				server:    server,
+				conn:      conn,
+				client:    client,
+				tracer:    tracer,
+				transport: transport,
+			})
+		}
+	}
+	t.Run("happy", adaptTest(testServerTransactionHappy))
+	t.Run("unknown_error", adaptTest(testServerTransactionUnknownError))
+	t.Run("status_error", adaptTest(testServerTransactionStatusError))
+	t.Run("panic", adaptTest(testServerTransactionPanic))
+}
+
+type testParams struct {
+	server    *helloworldServer
+	conn      *grpc.ClientConn
+	client    pb.GreeterClient
+	tracer    *elasticapm.Tracer
+	transport *transporttest.RecorderTransport
+}
+
+func testServerTransactionHappy(t *testing.T, p testParams) {
+	resp, err := p.client.SayHello(context.Background(), &pb.HelloRequest{
+		Name: "birita",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, resp, &pb.HelloReply{"hello, birita"})
+
+	p.tracer.Flush(nil)
+	tx := p.transport.Payloads()[0].Transactions()[0]
+	assert.Equal(t, "/helloworld.Greeter/SayHello", tx.Name)
+	assert.Equal(t, "grpc", tx.Type)
+	assert.Equal(t, "OK", tx.Result)
+
+	assert.Contains(t, tx.Context.Custom, "grpc")
+	grpcContext := tx.Context.Custom["grpc"].(map[string]interface{})
+	assert.Contains(t, grpcContext, "peer.address")
+	delete(grpcContext, "peer.address")
+	assert.Equal(t, &model.Context{
+		Custom: map[string]interface{}{
+			"grpc": map[string]interface{}{},
+		},
+	}, tx.Context)
+}
+
+func testServerTransactionUnknownError(t *testing.T, p testParams) {
+	p.server.err = errors.New("boom")
+	_, err := p.client.SayHello(context.Background(), &pb.HelloRequest{Name: "birita"})
+	assert.EqualError(t, err, "rpc error: code = Unknown desc = boom")
+
+	p.tracer.Flush(nil)
+	payloads := p.transport.Payloads()
+	require.Len(t, payloads, 1)
+	tx := payloads[0].Transactions()[0]
+	assert.Equal(t, "/helloworld.Greeter/SayHello", tx.Name)
+	assert.Equal(t, "grpc", tx.Type)
+	assert.Equal(t, "Unknown", tx.Result)
+}
+
+func testServerTransactionStatusError(t *testing.T, p testParams) {
+	p.server.err = status.Errorf(codes.DataLoss, "boom")
+	_, err := p.client.SayHello(context.Background(), &pb.HelloRequest{Name: "birita"})
+	assert.EqualError(t, err, "rpc error: code = DataLoss desc = boom")
+
+	p.tracer.Flush(nil)
+	payloads := p.transport.Payloads()
+	require.Len(t, payloads, 1)
+	tx := payloads[0].Transactions()[0]
+	assert.Equal(t, "/helloworld.Greeter/SayHello", tx.Name)
+	assert.Equal(t, "grpc", tx.Type)
+	assert.Equal(t, "DataLoss", tx.Result)
+}
+
+func testServerTransactionPanic(t *testing.T, p testParams) {
+	p.server.panic = true
+	p.server.err = errors.New("boom")
+	_, err := p.client.SayHello(context.Background(), &pb.HelloRequest{Name: "birita"})
+	assert.EqualError(t, err, "rpc error: code = Internal desc = boom")
+
+	p.tracer.Flush(nil)
+	payloads := p.transport.Payloads()
+	require.Len(t, payloads, 2)
+	e := payloads[0].Errors()[0]
+	assert.NotEmpty(t, e.Transaction.ID)
+	assert.Equal(t, false, e.Exception.Handled)
+	assert.Equal(t, "(*helloworldServer).SayHello", e.Culprit)
+	assert.Equal(t, "boom", e.Exception.Message)
+}
+
+func TestServerRecovery(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	s, server, addr := newServer(t, tracer, apmgrpc.WithRecovery())
+	defer s.GracefulStop()
+
+	conn, client := newClient(t, addr)
+	defer conn.Close()
+
+	server.panic = true
+	server.err = errors.New("boom")
+	_, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "birita"})
+	assert.EqualError(t, err, "rpc error: code = Internal desc = boom")
+
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	require.Len(t, payloads, 2)
+	e := payloads[0].Errors()[0]
+	assert.NotEmpty(t, e.Transaction.ID)
+
+	// Panic was recovered by the recovery interceptor and translated
+	// into an Internal error.
+	assert.Equal(t, true, e.Exception.Handled)
+	assert.Equal(t, "(*helloworldServer).SayHello", e.Culprit)
+	assert.Equal(t, "boom", e.Exception.Message)
+}
+
+func newServer(t *testing.T, tracer *elasticapm.Tracer, opts ...apmgrpc.ServerOption) (*grpc.Server, *helloworldServer, net.Addr) {
+	// We always install grpc_recovery first to avoid panics
+	// aborting the test process. We install it before the
+	// apmgrpc interceptor so that apmgrpc can recover panics
+	// itself if configured to do so.
+	interceptors := []grpc.UnaryServerInterceptor{grpc_recovery.UnaryServerInterceptor()}
+	serverOpts := []grpc.ServerOption{}
+	if tracer != nil {
+		opts = append(opts, apmgrpc.WithTracer(tracer))
+		interceptors = append(interceptors, apmgrpc.NewUnaryServerInterceptor(opts...))
+	}
+	serverOpts = append(serverOpts, grpc_middleware.WithUnaryServerChain(interceptors...))
+
+	s := grpc.NewServer(serverOpts...)
+	server := &helloworldServer{}
+	pb.RegisterGreeterServer(s, server)
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	go s.Serve(lis)
+	return s, server, lis.Addr()
+}
+
+func newClient(t *testing.T, addr net.Addr) (*grpc.ClientConn, pb.GreeterClient) {
+	conn, err := grpc.Dial(
+		addr.String(), grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(apmgrpc.NewUnaryClientInterceptor()),
+	)
+	require.NoError(t, err)
+	return conn, pb.NewGreeterClient(conn)
+}
+
+type helloworldServer struct {
+	panic bool
+	err   error
+}
+
+func (s *helloworldServer) SayHello(ctx context.Context, req *pb.HelloRequest) (*pb.HelloReply, error) {
+	// The context passed to the server should contain a Transaction
+	// for the gRPC request.
+	span, ctx := elasticapm.StartSpan(ctx, "server_span", "type")
+	if span != nil {
+		span.Done(-1)
+	}
+	if s.panic {
+		panic(s.err)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &pb.HelloReply{"hello, " + req.Name}, nil
+}

--- a/contrib/apmhttp/handler_test.go
+++ b/contrib/apmhttp/handler_test.go
@@ -12,14 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 
-	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/contrib/apmhttp"
 	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/transport/transporttest"
 )
 
 func TestHandler(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	mux := http.NewServeMux()
@@ -73,7 +72,7 @@ func TestHandler(t *testing.T) {
 }
 
 func TestHandlerHTTP2(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	mux := http.NewServeMux()
@@ -137,7 +136,7 @@ func TestHandlerHTTP2(t *testing.T) {
 }
 
 func TestHandlerRecovery(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	h := &apmhttp.Handler{
@@ -168,14 +167,4 @@ func TestHandlerRecovery(t *testing.T) {
 func panicHandler(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusTeapot)
 	panic("foo")
-}
-
-func newRecordingTracer() (*elasticapm.Tracer, *transporttest.RecorderTransport) {
-	var transport transporttest.RecorderTransport
-	tracer, err := elasticapm.NewTracer("apmhttp_test", "0.1")
-	if err != nil {
-		panic(err)
-	}
-	tracer.Transport = &transport
-	return tracer, &transport
 }

--- a/contrib/apmhttprouter/handler_test.go
+++ b/contrib/apmhttprouter/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/contrib/apmhttp"
 	"github.com/elastic/apm-agent-go/contrib/apmhttprouter"
 	"github.com/elastic/apm-agent-go/model"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestWrapHandle(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	router := httprouter.New()
@@ -73,7 +72,7 @@ func TestWrapHandle(t *testing.T) {
 }
 
 func TestRecovery(t *testing.T) {
-	tracer, transport := newRecordingTracer()
+	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
 	router := httprouter.New()
@@ -107,14 +106,4 @@ func TestRecovery(t *testing.T) {
 func panicHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	w.WriteHeader(http.StatusTeapot)
 	panic("foo")
-}
-
-func newRecordingTracer() (*elasticapm.Tracer, *transporttest.RecorderTransport) {
-	var transport transporttest.RecorderTransport
-	tracer, err := elasticapm.NewTracer("apmhttp_test", "0.1")
-	if err != nil {
-		panic(err)
-	}
-	tracer.Transport = &transport
-	return tracer, &transport
 }

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -5,9 +5,22 @@ import (
 	"encoding/json"
 	"sync"
 
+	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/internal/fastjson"
 	"github.com/elastic/apm-agent-go/model"
 )
+
+// NewRecorderTransport returns a new elasticapm.Tracer and
+// RecorderTransport, which is set as the tracer's transport.
+func NewRecorderTracer() (*elasticapm.Tracer, *RecorderTransport) {
+	var transport RecorderTransport
+	tracer, err := elasticapm.NewTracer("transporttest", "")
+	if err != nil {
+		panic(err)
+	}
+	tracer.Transport = &transport
+	return tracer, &transport
+}
 
 // RecorderTransport implements transport.Transport,
 // recording the payloads sent. The payloads can be


### PR DESCRIPTION
Introduce contrib/apmgrpc, which contains gRPC client and server unary interceptors.