### PR TITLE
contrib/apmhttp: improve URL reconstruction

### DIFF
--- a/contrib/apmhttp/context_test.go
+++ b/contrib/apmhttp/context_test.go
@@ -1,6 +1,7 @@
 package apmhttp_test
 
 import (
+	"crypto/tls"
 	"net/http"
 	"strconv"
 	"testing"
@@ -8,9 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/apm-agent-go/contrib/apmhttp"
+	"github.com/elastic/apm-agent-go/model"
 )
-
-// TODO(axw) test the rest
 
 func TestRequestRemoteAddress(t *testing.T) {
 	req := &http.Request{
@@ -27,10 +27,133 @@ func TestRequestRemoteAddress(t *testing.T) {
 
 	req.Header.Set("X-Real-IP", "127.1.2.3")
 	assert.Equal(t, "127.1.2.3", apmhttp.RequestRemoteAddress(req))
+
+	// "for" is missing from Forwarded, so fall back to the next thing
+	req.Header.Set("Forwarded", `by=127.0.0.1`)
+	assert.Equal(t, "127.1.2.3", apmhttp.RequestRemoteAddress(req))
+
+	req.Header.Set("Forwarded", `for=_secret`)
+	assert.Equal(t, "_secret", apmhttp.RequestRemoteAddress(req))
+
+	req.Header.Set("Forwarded", `by=127.0.0.1; for="[2001:db8:cafe::17]:4711"; proto=HTTPS`)
+	assert.Equal(t, "2001:db8:cafe::17", apmhttp.RequestRemoteAddress(req))
+}
+
+func TestRequestURLClient(t *testing.T) {
+	req := mustNewRequest("https://user:pass@host.invalid:9443/path?query&querier=foo#fragment")
+	assert.Equal(t, model.URL{
+		// Username and password removed
+		Full:     "https://host.invalid:9443/path?query&querier=foo#fragment",
+		Protocol: "https",
+		Hostname: "host.invalid",
+		Port:     "9443",
+		Path:     "/path",
+		Search:   "query&querier=foo",
+		Hash:     "fragment",
+	}, apmhttp.RequestURL(req))
+}
+
+func TestRequestURLServer(t *testing.T) {
+	req := mustNewRequest("/path?query&querier=foo")
+	req.Host = "host.invalid:8080"
+
+	assert.Equal(t, model.URL{
+		Full:     "http://host.invalid:8080/path?query&querier=foo",
+		Protocol: "http",
+		Hostname: "host.invalid",
+		Port:     "8080",
+		Path:     "/path",
+		Search:   "query&querier=foo",
+	}, apmhttp.RequestURL(req))
+}
+
+func TestRequestURLServerTLS(t *testing.T) {
+	req := mustNewRequest("/path?query&querier=foo")
+	req.Host = "host.invalid:8080"
+	req.TLS = &tls.ConnectionState{}
+	assert.Equal(t, "https", apmhttp.RequestURL(req).Protocol)
+}
+
+func TestRequestURLHeaders(t *testing.T) {
+	type test struct {
+		name   string
+		full   string
+		header http.Header
+	}
+
+	tests := []test{{
+		name: "Forwarded",
+		full: "https://forwarded.invalid:443/",
+		header: http.Header{
+			"Forwarded": []string{
+				"by=127.0.0.1; for=127.1.1.1; Host=\"forwarded.invalid:443\"; proto=HTTPS",
+				"host=whatever", // only first value considered
+			},
+		},
+	}, {
+		name:   "Forwarded-Multi",
+		full:   "http://first.invalid/",
+		header: http.Header{"Forwarded": []string{"host=first.invalid, host=second.invalid"}},
+	}, {
+		name:   "Forwarded-Malformed-Fields-Ignored",
+		full:   "http://first.invalid/",
+		header: http.Header{"Forwarded": []string{"what; nonsense=\"; host=first.invalid"}},
+	}, {
+		name:   "Forwarded-Trailing-Separators",
+		full:   "http://first.invalid/",
+		header: http.Header{"Forwarded": []string{"host=first.invalid;,"}},
+	}, {
+		name:   "Forwarded-Empty-Host",
+		full:   "http://host.invalid/", // falls back to the next option
+		header: http.Header{"Forwarded": []string{"host="}},
+	}, {
+		name:   "X-Forwarded-Host",
+		full:   "http://x-forwarded-host.invalid/",
+		header: http.Header{"X-Forwarded-Host": []string{"x-forwarded-host.invalid"}},
+	}, {
+		name:   "X-Forwarded-Proto",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Forwarded-Proto": []string{"https"}},
+	}, {
+		name:   "X-Forwarded-Protocol",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Forwarded-Protocol": []string{"https"}},
+	}, {
+		name:   "X-Url-Scheme",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Url-Scheme": []string{"https"}},
+	}, {
+		name:   "Front-End-Https",
+		full:   "https://host.invalid/",
+		header: http.Header{"Front-End-Https": []string{"on"}},
+	}, {
+		name:   "X-Forwarded-Ssl",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Forwarded-Ssl": []string{"on"}},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := mustNewRequest("/")
+			req.Host = "host.invalid"
+			req.Header = test.header
+			out := apmhttp.RequestURL(req)
+			req.Header = nil
+			assert.Equal(t, test.full, out.Full)
+		})
+	}
 }
 
 func TestStatusCode(t *testing.T) {
 	for i := 100; i < 600; i++ {
 		assert.Equal(t, strconv.Itoa(i), apmhttp.StatusCodeString(i))
 	}
+}
+
+func mustNewRequest(url string) *http.Request {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		panic(err)
+	}
+	return req
 }

