### PR TITLE
Revise errors interface

### DIFF
--- a/context.go
+++ b/context.go
@@ -47,7 +47,8 @@ func StartSpan(ctx context.Context, name, spanType string) (*Span, context.Conte
 
 // CaptureError returns a new Error related to the sampled transaction
 // present in the context, if any, and calls its SetException method
-// with the given error. The Exception.Handled field will be set to true.
+// with the given error. The Error.Handled field will be set to true,
+// and a stacktrace set.
 //
 // If there is no transaction in the context, or it is not being sampled,
 // CaptureError returns nil. As a convenience, if the provided error is
@@ -60,9 +61,8 @@ func CaptureError(ctx context.Context, err error) *Error {
 	if tx == nil || !tx.Sampled() {
 		return nil
 	}
-	e := tx.tracer.NewError()
-	e.SetException(err)
-	e.Exception.Handled = true
+	e := tx.tracer.NewError(err)
+	e.Handled = true
 	e.Transaction = tx
 	return e
 }

--- a/contrib/apmgin/middleware.go
+++ b/contrib/apmgin/middleware.go
@@ -85,9 +85,6 @@ func (m *middleware) handle(c *gin.Context) {
 		if v := recover(); v != nil {
 			c.AbortWithStatus(http.StatusInternalServerError)
 			e := m.tracer.Recovered(v, tx)
-			if e.Exception.Stacktrace == nil {
-				e.SetExceptionStacktrace(1)
-			}
 			e.Context = apmhttp.RequestContext(c.Request)
 			e.Send()
 		}
@@ -116,11 +113,10 @@ func (m *middleware) handle(c *gin.Context) {
 
 		// Report errors handled.
 		for _, err := range c.Errors {
-			e := m.tracer.NewError()
+			e := m.tracer.NewError(err.Err)
 			e.Transaction = tx
 			e.Context = txContext
-			e.SetException(err.Err)
-			e.Exception.Handled = true
+			e.Handled = true
 			e.Send()
 		}
 	}()

--- a/contrib/apmgrpc/server.go
+++ b/contrib/apmgrpc/server.go
@@ -62,10 +62,7 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 			r := recover()
 			if r != nil {
 				e := opts.tracer.Recovered(r, tx)
-				if e.Exception.Stacktrace == nil {
-					e.SetExceptionStacktrace(1)
-				}
-				e.Exception.Handled = opts.recover
+				e.Handled = opts.recover
 				e.Send()
 				if opts.recover {
 					err = status.Errorf(codes.Internal, "%s", r)

--- a/contrib/apmhttp/recovery.go
+++ b/contrib/apmhttp/recovery.go
@@ -20,9 +20,6 @@ func NewTraceRecovery(t *elasticapm.Tracer) RecoveryFunc {
 	}
 	return func(w http.ResponseWriter, req *http.Request, tx *elasticapm.Transaction, recovered interface{}) {
 		e := t.Recovered(recovered, tx)
-		if e.Exception.Stacktrace == nil {
-			e.SetExceptionStacktrace(1)
-		}
 		e.Context = RequestContext(req)
 		e.Send()
 	}

--- a/contrib/apmsql/conn.go
+++ b/contrib/apmsql/conn.go
@@ -67,9 +67,6 @@ func (c *conn) finishSpan(ctx context.Context, span *elasticapm.Span, query stri
 	}
 	span.Done(-1)
 	if e := elasticapm.CaptureError(ctx, resultError); e != nil {
-		if e.Exception.Stacktrace == nil {
-			e.SetExceptionStacktrace(2)
-		}
 		e.Send()
 	}
 }

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -24,6 +24,14 @@ func FormatTime(t time.Time) string {
 	return t.UTC().Format(dateTimeFormat)
 }
 
+func (l *Log) isZero() bool {
+	return l.Message == ""
+}
+
+func (e *Exception) isZero() bool {
+	return e.Message == ""
+}
+
 func (c Cookies) isZero() bool {
 	return len(c) == 0
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -416,7 +416,7 @@ func (v *Error) MarshalFastJSON(w *fastjson.Writer) {
 		w.RawString(",\"culprit\":")
 		w.String(v.Culprit)
 	}
-	if v.Exception != nil {
+	if !v.Exception.isZero() {
 		w.RawString(",\"exception\":")
 		v.Exception.MarshalFastJSON(w)
 	}
@@ -424,7 +424,7 @@ func (v *Error) MarshalFastJSON(w *fastjson.Writer) {
 		w.RawString(",\"id\":")
 		w.String(v.ID)
 	}
-	if v.Log != nil {
+	if !v.Log.isZero() {
 		w.RawString(",\"log\":")
 		v.Log.MarshalFastJSON(w)
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -264,10 +264,10 @@ type Error struct {
 
 	// Exception holds details of the exception (error or panic)
 	// to which this error relates.
-	Exception *Exception `json:"exception,omitempty"`
+	Exception Exception `json:"exception,omitempty"`
 
 	// Log holds additional information added when logging the error.
-	Log *Log `json:"log,omitempty"`
+	Log Log `json:"log,omitempty"`
 }
 
 // ErrorTransaction identifies the transaction within which the error occurred.


### PR DESCRIPTION
This is a step towards unexposing the model types from
the public API, as well as simplifying the public API.

Previously, to create an error you would call Tracer.NewError,
and then call either its SetLog or its SetException methods.
Now, instead you just call Tracer.NewError(error) or
Tracer.NewErrorLog(ErrorLogRecord). Additionally, you would
previously call SetLogStacktrace or SetExceptionStacktrace.
Now you just call SetStacktrace, and it is routed to the
correct place depending on how the error was constructed.

Error's previously embedded model.Error has been renamed
to "model" (i.e. unexposed), and various fields have been
added to Error for customising the error (ID, Culprit, etc.)
As a result, changes have been made to how we set the
exception details: if an error implements Type or Code
methods, those will be used for setting the exception type
and code respectively. Similarly, we now have an internal
StackTrace method, similar to the existing pkg/errors support.

model.Error's Exception and Log fields are no longer
pointers. Instead, they are omitted if their (required)
Message fields are empty. This should cut down on garbage
generation.

For errors, we still deal with model types directly in two
places: stacktraces and context. We will address these in
followups, as well as making similar changes to transactions
and spans.

Partially addresses https://github.com/elastic/apm-agent-go/issues/46