### PR TITLE
Truncate strings to avoid validation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
 before_install:
   - go get -v golang.org/x/tools/cmd/goimports
   - go get -v golang.org/x/lint/golint
+  - go get -d github.com/elastic/apm-server || true
 
 script:
   - make install precheck coverage.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   PATH: C:\msys64\mingw64\bin;%PATH%
 
 build_script:
+- cmd: go get -d github.com/elastic/apm-server || true
 - cmd: go get -t ./...
 
 test_script:

--- a/context.go
+++ b/context.go
@@ -67,6 +67,7 @@ func (c *Context) SetTag(key, value string) {
 	if !validTagKey(key) {
 		return
 	}
+	value = truncateString(value)
 	if c.model.Tags == nil {
 		c.model.Tags = map[string]string{key: value}
 	} else {
@@ -108,7 +109,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 	c.request = model.Request{
 		Body:        c.request.Body,
 		URL:         apmhttputil.RequestURL(req, forwarded),
-		Method:      req.Method,
+		Method:      truncateString(req.Method),
 		HTTPVersion: httpVersion,
 		Cookies:     req.Cookies(),
 	}
@@ -135,7 +136,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 	if !ok && req.URL.User != nil {
 		username = req.URL.User.Username()
 	}
-	c.user.Username = username
+	c.user.Username = truncateString(username)
 	if c.user.Username != "" {
 		c.model.User = &c.user
 	}

--- a/internal/apmstrings/truncate.go
+++ b/internal/apmstrings/truncate.go
@@ -1,0 +1,13 @@
+package apmstrings
+
+// Truncate returns s truncated at n runes.
+func Truncate(s string, n int) string {
+	var j int
+	for i := range s {
+		if j == n {
+			return s[:i]
+		}
+		j++
+	}
+	return s
+}

--- a/internal/apmstrings/truncate_test.go
+++ b/internal/apmstrings/truncate_test.go
@@ -1,0 +1,24 @@
+package apmstrings_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go/internal/apmstrings"
+)
+
+func TestTruncate(t *testing.T) {
+	const limit = 2
+	test := func(name, in, expect string) {
+		t.Run(name, func(t *testing.T) {
+			out := apmstrings.Truncate(in, limit)
+			assert.Equal(t, out, expect)
+		})
+	}
+	test("empty", "", "")
+	test("limit_ascii", "xx", "xx")
+	test("limit_multibyte", "世界", "世界")
+	test("truncate_ascii", "xxx", "xx")
+	test("truncate_multibyte", "世界世", "世界")
+}

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -176,7 +176,7 @@ func (v *URL) marshalFullURL(w *fastjson.Writer, schemeBegin, schemeEnd int) boo
 	}
 	if n := w.Size() - before; n > 1024 {
 		// Truncate the full URL to 1024 bytes.
-		w.Rewind(w.Size() - n - 1024)
+		w.Rewind(w.Size() - n + 1024)
 	}
 	w.RawByte('"')
 	return true
@@ -278,6 +278,37 @@ func (c *ExceptionCode) UnmarshalJSON(data []byte) error {
 // isZero is used by fastjson to implement omitempty.
 func (c *ExceptionCode) isZero() bool {
 	return c.String == "" && c.Number == 0
+}
+
+// MarshalFastJSON writes the JSON representation of c to w.
+func (u *UserID) MarshalFastJSON(w *fastjson.Writer) {
+	if u.String != "" {
+		w.String(u.String)
+		return
+	}
+	w.Float64(u.Number)
+}
+
+// UnmarshalJSON unmarshals the JSON data into c.
+func (u *UserID) UnmarshalJSON(data []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch v := v.(type) {
+	case string:
+		u.String = v
+	case float64:
+		u.Number = v
+	default:
+		return errors.Errorf("expected string or number, got %T", v)
+	}
+	return nil
+}
+
+// isZero is used by fastjson to implement omitempty.
+func (u *UserID) isZero() bool {
+	return u.String == "" && u.Number == 0
 }
 
 // MarshalFastJSON writes the JSON representation of b to w.

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -367,7 +367,7 @@ func (v *User) MarshalFastJSON(w *fastjson.Writer) {
 		}
 		w.String(v.Email)
 	}
