### PR TITLE
Capture HTTP bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ ELASTIC\_APM\_SERVICE\_NAME             |           | Service name, e.g. "my-ser
 ELASTIC\_APM\_SERVICE\_VERSION          |           | Service version, e.g. "1.0".
 ELASTIC\_APM\_HOSTNAME                  |           | Override for the hostname.
 ELASTIC\_APM\_SANITIZE\_FIELD\_NAMES    |[(1)](#(1))| A pattern to match names of cookies and form fields that should be redacted.
+ELASTIC\_APM\_CAPTURE\_BODY             | off       | Capture HTTP request bodies. Possible values: errors, transactions, all, off.
 
 <a name="(1)">(1)</a> ELASTIC\_APM\_SANITIZE\_FIELD\_NAMES
 

--- a/capturebody.go
+++ b/capturebody.go
@@ -1,0 +1,103 @@
+package elasticapm
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/elastic/apm-agent-go/model"
+)
+
+// CaptureBodyMode holds a value indicating how a tracer should capture
+// HTTP request bodies: for transactions, for errors, for both, or neither.
+type CaptureBodyMode int
+
+const (
+	// CaptureBodyOff disables capturing of HTTP request bodies. This is
+	// the default mode.
+	CaptureBodyOff CaptureBodyMode = 0
+
+	// CaptureBodyErrors captures HTTP request bodies for only errors.
+	CaptureBodyErrors CaptureBodyMode = 1
+
+	// CaptureBodyTransactions captures HTTP request bodies for only
+	// transactions.
+	CaptureBodyTransactions CaptureBodyMode = 1 << 1
+
+	// CaptureBodyAll captures HTTP request bodies for both transactions
+	// and errors.
+	CaptureBodyAll CaptureBodyMode = CaptureBodyErrors | CaptureBodyTransactions
+)
+
+// CaptureHTTPRequestBody replaces req.Body and returns a possibly nil
+// BodyCapturer which can later be passed to Context.SetHTTPRequestBody
+// for setting the request body in a transaction or error context. If the
+// tracer is not configured to capture HTTP request bodies, then req.Body
+// is left alone and nil is returned.
+//
+// This must be called before the request body is read.
+func (t *Tracer) CaptureHTTPRequestBody(req *http.Request) *BodyCapturer {
+	if req.Body == nil {
+		return nil
+	}
+	t.captureBodyMu.RLock()
+	captureBody := t.captureBody
+	t.captureBodyMu.RUnlock()
+	if captureBody == CaptureBodyOff {
+		return nil
+	}
+
+	type readerCloser struct {
+		io.Reader
+		io.Closer
+	}
+	bc := BodyCapturer{
+		captureBody:  captureBody,
+		request:      req,
+		originalBody: req.Body,
+	}
+	req.Body = &readerCloser{
+		Reader: io.TeeReader(req.Body, &bc.buffer),
+		Closer: req.Body,
+	}
+	return &bc
+}
+
+// BodyCapturer is returned by Tracer.CaptureHTTPRequestBody to later be
+// passed to Context.SetHTTPRequestBody.
+type BodyCapturer struct {
+	captureBody  CaptureBodyMode
+	originalBody io.ReadCloser
+	buffer       bytes.Buffer
+	request      *http.Request
+}
+
+func (bc *BodyCapturer) setContext(out *model.RequestBody) bool {
+	if bc.request.PostForm != nil {
+		// We must copy the map in case we need to
+		// sanitize the values. Ideally we should only
+		// copy if sanitization is necessary, but body
+		// capture shouldn't typically be enabled so
+		// we don't currently optimize this.
+		postForm := make(url.Values, len(bc.request.PostForm))
+		for k, v := range bc.request.PostForm {
+			vcopy := make([]string, len(v))
+			copy(vcopy, v)
+			postForm[k] = vcopy
+		}
+		out.Form = postForm
+		return true
+	}
+
+	// Read from the buffer and anything remaining in the body.
+	r := io.MultiReader(bytes.NewReader(bc.buffer.Bytes()), bc.originalBody)
+	all, err := ioutil.ReadAll(r)
+	if err != nil {
+		// TODO(axw) log error?
+		return false
+	}
+	out.Raw = string(all)
+	return true
+}

