### PR TITLE
all: drop support for Service.Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ ELASTIC\_APM\_MAX\_QUEUE\_SIZE           | 500       | Maximum number of transac
 ELASTIC\_APM\_TRANSACTION\_MAX\_SPANS    | 500       | Maximum number of spans to capture per transaction. After this is reached, new spans will not be created, and a dropped count will be incremented.
 ELASTIC\_APM\_TRANSACTION\_SAMPLE\_RATE  | 1.0       | Number in the range 0.0-1.0 inclusive, controlling how many transactions should be sampled (i.e. include full detail.)
 ELASTIC\_APM\_ENVIRONMENT                |           | Environment name, e.g. "production".
-ELASTIC\_APM\_FRAMEWORK\_NAME            |           | Framework name, e.g. "gin".
-ELASTIC\_APM\_FRAMEWORK\_VERSION         |           | Framework version, e.g. "1.0".
 ELASTIC\_APM\_SERVICE\_NAME              |           | Service name, e.g. "my-service". If this is unspecified, the agent will report the program binary name as the service name.
 ELASTIC\_APM\_SERVICE\_VERSION           |           | Service version, e.g. "1.0".
 ELASTIC\_APM\_HOSTNAME                   |           | Override for the hostname.

--- a/contrib/apmecho/middleware.go
+++ b/contrib/apmecho/middleware.go
@@ -8,26 +8,7 @@ import (
 
 	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/contrib/apmhttp"
-	"github.com/elastic/apm-agent-go/model"
 )
-
-// Framework is a model.Framework initialized with values
-// describing the gin framework name and version.
-var Framework = model.Framework{
-	Name:    "echo",
-	Version: echo.Version,
-}
-
-func init() {
-	if elasticapm.DefaultTracer.Service.Framework == nil {
-		// TODO(axw) this is not ideal, as there could be multiple
-		// frameworks in use within a program. The intake API should
-		// be extended to support specifying a framework on a
-		// transaction, or perhaps specifying multiple frameworks
-		// in the payload and referencing one from the transaction.
-		elasticapm.DefaultTracer.Service.Framework = &Framework
-	}
-}
 
 // Middleware returns a new Echo middleware handler for tracing
 // requests and reporting errors, using the given tracer, or

--- a/contrib/apmgin/bench_test.go
+++ b/contrib/apmgin/bench_test.go
@@ -51,7 +51,6 @@ func newTracer() *elasticapm.Tracer {
 	if err != nil {
 		panic(err)
 	}
-	tracer.Service.Framework = &apmgin.Framework
 
 	httpTransport, err := transport.NewHTTPTransport("http://testing.invalid:8200", "")
 	if err != nil {

--- a/contrib/apmgin/middleware.go
+++ b/contrib/apmgin/middleware.go
@@ -8,30 +8,14 @@ import (
 
 	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/contrib/apmhttp"
-	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/stacktrace"
 )
-
-// Framework is a model.Framework initialized with values
-// describing the gin framework name and version.
-var Framework = model.Framework{
-	Name:    "gin",
-	Version: gin.Version,
-}
 
 func init() {
 	stacktrace.RegisterLibraryPackage(
 		"github.com/gin-gonic",
 		"github.com/gin-contrib",
 	)
-	if elasticapm.DefaultTracer.Service.Framework == nil {
-		// TODO(axw) this is not ideal, as there could be multiple
-		// frameworks in use within a program. The intake API should
-		// be extended to support specifying a framework on a
-		// transaction, or perhaps specifying multiple frameworks
-		// in the payload and referencing one from the transaction.
-		elasticapm.DefaultTracer.Service.Framework = &Framework
-	}
 }
 
 // Middleware returns a new Gin middleware handler for tracing

--- a/contrib/apmlambda/lambda.go
+++ b/contrib/apmlambda/lambda.go
@@ -5,11 +5,9 @@ import (
 	"net"
 	"net/rpc"
 	"os"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/elastic/apm-agent-go"
-	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/stacktrace"
 
 	"github.com/aws/aws-lambda-go/lambda/messages"
@@ -43,15 +41,6 @@ func init() {
 	lambdaContext.FunctionVersion = lambdacontext.FunctionVersion
 	lambdaContext.MemoryLimit = lambdacontext.MemoryLimitInMB
 	lambdaContext.Region = os.Getenv("AWS_REGION")
-
-	if elasticapm.DefaultTracer.Service.Framework == nil {
-		executionEnv := os.Getenv("AWS_EXECUTION_ENV")
-		version := strings.TrimPrefix(executionEnv, "AWS_Lambda_")
-		elasticapm.DefaultTracer.Service.Framework = &model.Framework{
-			Name:    "AWS Lambda",
-			Version: version,
-		}
-	}
 }
 
 // Function is type exposed via net/rpc, to match the signature implemented


### PR DESCRIPTION
Stop exposing the full service model in the
tracer - expose only the service name, version,
and environment instead. It is now no longer
possible to override the agent, language or
runtime; and it is no longer possible to set
the framework at all.

Framework is problematic because it doesn't
necessarily apply to all transactions, and
there's no way to attach the information at
the transaction level. So instead of including
it in a problematic state, we'll drop support
initially and work updates into the API and
server, and then reintroduce it later.

See https://github.com/elastic/apm-agent-go/issues/69