### PR TITLE
module/...: update all to use functional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,11 @@ import (
 
 func main() {
 	var myHandler http.Handler = ...
-	tracedHandler := apmhttp.Handler{
-		Handler: myHandler,
-	}
+	tracedHandler := apmhttp.Wrap(myHandler)
 }
 ```
 
-If you want your handler to recover panics and send them to Elastic APM,
-then you can set the Recovery field of apmhttp.Handler:
-
-```go
-apmhttp.Handler{
-	Handler: myHandler,
-	Recovery: apmhttp.NewTraceHandler(nil),
-}
-```
+The apmhttp handler will recover panics and send them to Elastic APM.
 
 ### Gin
 
@@ -125,7 +115,7 @@ import (
 
 func main() {
 	engine := gin.New()
-	engine.Use(apmgin.Middleware(engine, nil))
+	engine.Use(apmgin.Middleware(engine))
 	...
 }
 ```
@@ -146,7 +136,7 @@ import (
 
 func main() {
 	router := mux.NewRouter()
-	router.Use(apmgorilla.Middleware(nil)) // nil for default tracer
+	router.Use(apmgorilla.Middleware())
 	...
 }
 ```
@@ -171,9 +161,7 @@ func main() {
 	router := httprouter.New()
 
 	const route = "/my/route"
-	tracer := elasticapm.DefaultTracer
-	recovery := apmhttp.NewTraceRecovery(tracer) // optional panic recovery
-	router.GET(route, apmhttprouter.WrapHandle(h, tracer, route, recovery))
+	router.GET(route, apmhttprouter.Wrap(h, route))
 	...
 }
 ```
@@ -193,7 +181,7 @@ import (
 
 func main() {
 	e := echo.New()
-	e.Use(apmecho.Middleware(nil)) // nil for default tracer
+	e.Use(apmecho.Middleware())
 	...
 }
 ```

--- a/env_test.go
+++ b/env_test.go
@@ -118,7 +118,7 @@ func testTracerSanitizeFieldNamesEnv(t *testing.T, envValue, expect string) {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "http://server.testing/", nil)
 	req.AddCookie(&http.Cookie{Name: "secret", Value: "top"})
-	h := &apmhttp.Handler{Handler: http.NotFoundHandler(), Tracer: tracer}
+	h := apmhttp.Wrap(http.NotFoundHandler(), apmhttp.WithTracer(tracer))
 	h.ServeHTTP(w, req)
 	tracer.Flush(nil)
 

--- a/module/apmecho/middleware_test.go
+++ b/module/apmecho/middleware_test.go
@@ -21,7 +21,7 @@ func TestEchoMiddleware(t *testing.T) {
 	defer tracer.Close()
 
 	e := echo.New()
-	e.Use(apmecho.Middleware(tracer))
+	e.Use(apmecho.Middleware(apmecho.WithTracer(tracer)))
 	e.GET("/hello/:name", handleHello)
 
 	w := doRequest(e, "GET", "http://server.testing/hello/foo")
@@ -68,7 +68,7 @@ func TestEchoMiddlewarePanic(t *testing.T) {
 	defer tracer.Close()
 
 	e := echo.New()
-	e.Use(apmecho.Middleware(tracer))
+	e.Use(apmecho.Middleware(apmecho.WithTracer(tracer)))
 	e.GET("/panic", handlePanic)
 
 	w := doRequest(e, "GET", "http://server.testing/panic")
@@ -82,7 +82,7 @@ func TestEchoMiddlewareError(t *testing.T) {
 	defer tracer.Close()
 
 	e := echo.New()
-	e.Use(apmecho.Middleware(tracer))
+	e.Use(apmecho.Middleware(apmecho.WithTracer(tracer)))
 	e.GET("/error", handleError)
 
 	w := doRequest(e, "GET", "http://server.testing/error")

--- a/module/apmgin/bench_test.go
+++ b/module/apmgin/bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkWithMiddleware(b *testing.B) {
 	tracer := newTracer()
 	defer tracer.Close()
 	addMiddleware := func(r *gin.Engine) {
-		r.Use(apmgin.Middleware(r, tracer))
+		r.Use(apmgin.Middleware(r, apmgin.WithTracer(tracer)))
 	}
 	for _, path := range benchmarkPaths {
 		b.Run(path, func(b *testing.B) {

--- a/module/apmgin/middleware_test.go
+++ b/module/apmgin/middleware_test.go
@@ -23,7 +23,7 @@ func TestMiddleware(t *testing.T) {
 	defer tracer.Close()
 
 	r := gin.New()
-	r.Use(apmgin.Middleware(r, tracer))
+	r.Use(apmgin.Middleware(r, apmgin.WithTracer(tracer)))
 	r.GET("/hello/:name", handleHello)
 
 	w := httptest.NewRecorder()

--- a/module/apmgorilla/middleware.go
+++ b/module/apmgorilla/middleware.go
@@ -10,21 +10,25 @@ import (
 )
 
 // Middleware returns a new gorilla/mux middleware handler
-// for tracing requests and reporting errors, using the
-// given tracer, or elasticapm.DefaultTracer if the tracer
-// is nil.
+// for tracing requests and reporting errors.
 //
 // This middleware will recover and report panics, so it can
 // be used instead of the gorilla/middleware.RecoveryHandler
 // middleware.
-func Middleware(t *elasticapm.Tracer) mux.MiddlewareFunc {
+//
+// By default, the middleware will use elasticapm.DefaultTracer.
+// Use WithTracer to specify an alternative tracer.
+func Middleware(o ...Option) mux.MiddlewareFunc {
+	opts := options{tracer: elasticapm.DefaultTracer}
+	for _, o := range o {
+		o(&opts)
+	}
 	return func(h http.Handler) http.Handler {
-		return &apmhttp.Handler{
-			Handler:     h,
-			Recovery:    apmhttp.NewTraceRecovery(t),
-			RequestName: routeRequestName,
-			Tracer:      t,
-		}
+		return apmhttp.Wrap(
+			h,
+			apmhttp.WithTracer(opts.tracer),
+			apmhttp.WithRequestName(routeRequestName),
+		)
 	}
 }
 
@@ -37,4 +41,22 @@ func routeRequestName(req *http.Request) string {
 		}
 	}
 	return apmhttp.RequestName(req)
+}
+
+type options struct {
+	tracer *elasticapm.Tracer
+}
+
+// Option sets options for tracing.
+type Option func(*options)
+
+// WithTracer returns an Option which sets t as the tracer
+// to use for tracing server requests.
+func WithTracer(t *elasticapm.Tracer) Option {
+	if t == nil {
+		panic("t == nil")
+	}
+	return func(o *options) {
+		o.tracer = t
+	}
 }

--- a/module/apmgorilla/middleware_test.go
+++ b/module/apmgorilla/middleware_test.go
@@ -19,7 +19,7 @@ func TestMuxMiddleware(t *testing.T) {
 	defer tracer.Close()
 
 	r := mux.NewRouter()
-	r.Use(apmgorilla.Middleware(tracer))
+	r.Use(apmgorilla.Middleware(apmgorilla.WithTracer(tracer)))
 	sub := r.PathPrefix("/prefix").Subrouter()
 	sub.Path("/articles/{category}/{id:[0-9]+}").Handler(http.HandlerFunc(articleHandler))
 

--- a/module/apmhttp/handler_bench_test.go
+++ b/module/apmhttp/handler_bench_test.go
@@ -27,11 +27,7 @@ func BenchmarkWithMiddleware(b *testing.B) {
 	tracer := newTracer()
 	defer tracer.Close()
 	wrapHandler := func(in http.Handler) http.Handler {
-		return &apmhttp.Handler{
-			Handler:  in,
-			Recovery: apmhttp.NewTraceRecovery(tracer),
-			Tracer:   tracer,
-		}
+		return apmhttp.Wrap(in, apmhttp.WithTracer(tracer))
 	}
 	for _, path := range benchmarkPaths {
 		b.Run(path, func(b *testing.B) {

--- a/module/apmhttp/recovery.go
+++ b/module/apmhttp/recovery.go
@@ -6,10 +6,16 @@ import (
 	"github.com/elastic/apm-agent-go"
 )
 
-// RecoveryFunc is the type of a function for use in Handler.Recovery.
-type RecoveryFunc func(w http.ResponseWriter, req *http.Request, body *elasticapm.BodyCapturer, tx *elasticapm.Transaction, recovered interface{})
+// RecoveryFunc is the type of a function for use in WithRecovery.
+type RecoveryFunc func(
+	w http.ResponseWriter,
+	req *http.Request,
+	body *elasticapm.BodyCapturer,
+	tx *elasticapm.Transaction,
+	recovered interface{},
+)
 
-// NewTraceRecovery returns a RecoveryFunc for use in Handler.Recovery.
+// NewTraceRecovery returns a RecoveryFunc for use in WithRecovery.
 //
 // The returned RecoveryFunc will report recovered error to Elastic APM
 // using the given Tracer, or elasticapm.DefaultTracer if t is nil. The
@@ -18,7 +24,13 @@ func NewTraceRecovery(t *elasticapm.Tracer) RecoveryFunc {
 	if t == nil {
 		t = elasticapm.DefaultTracer
 	}
-	return func(w http.ResponseWriter, req *http.Request, body *elasticapm.BodyCapturer, tx *elasticapm.Transaction, recovered interface{}) {
+	return func(
+		w http.ResponseWriter,
+		req *http.Request,
+		body *elasticapm.BodyCapturer,
+		tx *elasticapm.Transaction,
+		recovered interface{},
+	) {
 		e := t.Recovered(recovered, tx)
 		e.Context.SetHTTPRequest(req)
 		e.Context.SetHTTPRequestBody(body)

--- a/sanitizer_test.go
+++ b/sanitizer_test.go
@@ -21,10 +21,7 @@ func TestSanitizeRequest(t *testing.T) {
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusTeapot)
 	}))
-	h := &apmhttp.Handler{
-		Handler: mux,
-		Tracer:  tracer,
-	}
+	h := apmhttp.Wrap(mux, apmhttp.WithTracer(tracer))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "http://server.testing/", nil)
@@ -78,10 +75,7 @@ func testSetSanitizedFieldNames(t *testing.T, expect string, sanitized ...string
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusTeapot)
 	}))
-	h := &apmhttp.Handler{
-		Handler: mux,
-		Tracer:  tracer,
-	}
+	h := apmhttp.Wrap(mux, apmhttp.WithTracer(tracer))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "http://server.testing/", nil)


### PR DESCRIPTION
All modules are updated to use functional options
where we provide a Wrap or Middleware method. The
end result is that none of the modules require
passing in a nil Tracer to use the default.

Also:

- apmhttp now recovers panics by default
- apmhttprouter's WrapHandler is now called Wrap

Closes #77 