### PR TITLE
all: various internal optimizations

### DIFF
--- a/contrib/apmhttp/context.go
+++ b/contrib/apmhttp/context.go
@@ -2,19 +2,13 @@ package apmhttp
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/elastic/apm-agent-go/internal/apmhttputil"
 	"github.com/elastic/apm-agent-go/model"
 )
-
-// RequestName returns the name to use in model.Transaction.Name
-// for HTTP requests.
-func RequestName(req *http.Request) string {
-	return fmt.Sprintf("%s %s", req.Method, req.URL.Path)
-}
 
 // RequestContext returns the context to use in model.Transaction.Context
 // for HTTP requests.
@@ -29,6 +23,9 @@ func RequestName(req *http.Request) string {
 // if specified, or else the username in the URL if specified. Otherwise, the
 // Context.User field will be nil. In either case, application's may wish to
 // override the user values.
+//
+// TODO(axw) move this out of apmhttp, into the elasticapm package, or a
+// sub-package specifically for context creation.
 func RequestContext(req *http.Request) *model.Context {
 	username, _, ok := req.BasicAuth()
 	if !ok && req.URL.User != nil {
@@ -46,17 +43,22 @@ func RequestContext(req *http.Request) *model.Context {
 		httpVersion = fmt.Sprintf("%d.%d", req.ProtoMajor, req.ProtoMinor)
 	}
 
-	forwarded := maybeParseForwarded(req)
+	var forwarded *apmhttputil.ForwardedHeader
+	if fwd := req.Header.Get("Forwarded"); fwd != "" {
+		parsed := apmhttputil.ParseForwarded(fwd)
+		forwarded = &parsed
+	}
+
 	ctx := model.Context{
 		Request: &model.Request{
-			URL:         requestURL(req, forwarded),
+			URL:         apmhttputil.RequestURL(req, forwarded),
 			Method:      req.Method,
 			Headers:     RequestHeaders(req),
 			HTTPVersion: httpVersion,
 			Cookies:     req.Cookies(),
 			Socket: &model.RequestSocket{
 				Encrypted:     req.TLS != nil,
-				RemoteAddress: requestRemoteAddress(req, forwarded),
+				RemoteAddress: apmhttputil.RemoteAddr(req, forwarded),
 			},
 		},
 	}
@@ -68,90 +70,6 @@ func RequestContext(req *http.Request) *model.Context {
 	return &ctx
 }
 
-// RequestURL returns a model.URL for the given HTTP request.
-// This function may be used for either clients or servers.
-// For server-side requests, various proxy forwarding headers
-// are taken into account.
-//
-// If the URL contains user info, it will be removed and
-// excluded from the URL's "full" field.
-func RequestURL(req *http.Request) model.URL {
-	forwarded := maybeParseForwarded(req)
-	return requestURL(req, forwarded)
-}
-
-func requestURL(req *http.Request, forwarded *forwardedHeader) model.URL {
-	out := model.URL{
-		Path:   req.URL.Path,
-		Search: req.URL.RawQuery,
-		Hash:   req.URL.Fragment,
-	}
-	if req.URL.Host != "" {
-		// Absolute URI: client-side or proxy request, so ignore the
-		// headers.
-		out.Hostname, out.Port = splitHost(req.URL.Host)
-		out.Protocol = req.URL.Scheme
-
-		// If the URL contains user info, remove it before formatting
-		// so it doesn't make its way into the "full" URL, to avoid
-		// leaking PII or secrets. This is only necessary for clients.
-		user := req.URL.User
-		req.URL.User = nil
-		out.Full = req.URL.String()
-		req.URL.User = user
-		return out
-	}
-
-	// This is a server-side request URI, which contains only the path.
-	// We synthesize the full URL by extracting the host and protocol
-	// from headers, or inferring from other properties.
-	var fullHost string
-	if forwarded != nil && forwarded.Host != "" {
-		fullHost = forwarded.Host
-		out.Protocol = forwarded.Proto
-	} else if xfh := req.Header.Get("X-Forwarded-Host"); xfh != "" {
-		fullHost = xfh
-	} else {
-		fullHost = req.Host
-	}
-	out.Hostname, out.Port = splitHost(fullHost)
-
-	// Protocol might be extracted from the Forwarded header. If it's not,
-	// look for various other headers.
-	if out.Protocol == "" {
-		if proto := req.Header.Get("X-Forwarded-Proto"); proto != "" {
-			out.Protocol = proto
-		} else if proto := req.Header.Get("X-Forwarded-Protocol"); proto != "" {
-			out.Protocol = proto
-		} else if proto := req.Header.Get("X-Url-Scheme"); proto != "" {
-			out.Protocol = proto
-		} else if req.Header.Get("Front-End-Https") == "on" {
-			out.Protocol = "https"
-		} else if req.Header.Get("X-Forwarded-Ssl") == "on" {
-			out.Protocol = "https"
-		} else if req.TLS != nil {
-			out.Protocol = "https"
-		} else {
-			// Assume http otherwise.
-			out.Protocol = "http"
-		}
-	}
-
-	u := *req.URL
-	u.Scheme = out.Protocol
-	u.Host = fullHost
-	out.Full = u.String()
-	return out
-}
-
-func splitHost(in string) (host, port string) {
-	host, port, err := net.SplitHostPort(in)
-	if err != nil {
-		return in, ""
-	}
-	return host, port
-}
-
 // RequestHeaders returns the headers for the HTTP request relevant to tracing.
 func RequestHeaders(req *http.Request) *model.RequestHeaders {
 	return &model.RequestHeaders{
@@ -159,47 +77,6 @@ func RequestHeaders(req *http.Request) *model.RequestHeaders {
 		Cookie:      strings.Join(req.Header["Cookie"], ";"),
 		UserAgent:   req.UserAgent(),
 	}
-}
-
-// RequestRemoteAddress returns the remote address for the HTTP request.
-//
-// In order:
-//  - if the Forwarded header is set, then the first item in the
-//    list's "for" field is used, if it exists. The "for" value
-//    is returned even if it is an obfuscated identifier.
-//  - if the X-Real-IP header is set, then its value is returned.
-//  - if the X-Forwarded-For header is set, then the first value
-//    in the comma-separated list is returned.
-//  - otherwise, the host portion of req.RemoteAddr is returned.
-func RequestRemoteAddress(req *http.Request) string {
-	forwarded := maybeParseForwarded(req)
-	return requestRemoteAddress(req, forwarded)
-}
-
-func requestRemoteAddress(req *http.Request, forwarded *forwardedHeader) string {
-	if forwarded != nil {
-		if forwarded.For != "" {
-			remoteAddr, _, err := net.SplitHostPort(forwarded.For)
-			if err != nil {
-				remoteAddr = forwarded.For
-			}
-			return remoteAddr
-		}
-	}
-	if realIP := req.Header.Get("X-Real-IP"); realIP != "" {
-		return realIP
-	}
-	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
-		if sep := strings.IndexRune(xff, ','); sep > 0 {
-			xff = xff[:sep]
-		}
-		return strings.TrimSpace(xff)
-	}
-	remoteAddr, _, err := net.SplitHostPort(req.RemoteAddr)
-	if err != nil {
-		remoteAddr = req.RemoteAddr
-	}
-	return remoteAddr
 }
 
 // ResponseHeaders returns the headers for the HTTP response relevant to tracing.
@@ -342,61 +219,4 @@ func StatusCodeString(statusCode int) string {
 		return "511"
 	}
 	return strconv.Itoa(statusCode)
-}
-
-type forwardedHeader struct {
-	For   string
-	Host  string
-	Proto string
-}
-
-func maybeParseForwarded(req *http.Request) *forwardedHeader {
-	if fwd := req.Header.Get("Forwarded"); fwd != "" {
-		parsed := parseForwarded(fwd)
-		return &parsed
-	}
-	return nil
-}
-
-func parseForwarded(f string) forwardedHeader {
-	// We only consider the first value in the sequence,
-	// if there are multiple. Disregard everything after
-	// the first comma.
-	if comma := strings.IndexRune(f, ','); comma != -1 {
-		f = f[:comma]
-	}
-	var result forwardedHeader
-	for f != "" {
-		field := f
-		if semi := strings.IndexRune(f, ';'); semi != -1 {
-			field = f[:semi]
-			f = f[semi+1:]
-		} else {
-			f = ""
-		}
-		eq := strings.IndexRune(field, '=')
-		if eq == -1 {
-			// Malformed field, ignore.
-			continue
-		}
-		key := strings.TrimSpace(field[:eq])
-		value := strings.TrimSpace(field[eq+1:])
-		if len(value) > 0 && value[0] == '"' {
-			var err error
-			value, err = strconv.Unquote(value)
-			if err != nil {
-				// Malformed, ignore
-				continue
-			}
-		}
-		switch strings.ToLower(key) {
-		case "for":
-			result.For = value
-		case "host":
-			result.Host = value
-		case "proto":
-			result.Proto = strings.ToLower(value)
-		}
-	}
-	return result
 }

--- a/contrib/apmhttp/context_test.go
+++ b/contrib/apmhttp/context_test.go
@@ -1,159 +1,16 @@
 package apmhttp_test
 
 import (
-	"crypto/tls"
-	"net/http"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/apm-agent-go/contrib/apmhttp"
-	"github.com/elastic/apm-agent-go/model"
 )
-
-func TestRequestRemoteAddress(t *testing.T) {
-	req := &http.Request{
-		RemoteAddr: "[::1]:1234",
-		Header:     make(http.Header),
-	}
-	assert.Equal(t, "::1", apmhttp.RequestRemoteAddress(req))
-
-	req.Header.Set("X-Forwarded-For", "client.invalid")
-	assert.Equal(t, "client.invalid", apmhttp.RequestRemoteAddress(req))
-
-	req.Header.Set("X-Forwarded-For", "client.invalid, proxy.invalid")
-	assert.Equal(t, "client.invalid", apmhttp.RequestRemoteAddress(req))
-
-	req.Header.Set("X-Real-IP", "127.1.2.3")
-	assert.Equal(t, "127.1.2.3", apmhttp.RequestRemoteAddress(req))
-
-	// "for" is missing from Forwarded, so fall back to the next thing
-	req.Header.Set("Forwarded", `by=127.0.0.1`)
-	assert.Equal(t, "127.1.2.3", apmhttp.RequestRemoteAddress(req))
-
-	req.Header.Set("Forwarded", `for=_secret`)
-	assert.Equal(t, "_secret", apmhttp.RequestRemoteAddress(req))
-
-	req.Header.Set("Forwarded", `by=127.0.0.1; for="[2001:db8:cafe::17]:4711"; proto=HTTPS`)
-	assert.Equal(t, "2001:db8:cafe::17", apmhttp.RequestRemoteAddress(req))
-}
-
-func TestRequestURLClient(t *testing.T) {
-	req := mustNewRequest("https://user:pass@host.invalid:9443/path?query&querier=foo#fragment")
-	assert.Equal(t, model.URL{
-		// Username and password removed
-		Full:     "https://host.invalid:9443/path?query&querier=foo#fragment",
-		Protocol: "https",
-		Hostname: "host.invalid",
-		Port:     "9443",
-		Path:     "/path",
-		Search:   "query&querier=foo",
-		Hash:     "fragment",
-	}, apmhttp.RequestURL(req))
-}
-
-func TestRequestURLServer(t *testing.T) {
-	req := mustNewRequest("/path?query&querier=foo")
-	req.Host = "host.invalid:8080"
-
-	assert.Equal(t, model.URL{
-		Full:     "http://host.invalid:8080/path?query&querier=foo",
-		Protocol: "http",
-		Hostname: "host.invalid",
-		Port:     "8080",
-		Path:     "/path",
-		Search:   "query&querier=foo",
-	}, apmhttp.RequestURL(req))
-}
-
-func TestRequestURLServerTLS(t *testing.T) {
-	req := mustNewRequest("/path?query&querier=foo")
-	req.Host = "host.invalid:8080"
-	req.TLS = &tls.ConnectionState{}
-	assert.Equal(t, "https", apmhttp.RequestURL(req).Protocol)
-}
-
-func TestRequestURLHeaders(t *testing.T) {
-	type test struct {
-		name   string
-		full   string
-		header http.Header
-	}
-
-	tests := []test{{
-		name: "Forwarded",
-		full: "https://forwarded.invalid:443/",
-		header: http.Header{
-			"Forwarded": []string{
-				"by=127.0.0.1; for=127.1.1.1; Host=\"forwarded.invalid:443\"; proto=HTTPS",
-				"host=whatever", // only first value considered
-			},
-		},
-	}, {
-		name:   "Forwarded-Multi",
-		full:   "http://first.invalid/",
-		header: http.Header{"Forwarded": []string{"host=first.invalid, host=second.invalid"}},
-	}, {
-		name:   "Forwarded-Malformed-Fields-Ignored",
-		full:   "http://first.invalid/",
-		header: http.Header{"Forwarded": []string{"what; nonsense=\"; host=first.invalid"}},
-	}, {
-		name:   "Forwarded-Trailing-Separators",
-		full:   "http://first.invalid/",
-		header: http.Header{"Forwarded": []string{"host=first.invalid;,"}},
-	}, {
-		name:   "Forwarded-Empty-Host",
-		full:   "http://host.invalid/", // falls back to the next option
-		header: http.Header{"Forwarded": []string{"host="}},
-	}, {
-		name:   "X-Forwarded-Host",
-		full:   "http://x-forwarded-host.invalid/",
-		header: http.Header{"X-Forwarded-Host": []string{"x-forwarded-host.invalid"}},
-	}, {
-		name:   "X-Forwarded-Proto",
-		full:   "https://host.invalid/",
-		header: http.Header{"X-Forwarded-Proto": []string{"https"}},
-	}, {
-		name:   "X-Forwarded-Protocol",
-		full:   "https://host.invalid/",
-		header: http.Header{"X-Forwarded-Protocol": []string{"https"}},
-	}, {
-		name:   "X-Url-Scheme",
-		full:   "https://host.invalid/",
-		header: http.Header{"X-Url-Scheme": []string{"https"}},
-	}, {
-		name:   "Front-End-Https",
-		full:   "https://host.invalid/",
-		header: http.Header{"Front-End-Https": []string{"on"}},
-	}, {
-		name:   "X-Forwarded-Ssl",
-		full:   "https://host.invalid/",
-		header: http.Header{"X-Forwarded-Ssl": []string{"on"}},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			req := mustNewRequest("/")
-			req.Host = "host.invalid"
-			req.Header = test.header
-			out := apmhttp.RequestURL(req)
-			req.Header = nil
-			assert.Equal(t, test.full, out.Full)
-		})
-	}
-}
 
 func TestStatusCode(t *testing.T) {
 	for i := 100; i < 600; i++ {
 		assert.Equal(t, strconv.Itoa(i), apmhttp.StatusCodeString(i))
 	}
-}
-
-func mustNewRequest(url string) *http.Request {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		panic(err)
-	}
-	return req
 }