--- a/contrib/apmhttp/handler.go
+++ b/contrib/apmhttp/handler.go
@@ -7,6 +7,12 @@ import (
 	"github.com/elastic/apm-agent-go/model"
 )
 
+// Wrap returns a Handler wrapping h. This is a convenience function:
+// `apmhttp.Wrap(h)` is equivalent to `&apmhttp.Handler{Handler: h}`.
+func Wrap(h http.Handler) *Handler {
+	return &Handler{Handler: h}
+}
+
 // Handler wraps an http.Handler, reporting a new transaction for each request.
 //
 // The http.Request's context will be updated with the transaction.
@@ -28,6 +34,13 @@ type Handler struct {
 	// Tracer is an optional elasticapm.Tracer for tracing transactions.
 	// If this is nil, elasticapm.DefaultTracer will be used instead.
 	Tracer *elasticapm.Tracer
+}
+
+// WithRecovery returns a copy of h with Recovery set to r.
+func (h *Handler) WithRecovery(r RecoveryFunc) *Handler {
+	hcopy := *h
+	hcopy.Recovery = r
+	return &hcopy
 }
 
 // ServeHTTP delegates to h.Handler, tracing the transaction with

--- a/contrib/apmhttp/handler_test.go
+++ b/contrib/apmhttp/handler_test.go
@@ -17,6 +17,19 @@ import (
 	"github.com/elastic/apm-agent-go/transport/transporttest"
 )
 
+func TestWrap(t *testing.T) {
+	mux := http.DefaultServeMux
+	h := apmhttp.Wrap(mux)
+	r := apmhttp.NewTraceRecovery(nil)
+	h2 := h.WithRecovery(r)
+
+	assert.Equal(t, &apmhttp.Handler{Handler: mux}, h)
+	assert.NotEqual(t, h, h2)
+	assert.NotNil(t, h2.Recovery)
+	h2.Recovery = nil
+	assert.Equal(t, h, h2)
+}
+
 func TestHandler(t *testing.T) {
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()


### PR DESCRIPTION
Handle various reverse-proxy forwarding headers
when reconstructing the URL:

 - Forwarded
 - X-Forwarded-Host
 - X-Forwarded-Proto
 - X-Forwarded-Protocol
 - Front-EndHttps
 - X-Forwarded-Ssl

If the host is not set in a forwarding header
then the Host header value is used.

We also now use the "for" value from the Forwarded
header when determining the client address.

Closes #23