### PR TITLE
module/apmhttp: introduce client span tracing

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -148,6 +148,29 @@ func main() {
 
 The apmhttp handler will recover panics and send them to Elastic APM.
 
+Package apmhttp also provides functions for instrumenting an `http.Client` or `http.RoundTripper`
+such that outgoing requests are traced as spans, if the request context includes a transaction.
+
+[source,go]
+----
+import (
+	"net/http"
+	"golang.org/x/net/context/ctxhttp"
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+)
+
+var tracingClient = apmhttp.WrapClient(http.DefaultClient)
+
+func serverHandler(w http.ResponseWriter, req *http.Request) {
+	resp, err := ctxhttp.Get(req.Context(), tracingClient, "http://backend.local/foo")
+	...
+}
+
+func main() {
+	http.ListenAndServe(":8080", apmhttp.Wrap(serverHandler))
+}
+----
+
 ===== module/apmhttprouter
 Package apmhttprouter provides a low-level middleware handler for https://github.com/julienschmidt/httprouter[httprouter].
 

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -1,0 +1,73 @@
+package apmhttp
+
+import (
+	"net/http"
+
+	"github.com/elastic/apm-agent-go"
+)
+
+// WrapClient returns a new *http.Client with all fields copied
+// across, and the Transport field wrapped with WrapRoundTripper
+// such that client requests are reported as spans to Elastic APM
+// if their context contains a sampled transaction.
+//
+// If c is nil, then http.DefaultClient is wrapped.
+func WrapClient(c *http.Client, o ...ClientOption) *http.Client {
+	if c == nil {
+		c = http.DefaultClient
+	}
+	copied := *c
+	copied.Transport = WrapRoundTripper(copied.Transport, o...)
+	return &copied
+}
+
+// WrapRoundTripper returns an http.RoundTripper wrapping r, reporting each
+// request as a span to Elastic APM, if the request's context contains a
+// sampled transaction.
+//
+// If r is nil, then http.DefaultTransport is wrapped.
+func WrapRoundTripper(r http.RoundTripper, o ...ClientOption) http.RoundTripper {
+	if r == nil {
+		r = http.DefaultTransport
+	}
+	rt := &roundTripper{
+		r:              r,
+		requestName:    ClientRequestName,
+		requestIgnorer: ignoreNone,
+	}
+	for _, o := range o {
+		o(rt)
+	}
+	return rt
+}
+
+type roundTripper struct {
+	r              http.RoundTripper
+	requestName    RequestNameFunc
+	requestIgnorer RequestIgnorerFunc
+}
+
+// RoundTrip delegates to r.r, emitting a span if req's context
+// contains a transaction.
+func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.requestIgnorer(req) {
+		return r.r.RoundTrip(req)
+	}
+	ctx := req.Context()
+	tx := elasticapm.TransactionFromContext(ctx)
+	if tx == nil || !tx.Sampled() {
+		return r.r.RoundTrip(req)
+	}
+
+	name := r.requestName(req)
+	spanType := "ext.http"
+	span := tx.StartSpan(name, spanType, elasticapm.SpanFromContext(ctx))
+	defer span.Done(-1)
+
+	ctx = elasticapm.ContextWithSpan(ctx, span)
+	req = RequestWithContext(ctx, req)
+	return r.r.RoundTrip(req)
+}
+
+// ClientOption sets options for tracing client requests.
+type ClientOption func(*roundTripper)

--- a/module/apmhttp/client_bench_test.go
+++ b/module/apmhttp/client_bench_test.go
@@ -1,0 +1,47 @@
+package apmhttp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+)
+
+func BenchmarkClient(b *testing.B) {
+	b.Run("baseline", func(b *testing.B) {
+		benchmarkClient(b, func(c *http.Client) *http.Client {
+			return c
+		})
+	})
+	b.Run("wrapped", func(b *testing.B) {
+		benchmarkClient(b, func(c *http.Client) *http.Client {
+			return apmhttp.WrapClient(c)
+		})
+	})
+}
+
+func benchmarkClient(b *testing.B, wrap func(*http.Client) *http.Client) {
+	server := httptest.NewServer(testMux())
+	defer server.Close()
+	for _, path := range benchmarkPaths {
+		b.Run(path, func(b *testing.B) {
+			tracer := newTracer()
+			defer tracer.Close()
+			tx := tracer.StartTransaction("name", "type")
+			ctx := elasticapm.ContextWithTransaction(context.Background(), tx)
+			client := wrap(nil)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resp, err := ctxhttp.Get(ctx, client, server.URL+path)
+				require.NoError(b, err)
+				resp.Body.Close()
+			}
+		})
+	}
+}