--- a/contrib/apmhttp/handler_bench_test.go
+++ b/contrib/apmhttp/handler_bench_test.go
@@ -46,12 +46,10 @@ func benchmark(b *testing.B, path string, wrapHandler func(http.Handler) http.Ha
 	if wrapHandler != nil {
 		h = wrapHandler(h)
 	}
-
+	req, _ := http.NewRequest("GET", path, nil)
 	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		req, _ := http.NewRequest("GET", path, nil)
-		b.StartTimer()
 		h.ServeHTTP(w, req)
 	}
 }

--- a/contrib/apmhttp/requestname.go
+++ b/contrib/apmhttp/requestname.go
@@ -1,0 +1,18 @@
+// +build go1.10
+
+package apmhttp
+
+import (
+	"net/http"
+	"strings"
+)
+
+// RequestName returns the transaction name for req.
+func RequestName(req *http.Request) string {
+	var b strings.Builder
+	b.Grow(len(req.Method) + len(req.URL.Path) + 1)
+	b.WriteString(req.Method)
+	b.WriteByte(' ')
+	b.WriteString(req.URL.Path)
+	return b.String()
+}

--- a/contrib/apmhttp/requestname_go19.go
+++ b/contrib/apmhttp/requestname_go19.go
@@ -1,0 +1,14 @@
+// +build !go1.10
+
+package apmhttp
+
+import "net/http"
+
+// RequestName returns the transaction name for req.
+func RequestName(req *http.Request) string {
+	buf := make([]byte, len(req.Method)+len(req.URL.Path)+1)
+	n := copy(buf, req.Method)
+	buf[n] = ' '
+	copy(buf[n+1:], req.URL.Path)
+	return string(buf)
+}

