### PR TITLE
Add vet and golint to prechecks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
 before_install:
   - go get -v golang.org/x/tools/cmd/goimports
+  - go get -v golang.org/x/lint/golint
 
 script:
   - make install precheck coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,19 @@
 check: precheck test
 
 .PHONY: precheck
-precheck: check-goimports
+precheck: check-goimports check-lint check-vet
 
 .PHONY: check-goimports
 check-goimports:
 	sh scripts/check_goimports.sh
+
+.PHONY: check-lint
+check-lint:
+	golint -set_exit_status ./...
+
+.PHONY: check-vet
+check-vet:
+	go vet ./...
 
 .PHONY: install
 install:

--- a/context.go
+++ b/context.go
@@ -137,7 +137,7 @@ func (b *Context) SetHTTPRequest(req *http.Request) {
 	}
 }
 
-// SetHTTPResponse sets the HTTP response headers in the context.
+// SetHTTPResponseHeaders sets the HTTP response headers in the context.
 func (b *Context) SetHTTPResponseHeaders(h http.Header) {
 	b.responseHeaders.ContentType = h.Get("Content-Type")
 	if b.responseHeaders.ContentType != "" {
@@ -146,7 +146,7 @@ func (b *Context) SetHTTPResponseHeaders(h http.Header) {
 	}
 }
 
-// SetResponseResponseHeadersSent records whether or not response were sent.
+// SetHTTPResponseHeadersSent records whether or not response were sent.
 func (b *Context) SetHTTPResponseHeadersSent(headersSent bool) {
 	b.response.HeadersSent = &headersSent
 	b.model.Response = &b.response

--- a/model/model.go
+++ b/model/model.go
@@ -480,5 +480,5 @@ type ResponseHeaders struct {
 	ContentType string `json:"content-type,omitempty"`
 }
 
-// Timestamp is a timestamp, which is formatted as "YYYY-MM-DDTHH:mm:ss.sssZ".
+// Time is a timestamp, formatted as "YYYY-MM-DDTHH:mm:ss.sssZ".
 type Time time.Time


### PR DESCRIPTION
Add "go vet" and "golint" to the precheck make target. See https://github.com/elastic/apm-agent-go/pull/60.