### PR TITLE
elasticapm: Done->End, Span.Start->Timestamp

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -69,18 +69,20 @@ transaction.Context.SetCustom("key", "value")
 See <<context-api>> for more details on setting transaction context.
 
 [float]
-[[transaction-done]]
-==== `func (*Transaction) Done(time.Duration)`
+[[transaction-end]]
+==== `func (*Transaction) End()`
 
-Done sets the transaction's duration to the specified value, and enqueues it for
-sending to the Elastic APM server. The Transaction must not be used after this.
+End enqueues the transaction for sending to the Elastic APM server.
+The Transaction must not be used after this.
 
-If the duration specified is negative, then Done will set the duration to
-"time.Since(tx.Timestamp)" instead.
+The transaction's duration will be calculated as the amount of time
+elapsed since the transaction was started until this call. To override
+this behaviour, the transaction's Duration field may be set before
+calling End.
 
 [source,go]
 ----
-transaction.Done(-1)
+transaction.End()
 ----
 
 // -------------------------------------------------------------------------------------------------
@@ -104,7 +106,7 @@ to the transaction's timestamp.
 
 If the transaction is sampled, then the span's ID will be set, and its stacktrace will
 be set if the tracer is configured accordingly. If the transaction is not sampled, then
-the returned span will be silently discarded when its Done method is called. You can
+the returned span will be silently discarded when its End method is called. You can
 avoid any unnecessary computation for these dropped spans by calling its <<span-dropped, Dropped>>
 method.
 
@@ -130,13 +132,14 @@ span, ctx := elasticapm.StartSpan(ctx, "SELECT FROM foo", "db.mysql.query")
 ----
 
 [float]
-[[span-done]]
-==== `func (*Span) Done(time.Duration)`
+[[span-end]]
+==== `func (*Span) End()`
 
-Done sets the span's duration to the specified value. The Span must not be used after this.
+End marks the span as complete; it must not be used after this.
 
-If the duration specified is negative, then Done will set the duration to the amount of
-wall-clock time that has elapsed since the span was started.
+The span's duration will be calculated as the amount of time elapsed
+since the span was started until this call. To override this behaviour,
+the span's Duration field may be set before calling End.
 
 [float]
 [[span-dropped]]
@@ -300,7 +303,7 @@ transaction provided to Recover, and calls the resulting Error's Send method.
 [source,go]
 ----
 tx := elasticapm.DefaultTracer.StartTransaction(...)
-defer tx.Done(-1)
+defer tx.End()
 defer elasticapm.DefaultTracer.Recover(tx)
 ----
 
@@ -315,7 +318,7 @@ and then call its `Send` method.
 [source,go]
 ----
 tx := elasticapm.DefaultTracer.StartTransaction(...)
-defer tx.Done(-1)
+defer tx.End()
 defer elasticapm.DefaultTracer.Recover(tx)
 ----
 
@@ -349,7 +352,7 @@ an active Transaction object:
 [source,go]
 ----
 tx := elasticapm.DefaultTracer.StartTransaction("GET /foo", "request")
-defer tx.Done(-1)
+defer tx.End()
 e := elasticapm.DefaultTracer.NewError(err)
 e.Transaction = tx
 e.Send()

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -268,14 +268,14 @@ for a more thorough description of the types and methods.
 
 To report a transaction, you call <<tracer-api-start-transaction, elasticapm.DefaultTracer.StartTransaction>>
 with the transaction name and type. This returns a `Transaction` object; the transaction
-can be customized with additional context before you call its `Done` method to indicate
-that the transaction has completed. Once the transaction's `Done` method is called, it
+can be customized with additional context before you call its `End` method to indicate
+that the transaction has completed. Once the transaction's `End` method is called, it
 will be enqueued for sending to the Elastic APM server, and made available to the APM UI.
 
 [source,go]
 ----
 tx := elasticapm.DefaultTracer.StartTransaction("GET /api/v1", "request")
-defer tx.Done(-1)
+defer tx.End()
 ...
 tx.Result = "HTTP 2xx"
 tx.Context.SetTag("region", "us-east-1")
