### PR TITLE
 elasticapm: introduce/use SpanContext

### DIFF
--- a/contrib/apmsql/apmsql_bench_test.go
+++ b/contrib/apmsql/apmsql_bench_test.go
@@ -1,0 +1,52 @@
+package apmsql_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmsql"
+	_ "github.com/elastic/apm-agent-go/contrib/apmsql/sqlite3"
+	"github.com/elastic/apm-agent-go/transport"
+)
+
+func BenchmarkStmtQueryContext(b *testing.B) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(b, err)
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE foo (bar INT)")
+	require.NoError(b, err)
+
+	stmt, err := db.Prepare("SELECT * FROM foo")
+	require.NoError(b, err)
+	defer stmt.Close()
+
+	b.Run("baseline", func(b *testing.B) {
+		benchmarkQueries(b, context.Background(), stmt)
+	})
+	b.Run("instrumented", func(b *testing.B) {
+		httpTransport, err := transport.NewHTTPTransport("http://testing.invalid:8200", "")
+		require.NoError(b, err)
+		tracer, err := elasticapm.NewTracer("apmhttp_test", "0.1")
+		require.NoError(b, err)
+		tracer.Transport = httpTransport
+		defer tracer.Close()
+
+		tx := tracer.StartTransaction("name", "type")
+		ctx := elasticapm.ContextWithTransaction(context.Background(), tx)
+		benchmarkQueries(b, ctx, stmt)
+	})
+}
+
+func benchmarkQueries(b *testing.B, ctx context.Context, stmt *sql.Stmt) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows, err := stmt.QueryContext(ctx)
+		require.NoError(b, err)
+		rows.Close()
+	}
+}