--- a/error.go
+++ b/error.go
@@ -140,8 +140,9 @@ type Error struct {
 	// culprit.
 	Culprit string
 
-	// Transaction is the transaction to which the error
-	// correspoonds, if any.
+	// Transaction is the transaction to which the error correspoonds,
+	// if any. If this is set, the error's Send method must be called
+	// before the transaction's Done method.
 	Transaction *Transaction
 
 	// Timestamp records the time at which the error occurred.

--- a/internal/apmhttputil/forwarded.go
+++ b/internal/apmhttputil/forwarded.go
@@ -1,0 +1,57 @@
+package apmhttputil
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ForwardedHeader holds information extracted from a "Forwarded" HTTP header.
+type ForwardedHeader struct {
+	For   string
+	Host  string
+	Proto string
+}
+
+// ParseForwarded parses a "Forwarded" HTTP header.
+func ParseForwarded(f string) ForwardedHeader {
+	// We only consider the first value in the sequence,
+	// if there are multiple. Disregard everything after
+	// the first comma.
+	if comma := strings.IndexRune(f, ','); comma != -1 {
+		f = f[:comma]
+	}
+	var result ForwardedHeader
+	for f != "" {
+		field := f
+		if semi := strings.IndexRune(f, ';'); semi != -1 {
+			field = f[:semi]
+			f = f[semi+1:]
+		} else {
+			f = ""
+		}
+		eq := strings.IndexRune(field, '=')
+		if eq == -1 {
+			// Malformed field, ignore.
+			continue
+		}
+		key := strings.TrimSpace(field[:eq])
+		value := strings.TrimSpace(field[eq+1:])
+		if len(value) > 0 && value[0] == '"' {
+			var err error
+			value, err = strconv.Unquote(value)
+			if err != nil {
+				// Malformed, ignore
+				continue
+			}
+		}
+		switch strings.ToLower(key) {
+		case "for":
+			result.For = value
+		case "host":
+			result.Host = value
+		case "proto":
+			result.Proto = value
+		}
+	}
+	return result
+}

--- a/internal/apmhttputil/forwarded_test.go
+++ b/internal/apmhttputil/forwarded_test.go
@@ -1,0 +1,52 @@
+package apmhttputil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go/internal/apmhttputil"
+)
+
+func TestParseForwarded(t *testing.T) {
+	type test struct {
+		name   string
+		header string
+		expect apmhttputil.ForwardedHeader
+	}
+
+	tests := []test{{
+		name:   "Forwarded",
+		header: "by=127.0.0.1; for=127.1.1.1; Host=\"forwarded.invalid:443\"; proto=HTTPS",
+		expect: apmhttputil.ForwardedHeader{
+			For:   "127.1.1.1",
+			Host:  "forwarded.invalid:443",
+			Proto: "HTTPS",
+		},
+	}, {
+		name:   "Forwarded-Multi",
+		header: "host=first.invalid, host=second.invalid",
+		expect: apmhttputil.ForwardedHeader{
+			Host: "first.invalid",
+		},
+	}, {
+		name:   "Forwarded-Malformed-Fields-Ignored",
+		header: "what; nonsense=\"; host=first.invalid",
+		expect: apmhttputil.ForwardedHeader{
+			Host: "first.invalid",
+		},
+	}, {
+		name:   "Forwarded-Trailing-Separators",
+		header: "host=first.invalid;,",
+		expect: apmhttputil.ForwardedHeader{
+			Host: "first.invalid",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed := apmhttputil.ParseForwarded(test.header)
+			assert.Equal(t, test.expect, parsed)
+		})
+	}
+}

