### PR TITLE
all: introduce and use stacktrace.Frame

### DIFF
--- a/contrib/apmlambda/lambda.go
+++ b/contrib/apmlambda/lambda.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/rpc"
 	"os"
-	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -119,15 +118,14 @@ func (e invokeResponseError) Type() string {
 	return e.err.Type
 }
 
-func (e invokeResponseError) StackTrace() []model.StacktraceFrame {
-	frames := make([]model.StacktraceFrame, len(e.err.StackTrace))
+func (e invokeResponseError) StackTrace() []stacktrace.Frame {
+	frames := make([]stacktrace.Frame, len(e.err.StackTrace))
 	for i, f := range e.err.StackTrace {
-		packagePath, functionName := stacktrace.SplitFunctionName(f.Label)
-		frames[i].File = filepath.Base(f.Path)
-		frames[i].Line = int(f.Line)
-		frames[i].Module = packagePath
-		frames[i].Function = functionName
-		frames[i].LibraryFrame = stacktrace.IsLibraryPackage(packagePath)
+		frames[i] = stacktrace.Frame{
+			Function: f.Label,
+			File:     f.Path,
+			Line:     int(f.Line),
+		}
 	}
 	return frames
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,118 @@
+package elasticapm_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/stacktrace"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestErrorsStackTrace(t *testing.T) {
+	modelError := sendError(t, &errorsStackTracer{
+		"zing", newErrorsStackTrace(0, 2),
+	})
+	exception := modelError.Exception
+	stacktrace := exception.Stacktrace
+	assert.Equal(t, "zing", exception.Message)
+	assert.Equal(t, "github.com/elastic/apm-agent-go_test", exception.Module)
+	assert.Equal(t, "errorsStackTracer", exception.Type)
+	assert.Len(t, stacktrace, 2)
+	assert.Equal(t, "newErrorsStackTrace", stacktrace[0].Function)
+	assert.Equal(t, "TestErrorsStackTrace", stacktrace[1].Function)
+}
+
+func TestInternalStackTrace(t *testing.T) {
+	// Absolute path on both windows (UNC) and *nix
+	abspath := filepath.FromSlash("//abs/path/file.go")
+	modelError := sendError(t, &internalStackTracer{
+		"zing", []stacktrace.Frame{
+			{Function: "pkg/path.FuncName"},
+			{Function: "FuncName2", File: abspath, Line: 123},
+			{Function: "encoding/json.Marshal"},
+		},
+	})
+	exception := modelError.Exception
+	stacktrace := exception.Stacktrace
+	assert.Equal(t, "zing", exception.Message)
+	assert.Equal(t, "github.com/elastic/apm-agent-go_test", exception.Module)
+	assert.Equal(t, "internalStackTracer", exception.Type)
+	assert.Equal(t, []model.StacktraceFrame{{
+		Function: "FuncName",
+		Module:   "pkg/path",
+	}, {
+		AbsolutePath: abspath,
+		Function:     "FuncName2",
+		File:         "file.go",
+		Line:         123,
+	}, {
+		Function:     "Marshal",
+		Module:       "encoding/json",
+		LibraryFrame: true,
+	}}, stacktrace)
+}
+
+func sendError(t *testing.T, err error, f ...func(*elasticapm.Error)) *model.Error {
+	var r transporttest.RecorderTransport
+	tracer, newTracerErr := elasticapm.NewTracer("tracer.testing", "")
+	assert.NoError(t, newTracerErr)
+	defer tracer.Close()
+
+	error_ := tracer.NewError(err)
+	for _, f := range f {
+		f(error_)
+	}
+
+	tracer.Transport = &r
+	error_.Send()
+	tracer.Flush(nil)
+
+	payloads := r.Payloads()
+	require.Len(t, payloads, 1)
+	errors := payloads[0].Errors()
+	require.Len(t, errors, 1)
+	return errors[0]
+}
+
+type errorsStackTracer struct {
+	message    string
+	stackTrace errors.StackTrace
+}
+
+func (e *errorsStackTracer) Error() string {
+	return e.message
+}
+
+func (e *errorsStackTracer) StackTrace() errors.StackTrace {
+	return e.stackTrace
+}
+
+func newErrorsStackTrace(skip, n int) errors.StackTrace {
+	callers := make([]uintptr, 2)
+	callers = callers[:runtime.Callers(1, callers)]
+	frames := make([]errors.Frame, len(callers))
+	for i, pc := range callers {
+		frames[i] = errors.Frame(pc)
+	}
+	return errors.StackTrace(frames)
+}
+
+type internalStackTracer struct {
+	message string
+	frames  []stacktrace.Frame
+}
+
+func (e *internalStackTracer) Error() string {
+	return e.message
+}
+
+func (e *internalStackTracer) StackTrace() []stacktrace.Frame {
+	return e.frames
+}

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -1,0 +1,35 @@
+package elasticapm
+
+import (
+	"path/filepath"
+
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/stacktrace"
+)
+
+func appendModelStacktraceFrames(out []model.StacktraceFrame, in []stacktrace.Frame) []model.StacktraceFrame {
+	for _, f := range in {
+		out = append(out, modelStacktraceFrame(f))
+	}
+	return out
+}
+
+func modelStacktraceFrame(in stacktrace.Frame) model.StacktraceFrame {
+	var abspath string
+	file := in.File
+	if file != "" {
+		if filepath.IsAbs(file) {
+			abspath = file
+		}
+		file = filepath.Base(file)
+	}
+	packagePath, function := stacktrace.SplitFunctionName(in.Function)
+	return model.StacktraceFrame{
+		AbsolutePath: abspath,
+		File:         file,
+		Line:         in.Line,
+		Function:     function,
+		Module:       packagePath,
+		LibraryFrame: stacktrace.IsLibraryPackage(packagePath),
+	}
+}

--- a/stacktrace/doc.go
+++ b/stacktrace/doc.go
@@ -1,3 +1,3 @@
-// Package stacktrace provides functions for obtaining and formatting
-// stack frames according to the Elastic APM model.
+// Package stacktrace provides a simplified stack frame type,
+// functions for obtaining stack frames, and related utilities.
 package stacktrace

--- a/stacktrace/frame.go
+++ b/stacktrace/frame.go
@@ -1,0 +1,17 @@
+package stacktrace
+
+// Frame describes a stack frame.
+type Frame struct {
+	// File is the filename of the location of the stack frame.
+	// This may be either the absolute or base name of the file.
+	File string
+
+	// Line is the 1-based line number of the location of the
+	// stack frame, or zero if unknown.
+	Line int
+
+	// Function is the name of the function name for this stack
+	// frame. This should be package-qualified, and may be split
+	// using stacktrace.SplitFunctionName.
+	Function string
+}

--- a/stacktrace/stacktrace_test.go
+++ b/stacktrace/stacktrace_test.go
@@ -9,31 +9,24 @@ import (
 )
 
 func TestStacktrace(t *testing.T) {
-	type frameInfo struct {
-		Module   string
-		Function string
-	}
-	expect := []frameInfo{
-		{"github.com/elastic/apm-agent-go/stacktrace_test", "TestStacktrace.func1"},
-		{"runtime", "call32"},
-		{"runtime", "gopanic"},
-		{"github.com/elastic/apm-agent-go/stacktrace_test", "(*panicker).panic"},
-		{"github.com/elastic/apm-agent-go/stacktrace_test", "TestStacktrace"},
+	expect := []string{
+		"github.com/elastic/apm-agent-go/stacktrace_test.TestStacktrace.func1",
+		"runtime.call32",
+		"runtime.gopanic",
+		"github.com/elastic/apm-agent-go/stacktrace_test.(*panicker).panic",
+		"github.com/elastic/apm-agent-go/stacktrace_test.TestStacktrace",
 	}
 	defer func() {
 		err := recover()
 		if err == nil {
 			t.FailNow()
 		}
-		allFrames := stacktrace.Stacktrace(1, 5)
-		var info []frameInfo
-		for _, frame := range allFrames {
-			info = append(info, frameInfo{
-				Module:   frame.Module,
-				Function: frame.Function,
-			})
+		allFrames := stacktrace.AppendStacktrace(nil, 1, 5)
+		functions := make([]string, len(allFrames))
+		for i, frame := range allFrames {
+			functions[i] = frame.Function
 		}
-		if diff := cmp.Diff(info, expect); diff != "" {
+		if diff := cmp.Diff(functions, expect); diff != "" {
 			t.Fatalf("%s", diff)
 		}
 	}()

--- a/tracer.go
+++ b/tracer.go
@@ -568,17 +568,12 @@ func (s *sender) sendErrors(ctx context.Context, errors []*Error) bool {
 			e.Transaction.setID()
 			e.model.Transaction.ID = e.Transaction.ID
 		}
+		e.setStacktrace()
 		e.setCulprit()
-		if e.model.Log.Message != "" {
-			e.model.Log.Stacktrace = e.stacktrace
-		}
-		if e.model.Exception.Message != "" {
-			e.model.Exception.Handled = e.Handled
-			e.model.Exception.Stacktrace = e.stacktrace
-		}
-		e.model.Context = e.Context
 		e.model.ID = e.ID
 		e.model.Timestamp = model.FormatTime(e.Timestamp)
+		e.model.Context = e.Context
+		e.model.Exception.Handled = e.Handled
 		if s.processor != nil {
 			s.processor.ProcessError(&e.model)
 		}


### PR DESCRIPTION
Introduce stacktrace.Frame, a distilled
version of runtime.Frame, with only the
information we care about. Errors may
now implement

  type interface {
      StackTrace() []stacktrace.Frame
  }

as an alternative to pkg/errors, rather
than directly referencing the model
stacktrace frame type. This moves us a
step closer to not exposing the model
types in any if the public/stable API.

Stacktrace functions have been changed
to append to provided slices, enabling
memory reuse.