### PR TITLE
 module/...: introduce apmhttp.RequestWithContext

### DIFF
--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -47,7 +47,7 @@ func (m *middleware) handle(c echo.Context) error {
 	}
 
 	ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
-	req = req.WithContext(ctx)
+	req = apmhttp.RequestWithContext(ctx, req)
 	c.SetRequest(req)
 	defer tx.Done(-1)
 	body := m.tracer.CaptureHTTPRequestBody(req)

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -80,7 +80,7 @@ func (m *middleware) handle(c *gin.Context) {
 	}
 
 	ctx := elasticapm.ContextWithTransaction(c.Request.Context(), tx)
-	c.Request = c.Request.WithContext(ctx)
+	c.Request = apmhttp.RequestWithContext(ctx, c.Request)
 	defer tx.Done(-1)
 
 	body := m.tracer.CaptureHTTPRequestBody(c.Request)

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -41,7 +41,7 @@ func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 		}
 
 		ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
-		req = req.WithContext(ctx)
+		req = apmhttp.RequestWithContext(ctx, req)
 		defer tx.Done(-1)
 
 		finished := false
@@ -52,7 +52,7 @@ func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 				opts.recovery(w, req, body, tx, v)
 				finished = true
 			}
-			apmhttp.SetTransactionContext(tx, w, req, resp, body, finished)
+			apmhttp.SetTransactionContext(tx, req, resp, body, finished)
 		}()
 		h(w, req, p)
 		finished = true

--- a/transport/http.go
+++ b/transport/http.go
@@ -118,7 +118,7 @@ func (t *HTTPTransport) SendTransactions(ctx context.Context, p *model.Transacti
 	p.MarshalFastJSON(&t.jsonwriter)
 	buf := t.jsonwriter.Bytes()
 
-	req := t.newTransactionsRequest().WithContext(ctx)
+	req := requestWithContext(ctx, t.newTransactionsRequest())
 	req.ContentLength = int64(len(buf))
 	req.Body = ioutil.NopCloser(bytes.NewReader(buf))
 	return t.send(req, "SendTransactions")
@@ -130,7 +130,7 @@ func (t *HTTPTransport) SendErrors(ctx context.Context, p *model.ErrorsPayload) 
 	p.MarshalFastJSON(&t.jsonwriter)
 	buf := t.jsonwriter.Bytes()
 
-	req := t.newErrorsRequest().WithContext(ctx)
+	req := requestWithContext(ctx, t.newErrorsRequest())
 	req.ContentLength = int64(len(buf))
 	req.Body = ioutil.NopCloser(bytes.NewReader(buf))
 	return t.send(req, "SendErrors")
@@ -205,4 +205,13 @@ func (e *HTTPError) Error() string {
 		msg += ": " + e.Message
 	}
 	return msg
+}
+
+func requestWithContext(ctx context.Context, req *http.Request) *http.Request {
+	url := req.URL
+	req.URL = nil
+	reqCopy := req.WithContext(ctx)
+	reqCopy.URL = url
+	req.URL = url
+	return reqCopy
 }


### PR DESCRIPTION
net/http.Request.WithContext has an unfortunate code
path which copies the *net.URL within the request,
which causes an allocation. We don't need (or want)
this behaviour, we just want to set the new context.
To avoid the allocation we introduce a new function
apmhttp.RequestWithContext, which avoids the copy by
clearing the request's URL during the WithContext
call.

Also, apmhttp.SetTransactionContext has been updated
slightly to drop the ResponseWriter parameter. The
Response type grows a Headers field, which is used
instead.