--- a/internal/apmhttputil/remoteaddr.go
+++ b/internal/apmhttputil/remoteaddr.go
@@ -1,0 +1,40 @@
+package apmhttputil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// RemoteAddr returns the remote address for the HTTP request.
+//
+// In order:
+//  - if the Forwarded header is set, then the first item in the
+//    list's "for" field is used, if it exists. The "for" value
+//    is returned even if it is an obfuscated identifier.
+//  - if the X-Real-Ip header is set, then its value is returned.
+//  - if the X-Forwarded-For header is set, then the first value
+//    in the comma-separated list is returned.
+//  - otherwise, the host portion of req.RemoteAddr is returned.
+func RemoteAddr(req *http.Request, forwarded *ForwardedHeader) string {
+	if forwarded != nil {
+		if forwarded.For != "" {
+			remoteAddr, _, err := net.SplitHostPort(forwarded.For)
+			if err != nil {
+				remoteAddr = forwarded.For
+			}
+			return remoteAddr
+		}
+	}
+	if realIP := req.Header.Get("X-Real-Ip"); realIP != "" {
+		return realIP
+	}
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		if sep := strings.IndexRune(xff, ','); sep > 0 {
+			xff = xff[:sep]
+		}
+		return strings.TrimSpace(xff)
+	}
+	remoteAddr, _ := splitHost(req.RemoteAddr)
+	return remoteAddr
+}