--- a/contrib/apmsql/apmsql_go110_test.go
+++ b/contrib/apmsql/apmsql_go110_test.go
@@ -1,0 +1,31 @@
+// +build go1.10
+
+package apmsql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go/contrib/apmsql"
+)
+
+func TestConnect(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Note: only in Go 1.10 do we have context during connection.
+
+	tx := withTransaction(t, func(ctx context.Context) {
+		err := db.PingContext(ctx)
+		assert.NoError(t, err)
+	})
+	require.Len(t, tx.Spans, 2)
+	assert.Equal(t, "connect", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.connect", tx.Spans[0].Type)
+	assert.Equal(t, "ping", tx.Spans[1].Name)
+	assert.Equal(t, "db.sqlite3.ping", tx.Spans[1].Type)
+}

--- a/contrib/apmsql/apmsql_test.go
+++ b/contrib/apmsql/apmsql_test.go
@@ -20,15 +20,14 @@ func TestPingContext(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
+	db.Ping() // connect
 	tx := withTransaction(t, func(ctx context.Context) {
 		err := db.PingContext(ctx)
 		assert.NoError(t, err)
 	})
-	require.Len(t, tx.Spans, 2)
-	assert.Equal(t, "connect", tx.Spans[0].Name)
-	assert.Equal(t, "db.sqlite3.connect", tx.Spans[0].Type)
-	assert.Equal(t, "ping", tx.Spans[1].Name)
-	assert.Equal(t, "db.sqlite3.ping", tx.Spans[1].Type)
+	require.Len(t, tx.Spans, 1)
+	assert.Equal(t, "ping", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.ping", tx.Spans[0].Type)
 }
 
 func TestExecContext(t *testing.T) {
@@ -36,13 +35,14 @@ func TestExecContext(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
+	db.Ping() // connect
 	tx := withTransaction(t, func(ctx context.Context) {
 		_, err := db.ExecContext(ctx, "CREATE TABLE foo (bar INT)")
 		require.NoError(t, err)
 	})
-	require.Len(t, tx.Spans, 2)
-	assert.Equal(t, "CREATE", tx.Spans[1].Name)
-	assert.Equal(t, "db.sqlite3.exec", tx.Spans[1].Type)
+	require.Len(t, tx.Spans, 1)
+	assert.Equal(t, "CREATE", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.exec", tx.Spans[0].Type)
 }
 
 func TestQueryContext(t *testing.T) {
@@ -77,6 +77,7 @@ func TestPrepareContext(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
+	db.Ping() // connect
 	tx := withTransaction(t, func(ctx context.Context) {
 		stmt, err := db.PrepareContext(ctx, "CREATE TABLE foo (bar INT)")
 		require.NoError(t, err)
@@ -84,9 +85,9 @@ func TestPrepareContext(t *testing.T) {
 		_, err = stmt.Exec()
 		require.NoError(t, err)
 	})
-	require.Len(t, tx.Spans, 2)
-	assert.Equal(t, "CREATE", tx.Spans[1].Name)
-	assert.Equal(t, "db.sqlite3.prepare", tx.Spans[1].Type)
+	require.Len(t, tx.Spans, 1)
+	assert.Equal(t, "CREATE", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.prepare", tx.Spans[0].Type)
 }
 
 func TestStmtExecContext(t *testing.T) {

--- a/contrib/apmsql/apmsql_test.go
+++ b/contrib/apmsql/apmsql_test.go
@@ -1,0 +1,150 @@
+package apmsql_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/contrib/apmsql"
+	_ "github.com/elastic/apm-agent-go/contrib/apmsql/sqlite3"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestPingContext(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx := withTransaction(t, func(ctx context.Context) {
+		err := db.PingContext(ctx)
+		assert.NoError(t, err)
+	})
+	require.Len(t, tx.Spans, 2)
+	assert.Equal(t, "connect", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.connect", tx.Spans[0].Type)
+	assert.Equal(t, "ping", tx.Spans[1].Name)
+	assert.Equal(t, "db.sqlite3.ping", tx.Spans[1].Type)
+}
+
+func TestExecContext(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx := withTransaction(t, func(ctx context.Context) {
+		_, err := db.ExecContext(ctx, "CREATE TABLE foo (bar INT)")
+		require.NoError(t, err)
+	})
+	require.Len(t, tx.Spans, 2)
+	assert.Equal(t, "CREATE", tx.Spans[1].Name)
+	assert.Equal(t, "db.sqlite3.exec", tx.Spans[1].Type)
+}
+
+func TestQueryContext(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE foo (bar INT)")
+	require.NoError(t, err)
+
+	tx := withTransaction(t, func(ctx context.Context) {
+		rows, err := db.QueryContext(ctx, "SELECT * FROM foo")
+		require.NoError(t, err)
+		rows.Close()
+	})
+	require.Len(t, tx.Spans, 1)
+
+	assert.NotNil(t, tx.Spans[0].ID)
+	assert.Equal(t, "SELECT", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.query", tx.Spans[0].Type)
+	assert.Equal(t, &model.SpanContext{
+		Database: &model.DatabaseSpanContext{
+			Instance:  ":memory:",
+			Statement: "SELECT * FROM foo",
+			Type:      "sql",
+		},
+	}, tx.Spans[0].Context)
+}
+
+func TestPrepareContext(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx := withTransaction(t, func(ctx context.Context) {
+		stmt, err := db.PrepareContext(ctx, "CREATE TABLE foo (bar INT)")
+		require.NoError(t, err)
+		defer stmt.Close()
+		_, err = stmt.Exec()
+		require.NoError(t, err)
+	})
+	require.Len(t, tx.Spans, 2)
+	assert.Equal(t, "CREATE", tx.Spans[1].Name)
+	assert.Equal(t, "db.sqlite3.prepare", tx.Spans[1].Type)
+}
+
+func TestStmtExecContext(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE foo (bar INT)")
+	require.NoError(t, err)
+
+	stmt, err := db.Prepare("DELETE FROM foo WHERE bar < :ceil")
+	require.NoError(t, err)
+	defer stmt.Close()
+
+	tx := withTransaction(t, func(ctx context.Context) {
+		_, err = stmt.ExecContext(ctx, sql.Named("ceil", 999))
+		require.NoError(t, err)
+	})
+	require.Len(t, tx.Spans, 1)
+	assert.Equal(t, "DELETE", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.exec", tx.Spans[0].Type)
+}
+
+func TestStmtQueryContext(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE foo (bar INT)")
+	require.NoError(t, err)
+
+	stmt, err := db.Prepare("SELECT * FROM foo")
+	require.NoError(t, err)
+	defer stmt.Close()
+
+	tx := withTransaction(t, func(ctx context.Context) {
+		rows, err := stmt.QueryContext(ctx)
+		require.NoError(t, err)
+		rows.Close()
+	})
+	require.Len(t, tx.Spans, 1)
+	assert.Equal(t, "SELECT", tx.Spans[0].Name)
+	assert.Equal(t, "db.sqlite3.query", tx.Spans[0].Type)
+}
+
+func withTransaction(t *testing.T, f func(ctx context.Context)) *model.Transaction {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	tx := tracer.StartTransaction("name", "type")
+	ctx := elasticapm.ContextWithTransaction(context.Background(), tx)
+	f(ctx)
+
+	tx.Done(-1)
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	require.Len(t, payloads, 1)
+	transactions := payloads[0].Transactions()
+	require.Len(t, transactions, 1)
+	return transactions[0]
+}

--- a/contrib/apmsql/conn.go
+++ b/contrib/apmsql/conn.go
@@ -81,7 +81,7 @@ func (c *conn) Ping(ctx context.Context) (resultError error) {
 	if c.pinger == nil {
 		return nil
 	}
-	span, ctx := elasticapm.StartSpan(ctx, "ping", c.driver.spanType("ping"))
+	span, ctx := elasticapm.StartSpan(ctx, "ping", c.driver.pingSpanType)
 	if span != nil {
 		defer c.finishSpan(ctx, span, "", resultError)
 	}
@@ -92,7 +92,7 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 	if c.queryerContext == nil && c.queryer == nil {
 		return nil, driver.ErrSkip
 	}
-	span, ctx := elasticapm.StartSpan(ctx, "", c.driver.spanType("query"))
+	span, ctx := elasticapm.StartSpan(ctx, "", c.driver.querySpanType)
 	if span != nil {
 		defer c.finishSpan(ctx, span, query, resultError)
 	}
@@ -117,7 +117,7 @@ func (*conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 }
 
 func (c *conn) PrepareContext(ctx context.Context, query string) (_ driver.Stmt, resultError error) {
-	span, ctx := elasticapm.StartSpan(ctx, "", c.driver.spanType("prepare"))
+	span, ctx := elasticapm.StartSpan(ctx, "", c.driver.prepareSpanType)
 	if span != nil {
 		defer c.finishSpan(ctx, span, query, resultError)
 	}
@@ -146,7 +146,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 	if c.execerContext == nil && c.execer == nil {
 		return nil, driver.ErrSkip
 	}
-	span, ctx := elasticapm.StartSpan(ctx, "", c.driver.spanType("exec"))
+	span, ctx := elasticapm.StartSpan(ctx, "", c.driver.execSpanType)
 	if span != nil {
 		defer c.finishSpan(ctx, span, query, resultError)
 	}

--- a/contrib/apmsql/driver.go
+++ b/contrib/apmsql/driver.go
@@ -3,7 +3,6 @@ package apmsql
 import (
 	"database/sql"
 	"database/sql/driver"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -111,7 +110,11 @@ func (d *tracingDriver) querySignature(query string) string {
 }
 
 func (d *tracingDriver) Open(name string) (driver.Conn, error) {
-	return nil, errors.New("Open should not be called")
+	conn, err := d.Driver.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(conn, d, name), nil
 }
 
 func driverName(d driver.Driver) string {

--- a/contrib/apmsql/driver.go
+++ b/contrib/apmsql/driver.go
@@ -49,6 +49,12 @@ func Wrap(driver driver.Driver, opts ...WrapOption) driver.Driver {
 	if d.dsnParser == nil {
 		d.dsnParser = dsnParser(d.driverName)
 	}
+	// store span types to avoid repeat allocations
+	d.connectSpanType = d.formatSpanType("connect")
+	d.pingSpanType = d.formatSpanType("ping")
+	d.prepareSpanType = d.formatSpanType("prepare")
+	d.querySpanType = d.formatSpanType("query")
+	d.execSpanType = d.formatSpanType("exec")
 	return d
 }
 
@@ -79,9 +85,15 @@ type tracingDriver struct {
 	driver.Driver
 	driverName string
 	dsnParser  dsn.ParserFunc
+
+	connectSpanType string
+	execSpanType    string
+	pingSpanType    string
+	prepareSpanType string
+	querySpanType   string
 }
 
-func (d *tracingDriver) spanType(suffix string) string {
+func (d *tracingDriver) formatSpanType(suffix string) string {
 	return fmt.Sprintf("db.%s.%s", d.driverName, suffix)
 }
 

--- a/contrib/apmsql/driver_go110.go
+++ b/contrib/apmsql/driver_go110.go
@@ -30,7 +30,7 @@ type driverConnector struct {
 }
 
 func (d *driverConnector) Connect(ctx context.Context) (driver.Conn, error) {
-	span, ctx := elasticapm.StartSpan(ctx, "connect", d.driver.spanType("connect"))
+	span, ctx := elasticapm.StartSpan(ctx, "connect", d.driver.connectSpanType)
 	if span != nil {
 		defer span.Done(-1)
 	}

--- a/contrib/apmsql/stmt.go
+++ b/contrib/apmsql/stmt.go
@@ -5,15 +5,14 @@ import (
 	"database/sql/driver"
 
 	"github.com/elastic/apm-agent-go"
-	"github.com/elastic/apm-agent-go/model"
 )
 
 func newStmt(in driver.Stmt, conn *conn, query string) driver.Stmt {
 	stmt := &stmt{
-		Stmt:        in,
-		conn:        conn,
-		signature:   conn.driver.querySignature(query),
-		spanContext: conn.spanContext(query),
+		Stmt:      in,
+		conn:      conn,
+		signature: conn.driver.querySignature(query),
+		query:     query,
 	}
 	stmt.columnConverter, _ = in.(driver.ColumnConverter)
 	stmt.stmtExecContext, _ = in.(driver.StmtExecContext)
@@ -25,18 +24,17 @@ func newStmt(in driver.Stmt, conn *conn, query string) driver.Stmt {
 type stmt struct {
 	driver.Stmt
 	stmtGo19
-	conn        *conn
-	signature   string
-	spanContext *model.SpanContext
+	conn      *conn
+	signature string
+	query     string
 
 	columnConverter  driver.ColumnConverter
 	stmtExecContext  driver.StmtExecContext
 	stmtQueryContext driver.StmtQueryContext
 }
 
-func (s *stmt) finishSpan(ctx context.Context, span *elasticapm.Span, resultError error) {
-	span.Context = s.spanContext
-	s.conn.finishSpan(ctx, span, "", resultError)
+func (s *stmt) startSpan(ctx context.Context, spanType string) (*elasticapm.Span, context.Context) {
+	return s.conn.startSpan(ctx, s.signature, spanType, s.query)
 }
 
 func (s *stmt) ColumnConverter(idx int) driver.ValueConverter {
@@ -47,9 +45,9 @@ func (s *stmt) ColumnConverter(idx int) driver.ValueConverter {
 }
 
 func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (_ driver.Result, resultError error) {
-	span, ctx := elasticapm.StartSpan(ctx, s.signature, s.conn.driver.execSpanType)
+	span, ctx := s.startSpan(ctx, s.conn.driver.execSpanType)
 	if span != nil {
-		defer s.finishSpan(ctx, span, resultError)
+		defer s.conn.finishSpan(ctx, span, resultError)
 	}
 	if s.stmtExecContext != nil {
 		return s.stmtExecContext.ExecContext(ctx, args)
@@ -67,9 +65,9 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (_ dri
 }
 
 func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (_ driver.Rows, resultError error) {
-	span, ctx := elasticapm.StartSpan(ctx, s.signature, s.conn.driver.querySpanType)
+	span, ctx := s.startSpan(ctx, s.conn.driver.querySpanType)
 	if span != nil {
-		defer s.finishSpan(ctx, span, resultError)
+		defer s.conn.finishSpan(ctx, span, resultError)
 	}
 	if s.stmtQueryContext != nil {
 		return s.stmtQueryContext.QueryContext(ctx, args)

--- a/contrib/apmsql/stmt.go
+++ b/contrib/apmsql/stmt.go
@@ -47,7 +47,7 @@ func (s *stmt) ColumnConverter(idx int) driver.ValueConverter {
 }
 
 func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (_ driver.Result, resultError error) {
-	span, ctx := elasticapm.StartSpan(ctx, s.signature, s.conn.driver.spanType("exec"))
+	span, ctx := elasticapm.StartSpan(ctx, s.signature, s.conn.driver.execSpanType)
 	if span != nil {
 		defer s.finishSpan(ctx, span, resultError)
 	}
@@ -67,7 +67,7 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (_ dri
 }
 
 func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (_ driver.Rows, resultError error) {
-	span, ctx := elasticapm.StartSpan(ctx, s.signature, s.conn.driver.spanType("query"))
+	span, ctx := elasticapm.StartSpan(ctx, s.signature, s.conn.driver.querySpanType)
 	if span != nil {
 		defer s.finishSpan(ctx, span, resultError)
 	}

--- a/spancontext.go
+++ b/spancontext.go
@@ -1,0 +1,46 @@
+package elasticapm
+
+import (
+	"github.com/elastic/apm-agent-go/model"
+)
+
+// SpanContext provides methods for setting span context.
+type SpanContext struct {
+	model    model.SpanContext
+	database model.DatabaseSpanContext
+}
+
+// DatabaseSpanContext holds database span context.
+type DatabaseSpanContext struct {
+	// Instance holds the database instance name.
+	Instance string
+
+	// Statement holds the statement executed in the span,
+	// e.g. "SELECT * FROM foo".
+	Statement string
+
+	// Type holds the database type, e.g. "sql".
+	Type string
+
+	// User holds the username used for database access.
+	User string
+}
+
+func (c *SpanContext) build() *model.SpanContext {
+	switch {
+	case c.model.Database != nil:
+	default:
+		return nil
+	}
+	return &c.model
+}
+
+func (c *SpanContext) reset() {
+	*c = SpanContext{}
+}
+
+// SetDatabase sets the span context for database-related operations.
+func (c *SpanContext) SetDatabase(db DatabaseSpanContext) {
+	c.database = model.DatabaseSpanContext(db)
+	c.model.Database = &c.database
+}


### PR DESCRIPTION
Add a SpanContext type, embedded in Spans, and unexpose the model.Span field of Span.

Also, add some basic tests for contrib/apmsql.

Partially addresses #46