--- a/module/apmhttp/client_test.go
+++ b/module/apmhttp/client_test.go
@@ -1,0 +1,51 @@
+package apmhttp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestClient(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	mux := http.NewServeMux()
+	mux.Handle("/foo", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		w.Write([]byte("bar"))
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	tx := tracer.StartTransaction("name", "type")
+	ctx := elasticapm.ContextWithTransaction(context.Background(), tx)
+	client := apmhttp.WrapClient(http.DefaultClient)
+	resp, err := ctxhttp.Get(ctx, client, server.URL+"/foo")
+	assert.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusTeapot, resp.StatusCode)
+	tx.Done(-1)
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	require.Len(t, payloads, 1)
+	transactions := payloads[0].Transactions()
+	require.Len(t, transactions, 1)
+	transaction := transactions[0]
+	require.Len(t, transaction.Spans, 1)
+
+	span := transaction.Spans[0]
+	assert.Equal(t, "GET "+server.Listener.Addr().String(), span.Name)
+	assert.Equal(t, "ext.http", span.Type)
+	assert.Nil(t, span.Context)
+}

--- a/module/apmhttp/doc.go
+++ b/module/apmhttp/doc.go
@@ -1,4 +1,3 @@
-// Package apmhttp provides the Handler middleware for
-// tracing HTTP requests, and functions for extracting
-// transaction context from HTTP requests.
+// Package apmhttp provides a tracing middleware http.Handler for
+// servers, and a tracing http.RoundTripper for clients.
 package apmhttp

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -7,8 +7,8 @@ import (
 	"github.com/elastic/apm-agent-go"
 )
 
-// Wrap returns a Handler wrapping h, reporting each request as a
-// transaction to Elastic APM.
+// Wrap returns an http.Handler wrapping h, reporting each request as
+// a transaction to Elastic APM.
 //
 // By default, the returned Handler will use elasticapm.DefaultTracer.
 // Use WithTracer to specify an alternative tracer.

--- a/module/apmhttp/handler_bench_test.go
+++ b/module/apmhttp/handler_bench_test.go
@@ -15,15 +15,15 @@ import (
 
 var benchmarkPaths = []string{"/hello/world", "/sleep/1ms"}
 
-func BenchmarkWithoutMiddleware(b *testing.B) {
+func BenchmarkHandlerWithoutMiddleware(b *testing.B) {
 	for _, path := range benchmarkPaths {
 		b.Run(path, func(b *testing.B) {
-			benchmark(b, path, nil)
+			benchmarkHandler(b, path, nil)
 		})
 	}
 }
 
-func BenchmarkWithMiddleware(b *testing.B) {
+func BenchmarkHandlerWithMiddleware(b *testing.B) {
 	tracer := newTracer()
 	defer tracer.Close()
 	wrapHandler := func(in http.Handler) http.Handler {
@@ -31,12 +31,12 @@ func BenchmarkWithMiddleware(b *testing.B) {
 	}
 	for _, path := range benchmarkPaths {
 		b.Run(path, func(b *testing.B) {
-			benchmark(b, path, wrapHandler)
+			benchmarkHandler(b, path, wrapHandler)
 		})
 	}
 }
 
-func benchmark(b *testing.B, path string, wrapHandler func(http.Handler) http.Handler) {
+func benchmarkHandler(b *testing.B, path string, wrapHandler func(http.Handler) http.Handler) {
 	w := httptest.NewRecorder()
 	h := testMux()
 	if wrapHandler != nil {

--- a/module/apmhttp/requestname.go
+++ b/module/apmhttp/requestname.go
@@ -16,3 +16,13 @@ func ServerRequestName(req *http.Request) string {
 	b.WriteString(req.URL.Path)
 	return b.String()
 }
+
+// ClientRequestName returns the span name for the client request, req.
+func ClientRequestName(req *http.Request) string {
+	var b strings.Builder
+	b.Grow(len(req.Method) + len(req.URL.Host) + 1)
+	b.WriteString(req.Method)
+	b.WriteByte(' ')
+	b.WriteString(req.URL.Host)
+	return b.String()
+}

--- a/module/apmhttp/requestname_go19.go
+++ b/module/apmhttp/requestname_go19.go
@@ -12,3 +12,12 @@ func ServerRequestName(req *http.Request) string {
 	copy(buf[n+1:], req.URL.Path)
 	return string(buf)
 }
+
+// ClientRequestName returns the span name for the client request, req.
+func ClientRequestName(req *http.Request) string {
+	buf := make([]byte, len(req.Method)+len(req.URL.Host)+1)
+	n := copy(buf, req.Method)
+	buf[n] = ' '
+	copy(buf[n+1:], req.URL.Host)
+	return string(buf)
+}


### PR DESCRIPTION
Introduce WrapClient and WrapRoundTripper,
which create spans for client-side requests.
Spans are created only if the request context
contains a transaction.

Closes #98 