### PR TITLE
module/apmhttp: rename Option to ServerOption

### DIFF
--- a/module/apmgorilla/middleware.go
+++ b/module/apmgorilla/middleware.go
@@ -27,7 +27,7 @@ func Middleware(o ...Option) mux.MiddlewareFunc {
 		return apmhttp.Wrap(
 			h,
 			apmhttp.WithTracer(opts.tracer),
-			apmhttp.WithRequestName(routeRequestName),
+			apmhttp.WithServerRequestName(routeRequestName),
 		)
 	}
 }
@@ -40,7 +40,7 @@ func routeRequestName(req *http.Request) string {
 			return req.Method + " " + massageTemplate(tpl)
 		}
 	}
-	return apmhttp.RequestName(req)
+	return apmhttp.ServerRequestName(req)
 }
 
 type options struct {

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -16,14 +16,14 @@ import (
 // By default, the returned Handler will recover panics, reporting
 // them to the configured tracer. To override this behaviour, use
 // WithRecovery.
-func Wrap(h http.Handler, o ...Option) http.Handler {
+func Wrap(h http.Handler, o ...ServerOption) http.Handler {
 	if h == nil {
 		panic("h == nil")
 	}
 	handler := &handler{
 		handler:        h,
 		tracer:         elasticapm.DefaultTracer,
-		requestName:    RequestName,
+		requestName:    ServerRequestName,
 		requestIgnorer: ignoreNone,
 	}
 	for _, o := range o {
@@ -221,12 +221,12 @@ func ignoreNone(*http.Request) bool {
 	return false
 }
 
-// Option sets options for tracing.
-type Option func(*handler)
+// ServerOption sets options for tracing server requests.
+type ServerOption func(*handler)
 
-// WithTracer returns an Option which sets t as the tracer
+// WithTracer returns a ServerOption which sets t as the tracer
 // to use for tracing server requests.
-func WithTracer(t *elasticapm.Tracer) Option {
+func WithTracer(t *elasticapm.Tracer) ServerOption {
 	if t == nil {
 		panic("t == nil")
 	}
@@ -235,9 +235,9 @@ func WithTracer(t *elasticapm.Tracer) Option {
 	}
 }
 
-// WithRecovery returns an Option which sets r as the recovery
+// WithRecovery returns a ServerOption which sets r as the recovery
 // function to use for tracing server requests.
-func WithRecovery(r RecoveryFunc) Option {
+func WithRecovery(r RecoveryFunc) ServerOption {
 	if r == nil {
 		panic("r == nil")
 	}
@@ -246,12 +246,13 @@ func WithRecovery(r RecoveryFunc) Option {
 	}
 }
 
-// RequestNameFunc is the type of a function for use in WithRequestName.
+// RequestNameFunc is the type of a function for use in
+// WithServerRequestName.
 type RequestNameFunc func(*http.Request) string
 
-// WithRequestName returns an Option which sets r as the function
-// to use to obtain the transaction name for the given request.
-func WithRequestName(r RequestNameFunc) Option {
+// WithServerRequestName returns a ServerOption which sets r as the function
+// to use to obtain the transaction name for the given server request.
+func WithServerRequestName(r RequestNameFunc) ServerOption {
 	if r == nil {
 		panic("r == nil")
 	}
@@ -260,14 +261,15 @@ func WithRequestName(r RequestNameFunc) Option {
 	}
 }
 
-// RequestIgnorerFunc is the type of a function for use in WithRequestIgnorer.
+// RequestIgnorerFunc is the type of a function for use in
+// WithServerRequestIgnorer.
 type RequestIgnorerFunc func(*http.Request) bool
 
-// WithRequestIgnorer returns an Option which sets r as the
-// function to use to determine whether or not a request should
-// be ignored./ This is in addition to standard tracer
-// configuration, e.g. ELASTIC_APM_TRANSACTION_IGNORE_NAMES.
-func WithRequestIgnorer(r RequestIgnorerFunc) Option {
+// WithServerRequestIgnorer returns a ServerOption which sets r as the
+// function to use to determine whether or not a server request should
+// be ignored. This is in addition to standard tracer configuration,
+// e.g. ELASTIC_APM_TRANSACTION_IGNORE_NAMES.
+func WithServerRequestIgnorer(r RequestIgnorerFunc) ServerOption {
 	if r == nil {
 		panic("r == nil")
 	}

--- a/module/apmhttp/handler_test.go
+++ b/module/apmhttp/handler_test.go
@@ -245,7 +245,7 @@ func TestHandlerRequestIgnorer(t *testing.T) {
 	h := apmhttp.Wrap(
 		http.NotFoundHandler(),
 		apmhttp.WithTracer(tracer),
-		apmhttp.WithRequestIgnorer(func(*http.Request) bool {
+		apmhttp.WithServerRequestIgnorer(func(*http.Request) bool {
 			return true
 		}),
 	)

--- a/module/apmhttp/requestname.go
+++ b/module/apmhttp/requestname.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// RequestName returns the transaction name for req.
-func RequestName(req *http.Request) string {
+// ServerRequestName returns the transaction name for the server request, req.
+func ServerRequestName(req *http.Request) string {
 	var b strings.Builder
 	b.Grow(len(req.Method) + len(req.URL.Path) + 1)
 	b.WriteString(req.Method)

--- a/module/apmhttp/requestname_go19.go
+++ b/module/apmhttp/requestname_go19.go
@@ -4,8 +4,8 @@ package apmhttp
 
 import "net/http"
 
-// RequestName returns the transaction name for req.
-func RequestName(req *http.Request) string {
+// ServerRequestName returns the transaction name for the server request, req.
+func ServerRequestName(req *http.Request) string {
 	buf := make([]byte, len(req.Method)+len(req.URL.Path)+1)
 	n := copy(buf, req.Method)
 	buf[n] = ' '


### PR DESCRIPTION
(And other similar renamings.)

This is in preparation for https://github.com/elastic/apm-agent-go/issues/98, which will involve introducing client-side span tracing options.