--- a/internal/apmhttputil/remoteaddr_test.go
+++ b/internal/apmhttputil/remoteaddr_test.go
@@ -1,0 +1,36 @@
+package apmhttputil_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go/internal/apmhttputil"
+)
+
+func TestRemoteAddr(t *testing.T) {
+	req := &http.Request{
+		RemoteAddr: "[::1]:1234",
+		Header:     make(http.Header),
+	}
+	assert.Equal(t, "::1", apmhttputil.RemoteAddr(req, nil))
+
+	req.Header.Set("X-Forwarded-For", "client.invalid")
+	assert.Equal(t, "client.invalid", apmhttputil.RemoteAddr(req, nil))
+
+	req.Header.Set("X-Forwarded-For", "client.invalid, proxy.invalid")
+	assert.Equal(t, "client.invalid", apmhttputil.RemoteAddr(req, nil))
+
+	req.Header.Set("X-Real-IP", "127.1.2.3")
+	assert.Equal(t, "127.1.2.3", apmhttputil.RemoteAddr(req, nil))
+
+	// "for" is missing from Forwarded, so fall back to the next thing
+	assert.Equal(t, "127.1.2.3", apmhttputil.RemoteAddr(req, &apmhttputil.ForwardedHeader{}))
+
+	assert.Equal(t, "_secret", apmhttputil.RemoteAddr(req, &apmhttputil.ForwardedHeader{For: "_secret"}))
+
+	assert.Equal(t, "2001:db8:cafe::17", apmhttputil.RemoteAddr(req, &apmhttputil.ForwardedHeader{
+		For: "[2001:db8:cafe::17]:4711",
+	}))
+}

--- a/internal/apmhttputil/url.go
+++ b/internal/apmhttputil/url.go
@@ -1,0 +1,81 @@
+package apmhttputil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/elastic/apm-agent-go/model"
+)
+
+// RequestURL returns a model.URL for req.
+//
+// If req contains an absolute URI, the values will be split and
+// sanitized, but no further processing performed. For all other
+// requests (i.e. most server-side requests), we reconstruct the
+// URL based on various proxy forwarding headers and other request
+// attributes.
+func RequestURL(req *http.Request, forwarded *ForwardedHeader) model.URL {
+	out := model.URL{
+		Path:   req.URL.Path,
+		Search: req.URL.RawQuery,
+		Hash:   req.URL.Fragment,
+	}
+	if req.URL.Host != "" {
+		// Absolute URI: client-side or proxy request, so ignore the
+		// headers.
+		out.Hostname, out.Port = splitHost(req.URL.Host)
+		out.Protocol = req.URL.Scheme
+		return out
+	}
+
+	// This is a server-side request URI, which contains only the path.
+	// We synthesize the full URL by extracting the host and protocol
+	// from headers, or inferring from other properties.
+	var fullHost string
+	if forwarded != nil && forwarded.Host != "" {
+		fullHost = forwarded.Host
+		out.Protocol = forwarded.Proto
+	} else if xfh := req.Header.Get("X-Forwarded-Host"); xfh != "" {
+		fullHost = xfh
+	} else {
+		fullHost = req.Host
+	}
+	out.Hostname, out.Port = splitHost(fullHost)
+
+	// Protocol might be extracted from the Forwarded header. If it's not,
+	// look for various other headers.
+	if out.Protocol == "" {
+		if proto := req.Header.Get("X-Forwarded-Proto"); proto != "" {
+			out.Protocol = proto
+		} else if proto := req.Header.Get("X-Forwarded-Protocol"); proto != "" {
+			out.Protocol = proto
+		} else if proto := req.Header.Get("X-Url-Scheme"); proto != "" {
+			out.Protocol = proto
+		} else if req.Header.Get("Front-End-Https") == "on" {
+			out.Protocol = "https"
+		} else if req.Header.Get("X-Forwarded-Ssl") == "on" {
+			out.Protocol = "https"
+		} else if req.TLS != nil {
+			out.Protocol = "https"
+		} else {
+			// Assume http otherwise.
+			out.Protocol = "http"
+		}
+	}
+	return out
+}
+
+func splitHost(in string) (host, port string) {
+	if strings.LastIndexByte(in, ':') == -1 {
+		// In the common (relative to other "errors") case that
+		// there is no colon, we can avoid allocations by not
+		// calling SplitHostPort.
+		return in, ""
+	}
+	host, port, err := net.SplitHostPort(in)
+	if err != nil {
+		return in, ""
+	}
+	return host, port
+}

