### PR TITLE
transport: drop concurrency tests

### DIFF
--- a/transport/api.go
+++ b/transport/api.go
@@ -7,7 +7,8 @@ import (
 )
 
 // Transport provides an interface for sending transactions and errors
-// payloads to Elastic APM.
+// payloads to Elastic APM. Methods are not required to be safe for
+// concurrent use; tracers should serialize the calls.
 type Transport interface {
 	// SendTransactions sends the transactions payload to the server.
 	SendTransactions(context.Context, *model.TransactionsPayload) error


### PR DESCRIPTION
Transports aren't required to be safe for concurrent use,
so document that and drop the tests. They were causing
"go test -race" to fail.