### PR TITLE
Configuration to ignore transactions by name

### DIFF
--- a/contrib/apmecho/middleware.go
+++ b/contrib/apmecho/middleware.go
@@ -54,6 +54,11 @@ func (m *middleware) handle(c echo.Context) error {
 	req := c.Request()
 	name := req.Method + " " + c.Path()
 	tx := m.tracer.StartTransaction(name, "request")
+	if tx.Ignored() {
+		tx.Discard()
+		return m.handler(c)
+	}
+
 	ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 	req = req.WithContext(ctx)
 	c.SetRequest(req)

--- a/contrib/apmgin/middleware.go
+++ b/contrib/apmgin/middleware.go
@@ -83,6 +83,12 @@ func (m *middleware) handle(c *gin.Context) {
 		requestName = routeInfo.transactionName
 	}
 	tx := m.tracer.StartTransaction(requestName, "request")
+	if tx.Ignored() {
+		tx.Discard()
+		c.Next()
+		return
+	}
+
 	ctx := elasticapm.ContextWithTransaction(c.Request.Context(), tx)
 	c.Request = c.Request.WithContext(ctx)
 	defer tx.Done(-1)

--- a/contrib/apmgrpc/server.go
+++ b/contrib/apmgrpc/server.go
@@ -35,6 +35,11 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 		handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
 		tx := opts.tracer.StartTransaction(info.FullMethod, "grpc")
+		if tx.Ignored() {
+			tx.Discard()
+			return handler(ctx, req)
+		}
+
 		ctx = elasticapm.ContextWithTransaction(ctx, tx)
 		defer tx.Done(-1)
 

--- a/contrib/apmhttprouter/handler.go
+++ b/contrib/apmhttprouter/handler.go
@@ -28,6 +28,12 @@ func WrapHandle(
 	}
 	return func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 		tx := t.StartTransaction(req.Method+" "+route, "request")
+		if tx.Ignored() {
+			tx.Discard()
+			h(w, req, p)
+			return
+		}
+
 		ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 		req = req.WithContext(ctx)
 		defer tx.Done(-1)

--- a/env.go
+++ b/env.go
@@ -13,12 +13,13 @@ import (
 )
 
 const (
-	envFlushInterval         = "ELASTIC_APM_FLUSH_INTERVAL"
-	envMaxQueueSize          = "ELASTIC_APM_MAX_QUEUE_SIZE"
-	envMaxSpans              = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
-	envTransactionSampleRate = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
-	envSanitizeFieldNames    = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
-	envCaptureBody           = "ELASTIC_APM_CAPTURE_BODY"
+	envFlushInterval          = "ELASTIC_APM_FLUSH_INTERVAL"
+	envMaxQueueSize           = "ELASTIC_APM_MAX_QUEUE_SIZE"
+	envMaxSpans               = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
+	envTransactionSampleRate  = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
+	envTransactionIgnoreNames = "ELASTIC_APM_TRANSACTION_IGNORE_NAMES"
+	envSanitizeFieldNames     = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
+	envCaptureBody            = "ELASTIC_APM_CAPTURE_BODY"
 
 	defaultFlushInterval           = 10 * time.Second
 	defaultMaxTransactionQueueSize = 500
@@ -115,6 +116,19 @@ func initialSanitizedFieldNamesRegexp() (*regexp.Regexp, error) {
 	if err != nil {
 		_, err = regexp.Compile(value)
 		return nil, errors.Wrapf(err, "invalid %s value", envSanitizeFieldNames)
+	}
+	return re, nil
+}
+
+func initialTransactionIgnoreNamesRegexp() (*regexp.Regexp, error) {
+	value := os.Getenv(envTransactionIgnoreNames)
+	if value == "" {
+		return nil, nil
+	}
+	re, err := regexp.Compile(fmt.Sprintf("(?i:%s)", value))
+	if err != nil {
+		_, err = regexp.Compile(value)
+		return nil, errors.Wrapf(err, "invalid %s value", envTransactionIgnoreNames)
 	}
 	return re, nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -219,3 +219,35 @@ func testTracerCaptureBodyEnv(t *testing.T, envValue string, expectBody bool) {
 		assert.Nil(t, out.Context.Request.Body)
 	}
 }
+
+func TestTracerTransactionIgnoreNamesEnvInvalid(t *testing.T) {
+	os.Setenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES", "oy(")
+	defer os.Unsetenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES")
+
+	_, err := elasticapm.NewTracer("tracer_testing", "")
+	assert.EqualError(t, err, "invalid ELASTIC_APM_TRANSACTION_IGNORE_NAMES value: error parsing regexp: missing closing ): `oy(`")
+}
+
+func TestTracerTransactionIgnoreNamesEnv(t *testing.T) {
+	type test struct {
+		name    string
+		re      string
+		ignored bool
+	}
+	tests := []test{
+		{name: "matching", re: "foo", ignored: true},
+		{name: "nonmatching", re: "not_foo", ignored: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			os.Setenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES", test.re)
+			defer os.Unsetenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES")
+
+			tracer, _ := elasticapm.NewTracer("tracer_testing", "")
+			defer tracer.Close()
+
+			tx := tracer.StartTransaction("FOO", "type")
+			assert.Equal(t, test.ignored, tx.Ignored())
+		})
+	}
+}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -335,3 +335,19 @@ func TestTracerServiceNameValidation(t *testing.T) {
 	_, err := elasticapm.NewTracer("wot!", "")
 	assert.EqualError(t, err, `invalid service name "wot!": character '!' is not in the allowed set (a-zA-Z0-9 _-)`)
 }
+
+func TestTracerTransactionIgnoreNames(t *testing.T) {
+	tracer, _ := elasticapm.NewTracer("tracer_testing", "")
+	defer tracer.Close()
+
+	tracer.SetTransactionIgnoreNames("\\bignored")
+
+	tx := tracer.StartTransaction("iGnoReD", "type") // case-insensitive
+	assert.True(t, tx.Ignored())
+	assert.False(t, tx.Sampled()) // ignored => !sampled
+	tx.Discard()
+
+	tx = tracer.StartTransaction("not_ignored", "type")
+	assert.False(t, tx.Ignored())
+	tx.Discard()
+}


### PR DESCRIPTION
Introduce the ELASTIC_APM_TRANSACTION_IGNORE_NAMES
environment variable, which accepts a regular expression
(wrapped so that it is case-insensitive by default)
to match the names of transactions that should be
ignored. Ignored transactions should cause their
instrumentation modules to bail out early, to minimise
overhead.

Closes #59 