### PR TITLE
elasticapm: validate/sanitize service name

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -61,7 +61,7 @@ func TestInternalStackTrace(t *testing.T) {
 
 func sendError(t *testing.T, err error, f ...func(*elasticapm.Error)) *model.Error {
 	var r transporttest.RecorderTransport
-	tracer, newTracerErr := elasticapm.NewTracer("tracer.testing", "")
+	tracer, newTracerErr := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, newTracerErr)
 	defer tracer.Close()
 

--- a/tracer.go
+++ b/tracer.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/stacktrace"
 	"github.com/elastic/apm-agent-go/transport"
@@ -144,17 +142,15 @@ type Tracer struct {
 // or taking the service name and version from the environment
 // if unspecified.
 //
-// If service is nil, then the service will be defined using the
-// ELASTIC_APM_* environment variables.
+// If serviceName is empty, then the service name will be defined
+// using the ELASTIC_APM_SERVER_NAME environment variable.
 func NewTracer(serviceName, serviceVersion string) (*Tracer, error) {
 	service := &envService
 	if serviceName != "" {
+		if err := validateServiceName(serviceName); err != nil {
+			return nil, err
+		}
 		service = newService(serviceName, serviceVersion)
-	} else if service == nil {
-		return nil, errors.Errorf(
-			"no service name specified, and %s not specified",
-			envServiceName,
-		)
 	}
 	var opts options
 	if err := opts.init(false); err != nil {

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestTracerStats(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = transporttest.Discard
@@ -30,7 +30,7 @@ func TestTracerStats(t *testing.T) {
 }
 
 func TestTracerClosedSendNonblocking(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	tracer.Close()
 
@@ -41,7 +41,7 @@ func TestTracerClosedSendNonblocking(t *testing.T) {
 }
 
 func TestTracerFlushInterval(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = transporttest.Discard
@@ -59,7 +59,7 @@ func TestTracerFlushInterval(t *testing.T) {
 }
 
 func TestTracerMaxQueueSize(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 
@@ -84,7 +84,7 @@ func TestTracerMaxQueueSize(t *testing.T) {
 }
 
 func TestTracerRetryTimer(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 
@@ -123,7 +123,7 @@ func TestTracerRetryTimer(t *testing.T) {
 }
 
 func TestTracerRetryTimerFlush(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	interval := time.Second
@@ -163,7 +163,7 @@ func TestTracerRetryTimerFlush(t *testing.T) {
 
 func TestTracerMaxSpans(t *testing.T) {
 	var r transporttest.RecorderTransport
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = &r
@@ -194,7 +194,7 @@ func TestTracerMaxSpans(t *testing.T) {
 
 func TestTracerErrors(t *testing.T) {
 	var r transporttest.RecorderTransport
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = &r
@@ -216,7 +216,7 @@ func TestTracerErrors(t *testing.T) {
 }
 
 func TestTracerErrorsBuffered(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	errors := make(chan transporttest.SendErrorsRequest)
@@ -268,7 +268,7 @@ func TestTracerErrorsBuffered(t *testing.T) {
 }
 
 func TestTracerProcessor(t *testing.T) {
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = transporttest.Discard
@@ -308,7 +308,7 @@ func TestTracerProcessor(t *testing.T) {
 
 func TestTracerRecover(t *testing.T) {
 	var r transporttest.RecorderTransport
-	tracer, err := elasticapm.NewTracer("tracer.testing", "")
+	tracer, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.NoError(t, err)
 	defer tracer.Close()
 	tracer.Transport = &r
@@ -331,14 +331,7 @@ func capturePanic(tracer *elasticapm.Tracer, v interface{}) {
 	panic(v)
 }
 
-type testLogger struct {
-	t *testing.T
-}
-
-func (l testLogger) Debugf(format string, args ...interface{}) {
-	l.t.Logf("[DEBUG] "+format, args...)
-}
-
-func (l testLogger) Errorf(format string, args ...interface{}) {
-	l.t.Logf("[ERROR] "+format, args...)
+func TestTracerServiceNameValidation(t *testing.T) {
+	_, err := elasticapm.NewTracer("wot!", "")
+	assert.EqualError(t, err, `invalid service name "wot!": character '!' is not in the allowed set (a-zA-Z0-9 _-)`)
 }

--- a/utils.go
+++ b/utils.go
@@ -71,6 +71,9 @@ func getEnvironmentService() model.Service {
 	name := os.Getenv(envServiceName)
 	if name == "" {
 		name = filepath.Base(os.Args[0])
+		if runtime.GOOS == "windows" {
+			name = strings.TrimSuffix(name, filepath.Ext(name))
+		}
 	}
 	svc := newService(sanitizeServiceName(name), "")
 	return *svc


### PR DESCRIPTION
When specifying the service name via environment
variable, it is now sanitized; invalid characters
are replaced with '_'. When creating a tracer
with NewTracer with an explicitly specified
service name, that service name must be valid,
or an error will be returned. Otherwise, the
sanitized executable name will be used as the
service name.

Closes #32 