--- a/internal/apmhttputil/url_test.go
+++ b/internal/apmhttputil/url_test.go
@@ -1,0 +1,118 @@
+package apmhttputil_test
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go/internal/apmhttputil"
+	"github.com/elastic/apm-agent-go/internal/fastjson"
+	"github.com/elastic/apm-agent-go/model"
+)
+
+func TestRequestURLClient(t *testing.T) {
+	req := mustNewRequest("https://user:pass@host.invalid:9443/path?query&querier=foo#fragment")
+	assert.Equal(t, model.URL{
+		Protocol: "https",
+		Hostname: "host.invalid",
+		Port:     "9443",
+		Path:     "/path",
+		Search:   "query&querier=foo",
+		Hash:     "fragment",
+	}, apmhttputil.RequestURL(req, nil))
+}
+
+func TestRequestURLServer(t *testing.T) {
+	req := mustNewRequest("/path?query&querier=foo")
+	req.Host = "host.invalid:8080"
+
+	assert.Equal(t, model.URL{
+		Protocol: "http",
+		Hostname: "host.invalid",
+		Port:     "8080",
+		Path:     "/path",
+		Search:   "query&querier=foo",
+	}, apmhttputil.RequestURL(req, nil))
+}
+
+func TestRequestURLServerTLS(t *testing.T) {
+	req := mustNewRequest("/path?query&querier=foo")
+	req.Host = "host.invalid:8080"
+	req.TLS = &tls.ConnectionState{}
+	assert.Equal(t, "https", apmhttputil.RequestURL(req, nil).Protocol)
+}
+
+func TestRequestURLHeaders(t *testing.T) {
+	type test struct {
+		name      string
+		full      string
+		header    http.Header
+		forwarded *apmhttputil.ForwardedHeader
+	}
+
+	tests := []test{{
+		name:      "Forwarded",
+		full:      "https://forwarded.invalid:443/",
+		forwarded: &apmhttputil.ForwardedHeader{Host: "forwarded.invalid:443", Proto: "HTTPS"},
+	}, {
+		name:      "Forwarded-Empty-Host",
+		full:      "http://host.invalid/", // falls back to the next option
+		forwarded: &apmhttputil.ForwardedHeader{Host: ""},
+	}, {
+		name:   "X-Forwarded-Host",
+		full:   "http://x-forwarded-host.invalid/",
+		header: http.Header{"X-Forwarded-Host": []string{"x-forwarded-host.invalid"}},
+	}, {
+		name:   "X-Forwarded-Proto",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Forwarded-Proto": []string{"https"}},
+	}, {
+		name:   "X-Forwarded-Protocol",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Forwarded-Protocol": []string{"https"}},
+	}, {
+		name:   "X-Url-Scheme",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Url-Scheme": []string{"https"}},
+	}, {
+		name:   "Front-End-Https",
+		full:   "https://host.invalid/",
+		header: http.Header{"Front-End-Https": []string{"on"}},
+	}, {
+		name:   "X-Forwarded-Ssl",
+		full:   "https://host.invalid/",
+		header: http.Header{"X-Forwarded-Ssl": []string{"on"}},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := mustNewRequest("/")
+			req.Host = "host.invalid"
+			req.Header = test.header
+
+			out := apmhttputil.RequestURL(req, test.forwarded)
+
+			// Marshal the URL to gets its "full" representation.
+			var w fastjson.Writer
+			out.MarshalFastJSON(&w)
+
+			var decoded struct {
+				Full string
+			}
+			err := json.Unmarshal(w.Bytes(), &decoded)
+			assert.NoError(t, err)
+			assert.Equal(t, test.full, decoded.Full)
+		})
+	}
+}
+
+func mustNewRequest(url string) *http.Request {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -144,7 +144,7 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) {
 	w.RawString(",\"name\":")
 	w.String(v.Name)
 	w.RawString(",\"timestamp\":")
-	w.String(v.Timestamp)
+	v.Timestamp.MarshalFastJSON(w)
 	w.RawString(",\"type\":")
 	w.String(v.Type)
 	if v.Context != nil {
@@ -159,7 +159,7 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) {
 		w.RawString(",\"sampled\":")
 		w.Bool(*v.Sampled)
 	}
-	if v.SpanCount != nil {
+	if !v.SpanCount.isZero() {
 		w.RawString(",\"span_count\":")
 		v.SpanCount.MarshalFastJSON(w)
 	}
@@ -179,7 +179,7 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) {
 
 func (v *SpanCount) MarshalFastJSON(w *fastjson.Writer) {
 	w.RawByte('{')
-	if v.Dropped != nil {
+	if !v.Dropped.isZero() {
 		w.RawString("\"dropped\":")
 		v.Dropped.MarshalFastJSON(w)
 	}
@@ -407,7 +407,7 @@ func (v *User) MarshalFastJSON(w *fastjson.Writer) {
 func (v *Error) MarshalFastJSON(w *fastjson.Writer) {
 	w.RawByte('{')
 	w.RawString("\"timestamp\":")
-	w.String(v.Timestamp)
+	v.Timestamp.MarshalFastJSON(w)
 	if v.Context != nil {
 		w.RawString(",\"context\":")
 		v.Context.MarshalFastJSON(w)
@@ -700,82 +700,6 @@ func (v *RequestSocket) MarshalFastJSON(w *fastjson.Writer) {
 			w.RawString(prefix)
 		}
 		w.String(v.RemoteAddress)
-	}
-	w.RawByte('}')
-}
-
-func (v *URL) MarshalFastJSON(w *fastjson.Writer) {
-	w.RawByte('{')
-	first := true
-	if v.Full != "" {
-		const prefix = ",\"full\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.String(v.Full)
-	}
-	if v.Hash != "" {
-		const prefix = ",\"hash\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.String(v.Hash)
-	}
-	if v.Hostname != "" {
-		const prefix = ",\"hostname\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.String(v.Hostname)
-	}
-	if v.Path != "" {
-		const prefix = ",\"pathname\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.String(v.Path)
-	}
-	if v.Port != "" {
-		const prefix = ",\"port\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.String(v.Port)
-	}
-	if v.Protocol != "" {
-		const prefix = ",\"protocol\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.String(v.Protocol)
-	}
-	if v.Search != "" {
-		const prefix = ",\"search\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.String(v.Search)
 	}
 	w.RawByte('}')
 }

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -171,7 +171,9 @@ func TestMarshalPayloads(t *testing.T) {
 
 func TestMarshalError(t *testing.T) {
 	var e model.Error
-	e.Timestamp = "1970-01-01T00:02:03Z"
+	time, err := time.Parse("2006-01-02T15:04:05.999Z", "1970-01-01T00:02:03Z")
+	assert.NoError(t, err)
+	e.Timestamp = model.Time(time)
 
 	var w fastjson.Writer
 	e.MarshalFastJSON(&w)
@@ -393,7 +395,7 @@ func fakeTransaction() *model.Transaction {
 		ID:        "d51ae41d-93da-4984-bba3-ae15e9b2247f",
 		Name:      "GET /foo/bar",
 		Type:      "request",
-		Timestamp: model.FormatTime(time.Unix(123, 0)),
+		Timestamp: model.Time(time.Unix(123, 0).UTC()),
 		Duration:  123.456,
 		Result:    "418",
 		Context: &model.Context{
@@ -443,8 +445,8 @@ func fakeTransaction() *model.Transaction {
 				"tag": "urit",
 			},
 		},
-		SpanCount: &model.SpanCount{
-			Dropped: &model.SpanCountDropped{
+		SpanCount: model.SpanCount{
+			Dropped: model.SpanCountDropped{
 				Total: 4,
 			},
 		},

--- a/model/model.go
+++ b/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // Service represents the service handling transactions being traced.
@@ -111,8 +112,7 @@ type Transaction struct {
 	Type string `json:"type"`
 
 	// Timestamp holds the time at which the transaction started.
-	// This should be in the format "YYYY-MM-DDTHH:mm:ss.sssZ".
-	Timestamp string `json:"timestamp"`
+	Timestamp Time `json:"timestamp"`
 
 	// Duration records how long the transaction took to complete,
 	// in milliseconds.
@@ -134,7 +134,7 @@ type Transaction struct {
 	Sampled *bool `json:"sampled,omitempty"`
 
 	// SpanCount holds statistics on spans within a transaction.
-	SpanCount *SpanCount `json:"span_count,omitempty"`
+	SpanCount SpanCount `json:"span_count,omitempty"`
 
 	// Spans holds the transaction's spans.
 	Spans []*Span `json:"spans,omitempty"`
@@ -143,7 +143,7 @@ type Transaction struct {
 // SpanCount holds statistics on spans within a transaction.
 type SpanCount struct {
 	// Dropped holds statistics on dropped spans within a transaction.
-	Dropped *SpanCountDropped `json:"dropped,omitempty"`
+	Dropped SpanCountDropped `json:"dropped,omitempty"`
 }
 
 // SpanCountDropped holds statistics on dropped spans.
@@ -245,8 +245,7 @@ type User struct {
 // Error represents an error occurring in the service.
 type Error struct {
 	// Timestamp holds the time at which the error occurred.
-	// This should be in the format "YYYY-MM-DDTHH:mm:ss.sssZ".
-	Timestamp string `json:"timestamp"`
+	Timestamp Time `json:"timestamp"`
 
 	// ID holds a hex-formatted UUID for the error.
 	ID string `json:"id,omitempty"`
@@ -480,3 +479,6 @@ type ResponseHeaders struct {
 	// ContentType holds the content-type header.
 	ContentType string `json:"content-type,omitempty"`
 }
+
+// Timestamp is a timestamp, which is formatted as "YYYY-MM-DDTHH:mm:ss.sssZ".
+type Time time.Time

--- a/tracer.go
+++ b/tracer.go
@@ -571,7 +571,7 @@ func (s *sender) sendErrors(ctx context.Context, errors []*Error) bool {
 		e.setStacktrace()
 		e.setCulprit()
 		e.model.ID = e.ID
-		e.model.Timestamp = model.FormatTime(e.Timestamp)
+		e.model.Timestamp = model.Time(e.Timestamp.UTC())
 		e.model.Context = e.Context
 		e.model.Exception.Handled = e.Handled
 		if s.processor != nil {

--- a/transaction.go
+++ b/transaction.go
@@ -61,10 +61,9 @@ type Transaction struct {
 	sampled  bool
 	maxSpans int
 
-	mu           sync.Mutex
-	tags         []tag
-	spans        []*Span
-	spansDropped int
+	mu    sync.Mutex
+	tags  []tag
+	spans []*Span
 }
 
 type tag struct {
@@ -143,7 +142,7 @@ func (tx *Transaction) Done(d time.Duration) {
 		d = time.Since(tx.Timestamp)
 	}
 	tx.Duration = d.Seconds() * 1000
-	tx.Transaction.Timestamp = model.FormatTime(tx.Timestamp)
+	tx.Transaction.Timestamp = model.Time(tx.Timestamp.UTC())
 
 	tx.mu.Lock()
 	spans := tx.spans[:len(tx.spans)]
@@ -154,13 +153,6 @@ func (tx *Transaction) Done(d time.Duration) {
 		for i, s := range spans {
 			s.truncate(d)
 			tx.Spans[i] = &s.Span
-		}
-	}
-	if tx.spansDropped > 0 {
-		tx.SpanCount = &model.SpanCount{
-			Dropped: &model.SpanCountDropped{
-				Total: tx.spansDropped,
-			},
 		}
 	}
 	if len(tags) > 0 {
@@ -220,7 +212,7 @@ func (tx *Transaction) StartSpan(name, transactionType string, parent *Span) *Sp
 	tx.mu.Lock()
 	if tx.maxSpans > 0 && len(tx.spans) >= tx.maxSpans {
 		span.dropped = true
-		tx.spansDropped++
+		tx.SpanCount.Dropped.Total++
 	} else {
 		if parent != nil {
 			span.Parent = parent.ID


### PR DESCRIPTION
- apmhttp: move some HTTP context functions to internal/apmhttputil
- apmhttp: change responseWriter to not cache the CloseNotify or Flush methods, as that allocates more memory.
- apmhttp: use strings.Builder (go1.10+) or copy instead of fmt.Sprintf when formatting HTTP transaction names
- apmhttputil: pre-canonicalize HTTP headers (X-Real-IP -> X-Real-Ip) to avoid repeated string copies
- {apmhttputil,model}: format the full URL in the MarshalFastJSON method, to avoid allocating a string only to be copied into the buffer later.
- {elasticapm,model}: store time.Time in model objects, format using AppendFormat
- {elasticapm,model}: make Transaction.SpanCount a non-pointer field using fastjson's omitempty "isZero" method support

There's more to come, but they are more invasive, and change how we construct transaction context.

benchcmp for contrib/apmhttp:
```
benchmark                                     old ns/op     new ns/op     delta
BenchmarkWithoutMiddleware//hello/world-4     608           560           -7.89%
BenchmarkWithoutMiddleware//sleep/1ms-4       1219645       1212475       -0.59%
BenchmarkWithMiddleware//hello/world-4        4471          3189          -28.67%
BenchmarkWithMiddleware//sleep/1ms-4          1197057       1214006       +1.42%

benchmark                                     old allocs     new allocs     delta
BenchmarkWithoutMiddleware//hello/world-4     3              3              +0.00%
BenchmarkWithoutMiddleware//sleep/1ms-4       0              0              +0.00%
BenchmarkWithMiddleware//hello/world-4        24             15             -37.50%
BenchmarkWithMiddleware//sleep/1ms-4          20             11             -45.00%

benchmark                                     old bytes     new bytes     delta
BenchmarkWithoutMiddleware//hello/world-4     74            74            +0.00%
BenchmarkWithoutMiddleware//sleep/1ms-4       0             0             +0.00%
BenchmarkWithMiddleware//hello/world-4        1308          976           -25.38%
BenchmarkWithMiddleware//sleep/1ms-4          1204          865           -28.16%
```