### PR TITLE
contrib/apmhttp: update HTTP result format

### DIFF
--- a/contrib/apmecho/middleware.go
+++ b/contrib/apmecho/middleware.go
@@ -62,7 +62,7 @@ func (m *middleware) handle(c echo.Context) error {
 
 	resp := c.Response()
 	handlerErr := m.handler(c)
-	tx.Result = apmhttp.StatusCodeString(resp.Status)
+	tx.Result = apmhttp.StatusCodeResult(resp.Status)
 	if tx.Sampled() {
 		tx.Context.SetHTTPRequest(req)
 		tx.Context.SetHTTPRequestBody(body)

--- a/contrib/apmecho/middleware_test.go
+++ b/contrib/apmecho/middleware_test.go
@@ -33,7 +33,7 @@ func TestEchoMiddleware(t *testing.T) {
 
 	assert.Equal(t, "GET /hello/:name", transaction.Name)
 	assert.Equal(t, "request", transaction.Type)
-	assert.Equal(t, "418", transaction.Result)
+	assert.Equal(t, "HTTP 4xx", transaction.Result)
 
 	true_ := true
 	assert.Equal(t, &model.Context{

--- a/contrib/apmgin/middleware.go
+++ b/contrib/apmgin/middleware.go
@@ -87,7 +87,7 @@ func (m *middleware) handle(c *gin.Context) {
 			e.Context.SetHTTPRequestBody(body)
 			e.Send()
 		}
-		tx.Result = apmhttp.StatusCodeString(c.Writer.Status())
+		tx.Result = apmhttp.StatusCodeResult(c.Writer.Status())
 
 		if tx.Sampled() {
 			tx.Context.SetHTTPRequest(c.Request)

--- a/contrib/apmgin/middleware_test.go
+++ b/contrib/apmgin/middleware_test.go
@@ -38,7 +38,7 @@ func TestMiddleware(t *testing.T) {
 	transaction := transactions[0]
 	assert.Equal(t, "GET /hello/:name", transaction.Name)
 	assert.Equal(t, "request", transaction.Type)
-	assert.Equal(t, "200", transaction.Result)
+	assert.Equal(t, "HTTP 2xx", transaction.Result)
 
 	true_ := true
 	assert.Equal(t, &model.Context{

--- a/contrib/apmgorilla/middleware_test.go
+++ b/contrib/apmgorilla/middleware_test.go
@@ -32,7 +32,7 @@ func TestMuxMiddleware(t *testing.T) {
 
 	assert.Equal(t, "GET /prefix/articles/{category}/{id}", transaction.Name)
 	assert.Equal(t, "request", transaction.Type)
-	assert.Equal(t, "200", transaction.Result)
+	assert.Equal(t, "HTTP 2xx", transaction.Result)
 
 	true_ := true
 	assert.Equal(t, &model.Context{

--- a/contrib/apmhttp/context.go
+++ b/contrib/apmhttp/context.go
@@ -1,137 +1,23 @@
 package apmhttp
 
 import (
-	"net/http"
-	"strconv"
+	"fmt"
 )
 
-// StatusCodeString returns the stringified status code. Prefer this to
-// strconv.Itoa to avoid allocating memory for well known status codes.
-func StatusCodeString(statusCode int) string {
-	switch statusCode {
-	case http.StatusContinue:
-		return "100"
-	case http.StatusSwitchingProtocols:
-		return "101"
-	case http.StatusProcessing:
-		return "102"
+var standardStatusCodeResults = [...]string{
+	"HTTP 1xx",
+	"HTTP 2xx",
+	"HTTP 3xx",
+	"HTTP 4xx",
+	"HTTP 5xx",
+}
 
-	case http.StatusOK:
-		return "200"
-	case http.StatusCreated:
-		return "201"
-	case http.StatusAccepted:
-		return "202"
-	case http.StatusNonAuthoritativeInfo:
-		return "203"
-	case http.StatusNoContent:
-		return "204"
-	case http.StatusResetContent:
-		return "205"
-	case http.StatusPartialContent:
-		return "206"
-	case http.StatusMultiStatus:
-		return "207"
-	case http.StatusAlreadyReported:
-		return "208"
-	case http.StatusIMUsed:
-		return "226"
-
-	case http.StatusMultipleChoices:
-		return "300"
-	case http.StatusMovedPermanently:
-		return "301"
-	case http.StatusFound:
-		return "302"
-	case http.StatusSeeOther:
-		return "303"
-	case http.StatusNotModified:
-		return "304"
-	case http.StatusUseProxy:
-		return "305"
-
-	case http.StatusTemporaryRedirect:
-		return "307"
-	case http.StatusPermanentRedirect:
-		return "308"
-
-	case http.StatusBadRequest:
-		return "400"
-	case http.StatusUnauthorized:
-		return "401"
-	case http.StatusPaymentRequired:
-		return "402"
-	case http.StatusForbidden:
-		return "403"
-	case http.StatusNotFound:
-		return "404"
-	case http.StatusMethodNotAllowed:
-		return "405"
-	case http.StatusNotAcceptable:
-		return "406"
-	case http.StatusProxyAuthRequired:
-		return "407"
-	case http.StatusRequestTimeout:
-		return "408"
-	case http.StatusConflict:
-		return "409"
-	case http.StatusGone:
-		return "410"
-	case http.StatusLengthRequired:
-		return "411"
-	case http.StatusPreconditionFailed:
-		return "412"
-	case http.StatusRequestEntityTooLarge:
-		return "413"
-	case http.StatusRequestURITooLong:
-		return "414"
-	case http.StatusUnsupportedMediaType:
-		return "415"
-	case http.StatusRequestedRangeNotSatisfiable:
-		return "416"
-	case http.StatusExpectationFailed:
-		return "417"
-	case http.StatusTeapot:
-		return "418"
-	case http.StatusUnprocessableEntity:
-		return "422"
-	case http.StatusLocked:
-		return "423"
-	case http.StatusFailedDependency:
-		return "424"
-	case http.StatusUpgradeRequired:
-		return "426"
-	case http.StatusPreconditionRequired:
-		return "428"
-	case http.StatusTooManyRequests:
-		return "429"
-	case http.StatusRequestHeaderFieldsTooLarge:
-		return "431"
-	case http.StatusUnavailableForLegalReasons:
-		return "451"
-
-	case http.StatusInternalServerError:
-		return "500"
-	case http.StatusNotImplemented:
-		return "501"
-	case http.StatusBadGateway:
-		return "502"
-	case http.StatusServiceUnavailable:
-		return "503"
-	case http.StatusGatewayTimeout:
-		return "504"
-	case http.StatusHTTPVersionNotSupported:
-		return "505"
-	case http.StatusVariantAlsoNegotiates:
-		return "506"
-	case http.StatusInsufficientStorage:
-		return "507"
-	case http.StatusLoopDetected:
-		return "508"
-	case http.StatusNotExtended:
-		return "510"
-	case http.StatusNetworkAuthenticationRequired:
-		return "511"
+// StatusCodeResult returns the transaction result value to use for the given
+// status code.
+func StatusCodeResult(statusCode int) string {
+	switch i := statusCode / 100; i {
+	case 1, 2, 3, 4, 5:
+		return standardStatusCodeResults[i-1]
 	}
-	return strconv.Itoa(statusCode)
+	return fmt.Sprintf("HTTP %d", statusCode)
 }

--- a/contrib/apmhttp/context_test.go
+++ b/contrib/apmhttp/context_test.go
@@ -1,7 +1,6 @@
 package apmhttp_test
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +9,21 @@ import (
 )
 
 func TestStatusCode(t *testing.T) {
-	for i := 100; i < 600; i++ {
-		assert.Equal(t, strconv.Itoa(i), apmhttp.StatusCodeString(i))
+	for i := 100; i < 200; i++ {
+		assert.Equal(t, "HTTP 1xx", apmhttp.StatusCodeResult(i))
 	}
+	for i := 200; i < 300; i++ {
+		assert.Equal(t, "HTTP 2xx", apmhttp.StatusCodeResult(i))
+	}
+	for i := 300; i < 400; i++ {
+		assert.Equal(t, "HTTP 3xx", apmhttp.StatusCodeResult(i))
+	}
+	for i := 400; i < 500; i++ {
+		assert.Equal(t, "HTTP 4xx", apmhttp.StatusCodeResult(i))
+	}
+	for i := 500; i < 600; i++ {
+		assert.Equal(t, "HTTP 5xx", apmhttp.StatusCodeResult(i))
+	}
+	assert.Equal(t, "HTTP 0", apmhttp.StatusCodeResult(0))
+	assert.Equal(t, "HTTP 600", apmhttp.StatusCodeResult(600))
 }

--- a/contrib/apmhttp/handler.go
+++ b/contrib/apmhttp/handler.go
@@ -90,7 +90,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // written, e.g. because the handler panicked and we did not recover the
 // panic.
 func SetTransactionContext(tx *elasticapm.Transaction, w http.ResponseWriter, req *http.Request, resp *Response, body *elasticapm.BodyCapturer, finished bool) {
-	tx.Result = StatusCodeString(resp.StatusCode)
+	tx.Result = StatusCodeResult(resp.StatusCode)
 	if !tx.Sampled() {
 		return
 	}

--- a/contrib/apmhttp/handler_test.go
+++ b/contrib/apmhttp/handler_test.go
@@ -61,7 +61,7 @@ func TestHandler(t *testing.T) {
 	transaction := transactions[0]
 	assert.Equal(t, "GET /foo", transaction.Name)
 	assert.Equal(t, "request", transaction.Type)
-	assert.Equal(t, "418", transaction.Result)
+	assert.Equal(t, "HTTP 4xx", transaction.Result)
 
 	true_ := true
 	assert.Equal(t, &model.Context{

--- a/contrib/apmhttprouter/handler_test.go
+++ b/contrib/apmhttprouter/handler_test.go
@@ -44,7 +44,7 @@ func TestWrapHandle(t *testing.T) {
 	transaction := transactions[0]
 	assert.Equal(t, "GET /hello/:name/go/*wild", transaction.Name)
 	assert.Equal(t, "request", transaction.Type)
-	assert.Equal(t, "418", transaction.Result)
+	assert.Equal(t, "HTTP 4xx", transaction.Result)
 
 	true_ := true
 	assert.Equal(t, &model.Context{


### PR DESCRIPTION
Update apmhttp (and dependent modules) to format
the transaction result like "HTTP 2xx", "HTTP 4xx",
etc. This is how other agents are doing it, and
what the UI expects.

Closes #66 