### PR TITLE
Support ELASTIC_APM_ACTIVE

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -93,6 +93,19 @@ of the deployed revision, e.g. the output of `git rev-parse HEAD`.
 The name of the environment this service is deployed in, e.g. "production" or "staging".
 
 [float]
+[[config-active]]
+=== `ELASTIC_APM_ACTIVE`
+
+[options="header"]
+|============
+| Environment          | Default | Example
+| `ELASTIC_APM_ACTIVE` | true    | `false`
+|============
+
+Enable or disable the tracer. If set to false, then the Go agent does not send
+any data to the Elastic APM server, and instrumentation overhead is minimized.
+
+[float]
 [[config-transactions-ignore-patterns]]
 ==== `ELASTIC_APM_TRANSACTIONS_IGNORE_NAMES`
 [options="header"]

--- a/env.go
+++ b/env.go
@@ -26,6 +26,7 @@ const (
 	envServiceVersion         = "ELASTIC_APM_SERVICE_VERSION"
 	envEnvironment            = "ELASTIC_APM_ENVIRONMENT"
 	envSpanFramesMinDuration  = "ELASTIC_APM_SPAN_FRAMES_MIN_DURATION"
+	envActive                 = "ELASTIC_APM_ACTIVE"
 
 	defaultFlushInterval           = 10 * time.Second
 	defaultMaxTransactionQueueSize = 500
@@ -182,4 +183,16 @@ func initialSpanFramesMinDuration() (time.Duration, error) {
 		return 0, errors.Wrapf(err, "failed to parse %s", envSpanFramesMinDuration)
 	}
 	return d, nil
+}
+
+func initialActive() (bool, error) {
+	value := os.Getenv(envActive)
+	if value == "" {
+		return true, nil
+	}
+	active, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse %s", envActive)
+	}
+	return active, nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -284,3 +284,26 @@ func TestTracerSpanFramesMinDurationEnvInvalid(t *testing.T) {
 	_, err := elasticapm.NewTracer("tracer_testing", "")
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_SPAN_FRAMES_MIN_DURATION: time: invalid duration aeon")
 }
+
+func TestTracerActive(t *testing.T) {
+	os.Setenv("ELASTIC_APM_ACTIVE", "false")
+	defer os.Unsetenv("ELASTIC_APM_ACTIVE")
+
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+	assert.False(t, tracer.Active())
+
+	tx := tracer.StartTransaction("name", "type")
+	tx.Done(-1)
+
+	tracer.Flush(nil)
+	assert.Empty(t, transport.Payloads())
+}
+
+func TestTracerActiveInvalid(t *testing.T) {
+	os.Setenv("ELASTIC_APM_ACTIVE", "yep")
+	defer os.Unsetenv("ELASTIC_APM_ACTIVE")
+
+	_, err := elasticapm.NewTracer("tracer_testing", "")
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_ACTIVE: strconv.ParseBool: parsing \"yep\": invalid syntax")
+}

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -35,6 +35,9 @@ type middleware struct {
 }
 
 func (m *middleware) handle(c echo.Context) error {
+	if !m.tracer.Active() {
+		return m.handler(c)
+	}
 	req := c.Request()
 	name := req.Method + " " + c.Path()
 	tx := m.tracer.StartTransaction(name, "request")

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -47,6 +47,10 @@ type routeInfo struct {
 }
 
 func (m *middleware) handle(c *gin.Context) {
+	if !m.tracer.Active() {
+		c.Next()
+		return
+	}
 	m.setRouteMapOnce.Do(func() {
 		routes := m.engine.Routes()
 		rm := make(map[string]map[string]routeInfo)

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -34,6 +34,9 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
+		if !opts.tracer.Active() {
+			return handler(ctx, req)
+		}
 		tx := opts.tracer.StartTransaction(info.FullMethod, "grpc")
 		if tx.Ignored() {
 			tx.Discard()

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -29,6 +29,10 @@ func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 		opts.recovery = apmhttp.NewTraceRecovery(opts.tracer)
 	}
 	return func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+		if !opts.tracer.Active() {
+			h(w, req, p)
+			return
+		}
 		tx := opts.tracer.StartTransaction(req.Method+" "+route, "request")
 		if tx.Ignored() {
 			tx.Discard()


### PR DESCRIPTION
If the tracer is inactive, then no transactons or errors will
be sent to the server; the tracer goroutine is never started.
The tracer grows an "Active() bool" method, which modules can
use to check if they should bail early.

Also, add a "RequestIgnorer" option to apmhttp, so clients can
programatically ignore certain requests.

Closes #86 