### PR TITLE
elasticapm: change TransactionOption signature

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -36,8 +36,10 @@ func (t *Tracer) StartTransaction(name, transactionType string, opts ...Transact
 		tx.name = "" // ignored
 		return tx
 	}
+
+	var txOpts transactionOptions
 	for _, o := range opts {
-		o(tx)
+		o(&txOpts)
 	}
 
 	// Generate a random transaction ID.
@@ -158,4 +160,6 @@ func (tx *Transaction) enqueue() {
 }
 
 // TransactionOption sets options when starting a transaction.
-type TransactionOption func(*Transaction)
+type TransactionOption func(*transactionOptions)
+
+type transactionOptions struct{}


### PR DESCRIPTION
TransactionOption now accepts an unexposed
transactionOptions struct. TransactionOptions
must be defined within the elasticapm package,
so we can make assumptions about the state of
the transaction object after the options have
been applied. This will also give us a way of
specifying options like overriding the sampler,
which is not part of the transaction object.