-	if v.ID != nil {
+	if !v.ID.isZero() {
 		const prefix = ",\"id\":"
 		if first {
 			first = false
@@ -375,7 +375,7 @@ func (v *User) MarshalFastJSON(w *fastjson.Writer) {
 		} else {
 			w.RawString(prefix)
 		}
-		fastjson.Marshal(w, v.ID)
+		v.ID.MarshalFastJSON(w)
 	}
 	if v.Username != "" {
 		const prefix = ",\"username\":"

--- a/model/model.go
+++ b/model/model.go
@@ -236,10 +236,16 @@ type User struct {
 
 	// ID identifies the user, e.g. a primary key. This may be
 	// a string or number.
-	ID interface{} `json:"id,omitempty"`
+	ID UserID `json:"id,omitempty"`
 
 	// Email holds the email address of the user.
 	Email string `json:"email,omitempty"`
+}
+
+// UserID represents a user ID as either a number or a string.
+type UserID struct {
+	String string
+	Number float64
 }
 
 // Error represents an error occurring in the service.

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/elastic/apm-agent-go/internal/apmstrings"
 	"github.com/elastic/apm-agent-go/model"
 )
 
@@ -41,16 +42,16 @@ func getCurrentProcess() model.Process {
 	return model.Process{
 		Pid:   os.Getpid(),
 		Ppid:  &ppid,
-		Title: title,
+		Title: truncateString(title),
 		Argv:  os.Args,
 	}
 }
 
 func makeService(name, version, environment string) model.Service {
 	return model.Service{
-		Name:        name,
-		Version:     version,
-		Environment: environment,
+		Name:        truncateString(name),
+		Version:     truncateString(version),
+		Environment: truncateString(environment),
 		Agent:       goAgent,
 		Language:    &goLanguage,
 		Runtime:     &goRuntime,
@@ -68,6 +69,7 @@ func getLocalSystem() model.System {
 			system.Hostname = hostname
 		}
 	}
+	system.Hostname = truncateString(system.Hostname)
 	return system
 }
 
@@ -88,4 +90,9 @@ func validateServiceName(name string) error {
 
 func sanitizeServiceName(name string) string {
 	return serviceNameInvalidRegexp.ReplaceAllString(name, "_")
+}
+
+func truncateString(s string) string {
+	// At the time of writing, all length limits are 1024.
+	return apmstrings.Truncate(s, 1024)
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,274 @@
+package elasticapm_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/internal/fastjson"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-server/processor"
+	error_processor "github.com/elastic/apm-server/processor/error"
+	transaction_processor "github.com/elastic/apm-server/processor/transaction"
+)
+
+func TestValidateServiceName(t *testing.T) {
+	validatePayloadMetadata(t, func(tracer *elasticapm.Tracer) {
+		tracer.Service.Name = strings.Repeat("x", 1025)
+	})
+}
+
+func TestValidateServiceVersion(t *testing.T) {
+	validatePayloadMetadata(t, func(tracer *elasticapm.Tracer) {
+		tracer.Service.Version = strings.Repeat("x", 1025)
+	})
+}
+
+func TestValidateServiceEnvironment(t *testing.T) {
+	validatePayloadMetadata(t, func(tracer *elasticapm.Tracer) {
+		tracer.Service.Environment = strings.Repeat("x", 1025)
+	})
+}
+
+func TestValidateTransactionName(t *testing.T) {
+	validatePayloads(t, func(tracer *elasticapm.Tracer) {
+		tracer.StartTransaction(strings.Repeat("x", 1025), "type").Done(-1)
+	})
+}
+
+func TestValidateTransactionType(t *testing.T) {
+	validatePayloads(t, func(tracer *elasticapm.Tracer) {
+		tracer.StartTransaction("name", strings.Repeat("x", 1025)).Done(-1)
+	})
+}
+
+func TestValidateTransactionResult(t *testing.T) {
+	validatePayloads(t, func(tracer *elasticapm.Tracer) {
+		tx := tracer.StartTransaction("name", "type")
+		tx.Result = strings.Repeat("x", 1025)
+		tx.Done(-1)
+	})
+}
+
+func TestValidateSpanName(t *testing.T) {
+	validateTransaction(t, func(tx *elasticapm.Transaction) {
+		tx.StartSpan(strings.Repeat("x", 1025), "type", nil).Done(-1)
+	})
+}
+
+func TestValidateSpanType(t *testing.T) {
+	validateTransaction(t, func(tx *elasticapm.Transaction) {
+		tx.StartSpan("name", strings.Repeat("x", 1025), nil).Done(-1)
+	})
+}
+
+func TestValidateContextUser(t *testing.T) {
+	validateTransaction(t, func(tx *elasticapm.Transaction) {
+		req, err := http.NewRequest("GET", "/", nil)
+		require.NoError(t, err)
+		req.SetBasicAuth(strings.Repeat("x", 1025), "")
+		tx.Context.SetHTTPRequest(req)
+	})
+}
+
+func TestValidateContextCustom(t *testing.T) {
+	t.Run("long_key", func(t *testing.T) {
+		// NOTE(axw) this should probably fail, but does not. See:
+		// https://github.com/elastic/apm-server/issues/910
+		validateTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetCustom(strings.Repeat("x", 1025), "x")
+		})
+	})
+	t.Run("reserved_key_chars", func(t *testing.T) {
+		validateTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetCustom("x.y", "z")
+		})
+	})
+}
+
+func TestValidateContextTags(t *testing.T) {
+	t.Run("long_key", func(t *testing.T) {
+		// NOTE(axw) this should probably fail, but does not. See:
+		// https://github.com/elastic/apm-server/issues/910
+		validateTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetTag(strings.Repeat("x", 1025), "x")
+		})
+	})
+	t.Run("long_value", func(t *testing.T) {
+		validateTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetTag("x", strings.Repeat("x", 1025))
+		})
+	})
+	t.Run("reserved_key_chars", func(t *testing.T) {
+		validateTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetTag("x.y", "z")
+		})
+	})
+}
+
+func TestValidateRequestMethod(t *testing.T) {
+	validateTransaction(t, func(tx *elasticapm.Transaction) {
+		req, _ := http.NewRequest(strings.Repeat("x", 1025), "/", nil)
+		tx.Context.SetHTTPRequest(req)
+	})
+}
+
+func TestValidateRequestURL(t *testing.T) {
+	type test struct {
+		name string
+		url  string
+	}
+	long := strings.Repeat("x", 1025)
+	longNumber := strings.Repeat("8", 1025)
+	tests := []test{
+		{name: "scheme", url: fmt.Sprintf("%s://testing.invalid", long)},
+		{name: "hostname", url: fmt.Sprintf("http://%s/", long)},
+		{name: "port", url: fmt.Sprintf("http://testing.invalid:%s/", longNumber)},
+		{name: "path", url: fmt.Sprintf("http://testing.invalid/%s", long)},
+		{name: "query", url: fmt.Sprintf("http://testing.invalid/?%s", long)},
+		{name: "fragment", url: fmt.Sprintf("http://testing.invalid/#%s", long)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validateTransaction(t, func(tx *elasticapm.Transaction) {
+				req, _ := http.NewRequest("GET", test.url, nil)
+				tx.Context.SetHTTPRequest(req)
+			})
+		})
+	}
+}
+
+func TestValidateErrorException(t *testing.T) {
+	t.Run("empty_message", func(t *testing.T) {
+		validatePayloads(t, func(tracer *elasticapm.Tracer) {
+			tracer.NewError(&testError{
+				message: "",
+			}).Send()
+		})
+	})
+	t.Run("code", func(t *testing.T) {
+		validatePayloads(t, func(tracer *elasticapm.Tracer) {
+			tracer.NewError(&testError{
+				message: "xyz",
+				code:    strings.Repeat("x", 1025),
+			}).Send()
+		})
+	})
+	t.Run("type", func(t *testing.T) {
+		validatePayloads(t, func(tracer *elasticapm.Tracer) {
+			tracer.NewError(&testError{
+				message: "xyz",
+				type_:   strings.Repeat("x", 1025),
+			}).Send()
+		})
+	})
+}
+
+func TestValidateErrorLog(t *testing.T) {
+	tests := map[string]elasticapm.ErrorLogRecord{
+		"empty_message": {
+			Message: "",
+		},
+		"level": {
+			Message: "x",
+			Level:   strings.Repeat("x", 1025),
+		},
+		"logger_name": {
+			Message:    "x",
+			LoggerName: strings.Repeat("x", 1025),
+		},
+		"message_format": {
+			Message:       "x",
+			MessageFormat: strings.Repeat("x", 1025),
+		},
+	}
+	for name, record := range tests {
+		t.Run(name, func(t *testing.T) {
+			validatePayloads(t, func(tracer *elasticapm.Tracer) {
+				tracer.NewErrorLog(record).Send()
+			})
+		})
+	}
+}
+
+func validateTransaction(t *testing.T, f func(tx *elasticapm.Transaction)) {
+	validatePayloads(t, func(tracer *elasticapm.Tracer) {
+		tx := tracer.StartTransaction("name", "type")
+		f(tx)
+		tx.Done(-1)
+	})
+}
+
+func validatePayloadMetadata(t *testing.T, f func(tracer *elasticapm.Tracer)) {
+	validatePayloads(t, func(tracer *elasticapm.Tracer) {
+		f(tracer)
+		tracer.StartTransaction("name", "type").Done(-1)
+	})
+}
+
+func validatePayloads(t *testing.T, f func(tracer *elasticapm.Tracer)) {
+	tracer, _ := elasticapm.NewTracer("tracer_testing", "")
+	defer tracer.Close()
+	tracer.Service.Name = "x"
+	tracer.Service.Version = "x"
+	tracer.Service.Environment = "x"
+	tracer.Transport = &validatingTransport{
+		t:  t,
+		tp: transaction_processor.NewProcessor(),
+		ep: error_processor.NewProcessor(),
+	}
+	f(tracer)
+	tracer.Flush(nil)
+}
+
+type validatingTransport struct {
+	t  *testing.T
+	tp processor.Processor
+	ep processor.Processor
+	w  fastjson.Writer
+}
+
+func (t *validatingTransport) SendTransactions(ctx context.Context, p *model.TransactionsPayload) error {
+	t.validate(p, t.tp)
+	return nil
+}
+
+func (t *validatingTransport) SendErrors(ctx context.Context, p *model.ErrorsPayload) error {
+	t.validate(p, t.ep)
+	return nil
+}
+
+func (t *validatingTransport) validate(payload fastjson.Marshaler, processor processor.Processor) {
+	t.w.Reset()
+	payload.MarshalFastJSON(&t.w)
+	raw := make(map[string]interface{})
+	err := json.Unmarshal(t.w.Bytes(), &raw)
+	require.NoError(t.t, err)
+	err = processor.Validate(raw)
+	assert.NoError(t.t, err)
+}
+
+type testError struct {
+	message string
+	code    string
+	type_   string
+}
+
+func (e *testError) Error() string {
+	return e.message
+}
+
+func (e *testError) Code() string {
+	return e.code
+}
+
+func (e *testError) Type() string {
+	return e.type_
+}


### PR DESCRIPTION
Truncate strings we send so we don't cause validation errors. The alternative is to reject the entire payload, which is a bit drastic.

Also, if an error log or exception message is empty, set it to "[EMPTY]" instead. The message is required.

Fix a bug found in the "full" URL truncation logic.

Closes https://github.com/elastic/apm-agent-go/issues/48