@@ -307,11 +307,11 @@ contains a span, then that will be considered the parent.
 [source,go]
 ----
 span, ctx := elasticapm.StartSpan(ctx, "SELECT FROM foo", "db.mysql.query")
-defer span.Done(-1)
+defer span.End()
 ----
 
 `Transaction.StartSpan` and `elasticapm.StartSpan` will always return a non-nil `Span`, even if the
-transaction is nil. It is always safe to defer a call to the span's Done method. If setting the span's
+transaction is nil. It is always safe to defer a call to the span's End method. If setting the span's
 context would incur significant overhead, you may want to check if the span is dropped first, by calling
 the `Span.Dropped` method.
 

--- a/error.go
+++ b/error.go
@@ -150,7 +150,7 @@ type Error struct {
 
 	// Transaction is the transaction to which the error correspoonds,
 	// if any. If this is set, the error's Send method must be called
-	// before the transaction's Done method.
+	// before the transaction's End method.
 	Transaction *Transaction
 
 	// Timestamp records the time at which the error occurred.

--- a/example_test.go
+++ b/example_test.go
@@ -108,7 +108,7 @@ type api struct {
 
 func (api *api) handleOrder(ctx context.Context, product string) {
 	tx := api.tracer.StartTransaction("order", "request")
-	defer tx.Done(-1)
+	defer tx.End()
 	ctx = elasticapm.ContextWithTransaction(ctx, tx)
 
 	tx.Context.SetCustom("product", product)
@@ -120,7 +120,7 @@ func (api *api) handleOrder(ctx context.Context, product string) {
 
 func storeOrder(ctx context.Context, product string) {
 	span, _ := elasticapm.StartSpan(ctx, "store_order", "rpc")
-	defer span.Done(-1)
+	defer span.End()
 
 	time.Sleep(50 * time.Millisecond)
 }

--- a/gocontext.go
+++ b/gocontext.go
@@ -34,7 +34,7 @@ func TransactionFromContext(ctx context.Context) *Transaction {
 // and parent span in the context, if any. If the span isn't dropped, it
 // will be stored in the resulting context.
 //
-// StartSpan always returns a non-nil Span. Its Done method must be called
+// StartSpan always returns a non-nil Span. Its End method must be called
 // when the span completes.
 func StartSpan(ctx context.Context, name, spanType string) (*Span, context.Context) {
 	tx := TransactionFromContext(ctx)

--- a/gofuzz.go
+++ b/gofuzz.go
@@ -133,7 +133,7 @@ func Fuzz(data []byte) int {
 				continue
 			}
 			span := tx.StartSpan(s.Name, s.Type, nil)
-			span.Start = tx.Timestamp.Add(time.Duration(s.Start * float64(time.Millisecond)))
+			span.Timestamp = tx.Timestamp.Add(time.Duration(s.Start * float64(time.Millisecond)))
 			if s.Context != nil && s.Context.Database != nil {
 				span.Context.SetDatabase(DatabaseSpanContext{
 					Instance:  s.Context.Database.Instance,
@@ -142,9 +142,11 @@ func Fuzz(data []byte) int {
 					User:      s.Context.Database.User,
 				})
 			}
-			span.Done(time.Duration(s.Duration * float64(time.Millisecond)))
+			span.Duration = time.Duration(s.Duration * float64(time.Millisecond))
+			span.End()
 		}
-		tx.Done(time.Duration(t.Duration * float64(time.Millisecond)))
+		tx.Duration = time.Duration(t.Duration * float64(time.Millisecond))
+		tx.End()
 	}
 
 	for _, e := range payload.Errors {

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -49,7 +49,7 @@ func (m *middleware) handle(c echo.Context) error {
 	ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 	req = apmhttp.RequestWithContext(ctx, req)
 	c.SetRequest(req)
-	defer tx.Done(-1)
+	defer tx.End()
 	body := m.tracer.CaptureHTTPRequestBody(req)
 
 	defer func() {

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -81,7 +81,7 @@ func (m *middleware) handle(c *gin.Context) {
 
 	ctx := elasticapm.ContextWithTransaction(c.Request.Context(), tx)
 	c.Request = apmhttp.RequestWithContext(ctx, c.Request)
-	defer tx.Done(-1)
+	defer tx.End()
 
 	body := m.tracer.CaptureHTTPRequestBody(c.Request)
 	ginContext := ginContext{Handler: handlerName}

--- a/module/apmgrpc/client.go
+++ b/module/apmgrpc/client.go
@@ -27,7 +27,7 @@ func NewUnaryClientInterceptor(o ...ClientOption) grpc.UnaryClientInterceptor {
 		opts ...grpc.CallOption,
 	) error {
 		span, ctx := elasticapm.StartSpan(ctx, method, "grpc")
-		defer span.Done(-1)
+		defer span.End()
 		return invoker(ctx, method, req, resp, cc, opts...)
 	}
 }

--- a/module/apmgrpc/client_test.go
+++ b/module/apmgrpc/client_test.go
@@ -34,7 +34,7 @@ func TestClientSpan(t *testing.T) {
 	resp, err = client.SayHello(ctx, &pb.HelloRequest{Name: "birita"})
 	require.NoError(t, err)
 	assert.Equal(t, resp, &pb.HelloReply{Message: "hello, birita"})
-	tx.Done(-1)
+	tx.End()
 
 	tracer.Flush(nil)
 	out := transport.Payloads()[0].Transactions()[0]

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -44,7 +44,7 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 		}
 
 		ctx = elasticapm.ContextWithTransaction(ctx, tx)
-		defer tx.Done(-1)
+		defer tx.End()
 
 		if tx.Sampled() {
 			p, ok := peer.FromContext(ctx)

--- a/module/apmgrpc/server_test.go
+++ b/module/apmgrpc/server_test.go
@@ -203,7 +203,7 @@ func (s *helloworldServer) SayHello(ctx context.Context, req *pb.HelloRequest) (
 	// The context passed to the server should contain a Transaction
 	// for the gRPC request.
 	span, ctx := elasticapm.StartSpan(ctx, "server_span", "type")
-	span.Done(-1)
+	span.End()
 	if s.panic {
 		panic(s.err)
 	}

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -62,7 +62,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	name := r.requestName(req)
 	spanType := "ext.http"
 	span := tx.StartSpan(name, spanType, elasticapm.SpanFromContext(ctx))
-	defer span.Done(-1)
+	defer span.End()
 
 	ctx = elasticapm.ContextWithSpan(ctx, span)
 	req = RequestWithContext(ctx, req)

--- a/module/apmhttp/client_test.go
+++ b/module/apmhttp/client_test.go
@@ -34,7 +34,7 @@ func TestClient(t *testing.T) {
 	assert.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusTeapot, resp.StatusCode)
-	tx.Done(-1)
+	tx.End()
 	tracer.Flush(nil)
 
 	payloads := transport.Payloads()

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -61,7 +61,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 	req = RequestWithContext(ctx, req)
-	defer tx.Done(-1)
+	defer tx.End()
 
 	finished := false
 	body := h.tracer.CaptureHTTPRequestBody(req)

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -42,7 +42,7 @@ func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 
 		ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 		req = apmhttp.RequestWithContext(ctx, req)
-		defer tx.Done(-1)
+		defer tx.End()
 
 		finished := false
 		body := opts.tracer.CaptureHTTPRequestBody(req)

--- a/module/apmlambda/lambda.go
+++ b/module/apmlambda/lambda.go
@@ -59,7 +59,7 @@ func (f *Function) Ping(req *messages.PingRequest, response *messages.PingRespon
 func (f *Function) Invoke(req *messages.InvokeRequest, response *messages.InvokeResponse) error {
 	tx := f.tracer.StartTransaction(lambdacontext.FunctionName, "function")
 	defer f.tracer.Flush(nonBlocking)
-	defer tx.Done(-1)
+	defer tx.End()
 	defer f.tracer.Recover(tx)
 	if tx.Sampled() {
 		tx.Context.SetCustom("lambda", &lambdaContext)

--- a/module/apmsql/apmsql_test.go
+++ b/module/apmsql/apmsql_test.go
@@ -141,7 +141,7 @@ func withTransaction(t *testing.T, f func(ctx context.Context)) *model.Transacti
 	ctx := elasticapm.ContextWithTransaction(context.Background(), tx)
 	f(ctx)
 
-	tx.Done(-1)
+	tx.End()
 	tracer.Flush(nil)
 	payloads := transport.Payloads()
 	require.Len(t, payloads, 1)

--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -66,7 +66,7 @@ func (c *conn) finishSpan(ctx context.Context, span *elasticapm.Span, resultErro
 		// in check.
 		return
 	}
-	span.Done(-1)
+	span.End()
 	if e := elasticapm.CaptureError(ctx, resultError); e != nil {
 		e.Send()
 	}

--- a/module/apmsql/driver_go110.go
+++ b/module/apmsql/driver_go110.go
@@ -31,7 +31,7 @@ type driverConnector struct {
 
 func (d *driverConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	span, ctx := elasticapm.StartSpan(ctx, "connect", d.driver.connectSpanType)
-	defer span.Done(-1)
+	defer span.End()
 	dsnInfo := d.driver.dsnParser(d.name)
 	if !span.Dropped() {
 		span.Context.SetDatabase(elasticapm.DatabaseSpanContext{

--- a/validation_test.go
+++ b/validation_test.go
@@ -39,13 +39,13 @@ func TestValidateServiceEnvironment(t *testing.T) {
 
 func TestValidateTransactionName(t *testing.T) {
 	validatePayloads(t, func(tracer *elasticapm.Tracer) {
-		tracer.StartTransaction(strings.Repeat("x", 1025), "type").Done(-1)
+		tracer.StartTransaction(strings.Repeat("x", 1025), "type").End()
 	})
 }
 
 func TestValidateTransactionType(t *testing.T) {
 	validatePayloads(t, func(tracer *elasticapm.Tracer) {
-		tracer.StartTransaction("name", strings.Repeat("x", 1025)).Done(-1)
+		tracer.StartTransaction("name", strings.Repeat("x", 1025)).End()
 	})
 }
 
@@ -53,19 +53,19 @@ func TestValidateTransactionResult(t *testing.T) {
 	validatePayloads(t, func(tracer *elasticapm.Tracer) {
 		tx := tracer.StartTransaction("name", "type")
 		tx.Result = strings.Repeat("x", 1025)
-		tx.Done(-1)
+		tx.End()
 	})
 }
 
 func TestValidateSpanName(t *testing.T) {
 	validateTransaction(t, func(tx *elasticapm.Transaction) {
-		tx.StartSpan(strings.Repeat("x", 1025), "type", nil).Done(-1)
+		tx.StartSpan(strings.Repeat("x", 1025), "type", nil).End()
 	})
 }
 
 func TestValidateSpanType(t *testing.T) {
 	validateTransaction(t, func(tx *elasticapm.Transaction) {
-		tx.StartSpan("name", strings.Repeat("x", 1025), nil).Done(-1)
+		tx.StartSpan("name", strings.Repeat("x", 1025), nil).End()
 	})
 }
 
@@ -202,14 +202,14 @@ func validateTransaction(t *testing.T, f func(tx *elasticapm.Transaction)) {
 	validatePayloads(t, func(tracer *elasticapm.Tracer) {
 		tx := tracer.StartTransaction("name", "type")
 		f(tx)
-		tx.Done(-1)
+		tx.End()
 	})
 }
 
 func validatePayloadMetadata(t *testing.T, f func(tracer *elasticapm.Tracer)) {
 	validatePayloads(t, func(tracer *elasticapm.Tracer) {
 		f(tracer)
-		tracer.StartTransaction("name", "type").Done(-1)
+		tracer.StartTransaction("name", "type").End()
 	})
 }
 


### PR DESCRIPTION
Rename Span.Done and Transaction.Done methods to End. Drop the time.Duration parameter, and instead expose a time.Duration field on the types, initialised to a negative value. If it is negative at the time End is called, set it to the time elapsed since the Timestamp field.

Also, rename Span.Start to Span.Timestamp to be consistent with the Transaction type.

Closes #104 
Closes #105 