### PR TITLE
stacktrace: vendored packages are libraries

### DIFF
--- a/stacktrace/generate_library.bash
+++ b/stacktrace/generate_library.bash
@@ -46,10 +46,16 @@ func RegisterApplicationPackage(pkg ...string) {
 }
 
 // IsLibraryPackage reports whether or not the given package path is
-// a well-known library path (stdlib or apm-agent-go).
+// a library package. This includes known library packages
+// (e.g. stdlib or apm-agent-go), vendored packages, and any packages
+// with a prefix registered with RegisterLibraryPackage but not
+// RegisterApplicationPackage.
 func IsLibraryPackage(pkg string) bool {
 	if strings.HasSuffix(pkg, "_test") {
 		return false
+	}
+	if strings.Contains(pkg, "/vendor/") {
+		return true
 	}
 	prefix, v, ok := libraryPackages.LongestPrefix(pkg)
 	if !ok || v == false {

--- a/stacktrace/library.go
+++ b/stacktrace/library.go
@@ -224,10 +224,16 @@ func RegisterApplicationPackage(pkg ...string) {
 }
 
 // IsLibraryPackage reports whether or not the given package path is
-// a well-known library path (stdlib or apm-agent-go).
+// a library package. This includes known library packages
+// (e.g. stdlib or apm-agent-go), vendored packages, and any packages
+// with a prefix registered with RegisterLibraryPackage but not
+// RegisterApplicationPackage.
 func IsLibraryPackage(pkg string) bool {
 	if strings.HasSuffix(pkg, "_test") {
 		return false
+	}
+	if strings.Contains(pkg, "/vendor/") {
+		return true
 	}
 	prefix, v, ok := libraryPackages.LongestPrefix(pkg)
 	if !ok || v == false {

--- a/stacktrace/library_test.go
+++ b/stacktrace/library_test.go
@@ -21,4 +21,6 @@ func TestLibraryPackage(t *testing.T) {
 	assert.True(t, stacktrace.IsLibraryPackage("encoding/jsonzzz"))
 	assert.False(t, stacktrace.IsLibraryPackage("encoding/jsonzzz/yyy"))
 	assert.False(t, stacktrace.IsLibraryPackage("encoding/jsonzzz/yyy/xxx"))
+
+	assert.True(t, stacktrace.IsLibraryPackage("github.com/elastic/apm-server/vendor/github.com/elastic/apm-agent-go"))
 }


### PR DESCRIPTION
When classifying packages, always consider packages whose paths contain "/vendor/" to be libraries.

Closes #89 