--- a/context.go
+++ b/context.go
@@ -13,33 +13,36 @@ import (
 type Context struct {
 	model           model.Context
 	request         model.Request
+	requestBody     model.RequestBody
 	requestHeaders  model.RequestHeaders
 	requestSocket   model.RequestSocket
 	response        model.Response
 	responseHeaders model.ResponseHeaders
 	user            model.User
+	captureBodyMask CaptureBodyMode
 }
 
-func (b *Context) build() *model.Context {
+func (c *Context) build() *model.Context {
 	switch {
-	case b.model.Request != nil:
-	case b.model.Response != nil:
-	case b.model.User != nil:
-	case len(b.model.Custom) != 0:
-	case len(b.model.Tags) != 0:
+	case c.model.Request != nil:
+	case c.model.Response != nil:
+	case c.model.User != nil:
+	case len(c.model.Custom) != 0:
+	case len(c.model.Tags) != 0:
 	default:
 		return nil
 	}
-	return &b.model
+	return &c.model
 }
 
-func (b *Context) reset() {
+func (c *Context) reset() {
 	modelContext := model.Context{
 		// TODO(axw) reuse space for tags
-		Custom: b.model.Custom[:0],
+		Custom: c.model.Custom[:0],
 	}
-	*b = Context{
-		model: modelContext,
+	*c = Context{
+		model:           modelContext,
+		captureBodyMask: c.captureBodyMask,
 	}
 }
 
@@ -51,23 +54,23 @@ func (b *Context) reset() {
 // used to encode the value. Otherwise, value will be encoded using
 // json.Marshal. As a special case, values of type map[string]interface{}
 // will be traversed and values encoded according to the same rules.
-func (b *Context) SetCustom(key string, value interface{}) {
+func (c *Context) SetCustom(key string, value interface{}) {
 	if !validTagKey(key) {
 		return
 	}
-	b.model.Custom.Set(key, value)
+	c.model.Custom.Set(key, value)
 }
 
 // SetTag sets a tag in the context. If the key is invalid
 // (contains '.', '*', or '"'), the call is a no-op.
-func (b *Context) SetTag(key, value string) {
+func (c *Context) SetTag(key, value string) {
 	if !validTagKey(key) {
 		return
 	}
-	if b.model.Tags == nil {
-		b.model.Tags = map[string]string{key: value}
+	if c.model.Tags == nil {
+		c.model.Tags = map[string]string{key: value}
 	} else {
-		b.model.Tags[key] = value
+		c.model.Tags[key] = value
 	}
 }
 
@@ -85,7 +88,7 @@ func (b *Context) SetTag(key, value string) {
 // from that will be recorded in the context. Otherwise, if the
 // request contains user info in the URL (i.e. a client-side URL),
 // that will be used.
-func (b *Context) SetHTTPRequest(req *http.Request) {
+func (c *Context) SetHTTPRequest(req *http.Request) {
 	// Special cases to avoid calling into fmt.Sprintf in most cases.
 	var httpVersion string
 	switch {
@@ -102,64 +105,76 @@ func (b *Context) SetHTTPRequest(req *http.Request) {
 		parsed := apmhttputil.ParseForwarded(fwd)
 		forwarded = &parsed
 	}
-	b.request = model.Request{
+	c.request = model.Request{
+		Body:        c.request.Body,
 		URL:         apmhttputil.RequestURL(req, forwarded),
 		Method:      req.Method,
 		HTTPVersion: httpVersion,
 		Cookies:     req.Cookies(),
 	}
-	b.model.Request = &b.request
+	c.model.Request = &c.request
 
-	b.requestHeaders = model.RequestHeaders{
+	c.requestHeaders = model.RequestHeaders{
 		ContentType: req.Header.Get("Content-Type"),
 		Cookie:      strings.Join(req.Header["Cookie"], ";"),
 		UserAgent:   req.UserAgent(),
 	}
-	if b.requestHeaders != (model.RequestHeaders{}) {
-		b.request.Headers = &b.requestHeaders
+	if c.requestHeaders != (model.RequestHeaders{}) {
+		c.request.Headers = &c.requestHeaders
 	}
 
-	b.requestSocket = model.RequestSocket{
+	c.requestSocket = model.RequestSocket{
 		Encrypted:     req.TLS != nil,
 		RemoteAddress: apmhttputil.RemoteAddr(req, forwarded),
 	}
-	if b.requestSocket != (model.RequestSocket{}) {
-		b.request.Socket = &b.requestSocket
+	if c.requestSocket != (model.RequestSocket{}) {
+		c.request.Socket = &c.requestSocket
 	}
 
 	username, _, ok := req.BasicAuth()
 	if !ok && req.URL.User != nil {
 		username = req.URL.User.Username()
 	}
-	b.user.Username = username
-	if b.user.Username != "" {
-		b.model.User = &b.user
+	c.user.Username = username
+	if c.user.Username != "" {
+		c.model.User = &c.user
+	}
+}
+
+// SetHTTPRequestBody sets the request body in context given a (possibly nil)
+// BodyCapturer returned by Tracer.CaptureHTTPRequestBody.
+func (c *Context) SetHTTPRequestBody(bc *BodyCapturer) {
+	if bc == nil || bc.captureBody&c.captureBodyMask == 0 {
+		return
+	}
+	if bc.setContext(&c.requestBody) {
+		c.request.Body = &c.requestBody
 	}
 }
 
 // SetHTTPResponseHeaders sets the HTTP response headers in the context.
-func (b *Context) SetHTTPResponseHeaders(h http.Header) {
-	b.responseHeaders.ContentType = h.Get("Content-Type")
-	if b.responseHeaders.ContentType != "" {
-		b.response.Headers = &b.responseHeaders
-		b.model.Response = &b.response
+func (c *Context) SetHTTPResponseHeaders(h http.Header) {
+	c.responseHeaders.ContentType = h.Get("Content-Type")
+	if c.responseHeaders.ContentType != "" {
+		c.response.Headers = &c.responseHeaders
+		c.model.Response = &c.response
 	}
 }
 
 // SetHTTPResponseHeadersSent records whether or not response were sent.
-func (b *Context) SetHTTPResponseHeadersSent(headersSent bool) {
-	b.response.HeadersSent = &headersSent
-	b.model.Response = &b.response
+func (c *Context) SetHTTPResponseHeadersSent(headersSent bool) {
+	c.response.HeadersSent = &headersSent
+	c.model.Response = &c.response
 }
 
 // SetHTTPResponseFinished records whether or not the response was finished.
-func (b *Context) SetHTTPResponseFinished(finished bool) {
-	b.response.Finished = &finished
-	b.model.Response = &b.response
+func (c *Context) SetHTTPResponseFinished(finished bool) {
+	c.response.Finished = &finished
+	c.model.Response = &c.response
 }
 
 // SetHTTPStatusCode records the HTTP response status code.
-func (b *Context) SetHTTPStatusCode(statusCode int) {
-	b.response.StatusCode = statusCode
-	b.model.Response = &b.response
+func (c *Context) SetHTTPStatusCode(statusCode int) {
+	c.response.StatusCode = statusCode
+	c.model.Response = &c.response
 }

--- a/contrib/apmecho/middleware_test.go
+++ b/contrib/apmecho/middleware_test.go
@@ -33,7 +33,7 @@ func TestEchoMiddleware(t *testing.T) {
 
 	assert.Equal(t, "GET /hello/:name", transaction.Name)
 	assert.Equal(t, "request", transaction.Type)
-	assert.Equal(t, "200", transaction.Result)
+	assert.Equal(t, "418", transaction.Result)
 
 	true_ := true
 	assert.Equal(t, &model.Context{
@@ -54,7 +54,7 @@ func TestEchoMiddleware(t *testing.T) {
 			},
 		},
 		Response: &model.Response{
-			StatusCode:  200,
+			StatusCode:  418,
 			HeadersSent: &true_,
 			Headers: &model.ResponseHeaders{
 				ContentType: "text/plain; charset=UTF-8",
@@ -103,7 +103,7 @@ func assertError(t *testing.T, payloads transporttest.Payloads, culprit, message
 }
 
 func handleHello(c echo.Context) error {
-	return c.String(http.StatusOK, fmt.Sprintf("Hello, %s!", c.Param("name")))
+	return c.String(http.StatusTeapot, fmt.Sprintf("Hello, %s!", c.Param("name")))
 }
 
 func handlePanic(c echo.Context) error {

--- a/contrib/apmhttp/recovery.go
+++ b/contrib/apmhttp/recovery.go
@@ -7,7 +7,7 @@ import (
 )
 
 // RecoveryFunc is the type of a function for use in Handler.Recovery.
-type RecoveryFunc func(w http.ResponseWriter, req *http.Request, tx *elasticapm.Transaction, recovered interface{})
+type RecoveryFunc func(w http.ResponseWriter, req *http.Request, body *elasticapm.BodyCapturer, tx *elasticapm.Transaction, recovered interface{})
 
 // NewTraceRecovery returns a RecoveryFunc for use in Handler.Recovery.
 //
@@ -18,9 +18,10 @@ func NewTraceRecovery(t *elasticapm.Tracer) RecoveryFunc {
 	if t == nil {
 		t = elasticapm.DefaultTracer
 	}
-	return func(w http.ResponseWriter, req *http.Request, tx *elasticapm.Transaction, recovered interface{}) {
+	return func(w http.ResponseWriter, req *http.Request, body *elasticapm.BodyCapturer, tx *elasticapm.Transaction, recovered interface{}) {
 		e := t.Recovered(recovered, tx)
 		e.Context.SetHTTPRequest(req)
+		e.Context.SetHTTPRequestBody(body)
 		e.Send()
 	}
 }

--- a/contrib/apmhttprouter/handler.go
+++ b/contrib/apmhttprouter/handler.go
@@ -33,15 +33,16 @@ func WrapHandle(
 		defer tx.Done(-1)
 
 		finished := false
+		body := t.CaptureHTTPRequestBody(req)
 		w, resp := apmhttp.WrapResponseWriter(w)
 		defer func() {
 			if recovery != nil {
 				if v := recover(); v != nil {
-					recovery(w, req, tx, v)
+					recovery(w, req, body, tx, v)
 					finished = true
 				}
 			}
-			apmhttp.SetTransactionContext(tx, w, req, resp, finished)
+			apmhttp.SetTransactionContext(tx, w, req, resp, body, finished)
 		}()
 		h(w, req, p)
 		finished = true

--- a/env.go
+++ b/env.go
@@ -18,10 +18,12 @@ const (
 	envMaxSpans              = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
 	envTransactionSampleRate = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
 	envSanitizeFieldNames    = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
+	envCaptureBody           = "ELASTIC_APM_CAPTURE_BODY"
 
 	defaultFlushInterval           = 10 * time.Second
 	defaultMaxTransactionQueueSize = 500
 	defaultMaxSpans                = 500
+	defaultCaptureBody             = CaptureBodyOff
 )
 
 var (
@@ -115,4 +117,22 @@ func initialSanitizedFieldNamesRegexp() (*regexp.Regexp, error) {
 		return nil, errors.Wrapf(err, "invalid %s value", envSanitizeFieldNames)
 	}
 	return re, nil
+}
+
+func initialCaptureBody() (CaptureBodyMode, error) {
+	value := os.Getenv(envCaptureBody)
+	if value == "" {
+		return defaultCaptureBody, nil
+	}
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "all":
+		return CaptureBodyAll, nil
+	case "errors":
+		return CaptureBodyErrors, nil
+	case "transactions":
+		return CaptureBodyTransactions, nil
+	case "off":
+		return CaptureBodyOff, nil
+	}
+	return -1, errors.Errorf("invalid %s value %q", envCaptureBody, value)
 }

--- a/error.go
+++ b/error.go
@@ -115,7 +115,12 @@ func (t *Tracer) NewErrorLog(r ErrorLogRecord) *Error {
 func (t *Tracer) newError() *Error {
 	e, _ := t.errorPool.Get().(*Error)
 	if e == nil {
-		e = &Error{tracer: t}
+		e = &Error{
+			tracer: t,
+			Context: Context{
+				captureBodyMask: CaptureBodyErrors,
+			},
+		}
 	}
 	e.Timestamp = time.Now()
 	return e

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -327,15 +328,16 @@ func (b *RequestBody) UnmarshalJSON(data []byte) error {
 		b.Raw = v
 		return nil
 	case map[string]interface{}:
+		form := make(url.Values, len(v))
 		for k, v := range v {
 			switch v := v.(type) {
 			case string:
-				b.Form.Set(k, v)
+				form.Set(k, v)
 			case []interface{}:
 				for _, v := range v {
 					switch v := v.(type) {
 					case string:
-						b.Form.Add(k, v)
+						form.Add(k, v)
 					default:
 						return errors.Errorf("expected string, got %T", v)
 					}
@@ -344,6 +346,7 @@ func (b *RequestBody) UnmarshalJSON(data []byte) error {
 				return errors.Errorf("expected string or []string, got %T", v)
 			}
 		}
+		b.Form = form
 	default:
 		return errors.Errorf("expected string or map, got %T", v)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -21,7 +21,12 @@ func (t *Tracer) StartTransaction(name, transactionType string) *Transaction {
 func (t *Tracer) newTransaction(name, transactionType string) *Transaction {
 	tx, _ := t.transactionPool.Get().(*Transaction)
 	if tx == nil {
-		tx = &Transaction{tracer: t}
+		tx = &Transaction{
+			tracer: t,
+			Context: Context{
+				captureBodyMask: CaptureBodyTransactions,
+			},
+		}
 	}
 	tx.model.Name = name
 	tx.model.Type = transactionType


### PR DESCRIPTION
If ELASTIC_APM_CAPTURE_BODY is set, then HTTP modules will capture the request body, either as a raw string or as a map of form data.

Closes #58 