### PR TITLE
elasticapm: drop Transaction.Ignored()

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -70,6 +70,7 @@ alphabet, numbers, dashes, underscores and spaces.
 [float]
 [[config-service-version]]
 === `ELASTIC_APM_SERVICE_VERSION`
+
 [options="header"]
 |============
 | Environment                    | Default | Example
@@ -106,29 +107,13 @@ Enable or disable the tracer. If set to false, then the Go agent does not send
 any data to the Elastic APM server, and instrumentation overhead is minimized.
 
 [float]
-[[config-transactions-ignore-patterns]]
-==== `ELASTIC_APM_TRANSACTIONS_IGNORE_NAMES`
-[options="header"]
-|============
-| Environment                             | Default | Example
-| `ELASTIC_APM_TRANSACTIONS_IGNORE_NAMES` |         | `^OPTIONS`
-|============
-
-A regular expression matching the names of transactions to ignore. Ignored transactions
-will not be sent to the APM server.
-
-The pattern specified in `ELASTIC_APM_TRANSCATION_IGNORE_NAMES` is treated
-case-insensitively by default. To override this behavior and match case-sensitively,
-wrap the value like `(?-i:<value>)`. For a full definition of Go's regular
-expression syntax, see https://golang.org/pkg/regexp/syntax/.
-
-[float]
 [[config-sanitize-field-names]]
-==== `ELASTIC_APM_SANITIZE_FIELD_NAMES`
+=== `ELASTIC_APM_SANITIZE_FIELD_NAMES`
+
 [options="header"]
 |============
-| Environment                        | Default                                                                    | Example
-| `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `password|passwd|pwd|secret|.*key|.*token|.*session.*|.*credit.*|.*card.*` | `sekrits`
+| Environment                        | Default                                                                            | Example
+| `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `password\|passwd\|pwd\|secret\|.*key\|.*token\|.*session.*\|.*credit.*\|.*card.*` | `sekrits`
 |============
 
 A regular expression matching the names of HTTP cookies and POST form fields to redact.
@@ -140,8 +125,9 @@ expression syntax, see https://golang.org/pkg/regexp/syntax/.
 
 [float]
 [[config-capture-body]]
-==== `ELASTIC_APM_CAPTURE_BODY`
+=== `ELASTIC_APM_CAPTURE_BODY`
 
+[options="header"]
 |============
 | Environment                | Default
 | `ELASTIC_APM_CAPTURE_BODY` | `off`
@@ -156,8 +142,9 @@ If your service handles data like this, enable this feature with care.
 
 [float]
 [[config-hostname]]
-==== `ELASTIC_APM_HOSTNAME`
+=== `ELASTIC_APM_HOSTNAME`
 
+[options="header"]
 [options="header"]
 |============
 | Environment                | Default         | Example
@@ -168,8 +155,9 @@ The host name to use when sending error and transaction data to the APM server.
 
 [float]
 [[config-flush-interval]]
-==== `ELASTIC_APM_FLUSH_INTERVAL`
+=== `ELASTIC_APM_FLUSH_INTERVAL`
 
+[options="header"]
 |============
 | Environment                  | Default
 | `ELASTIC_APM_FLUSH_INTERVAL` | `10s`
@@ -185,8 +173,9 @@ time until transactions are indexed and searchable in Elasticsearch.
 
 [float]
 [[config-transaction-max-spans]]
-==== `ELASTIC_APM_TRANSACTION_MAX_SPANS`
+=== `ELASTIC_APM_TRANSACTION_MAX_SPANS`
 
+[options="header"]
 |============
 | Environment                         | Default
 | `ELASTIC_APM_TRANSACTION_MAX_SPANS` | `500`
@@ -201,8 +190,9 @@ for such edge cases.
 
 [float]
 [[config-span-frames-min-duration-ms]]
-==== `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`
+=== `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`
 
+[options="header"]
 |============
 | Environment                            | Default
 | `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION` | `5ms`
@@ -215,8 +205,9 @@ some processing and storage overhead.
 
 [float]
 [[config-max-queue-size]]
-==== `ELASTIC_APM_MAX_QUEUE_SIZE`
+=== `ELASTIC_APM_MAX_QUEUE_SIZE`
 
+[options="header"]
 |============
 | Environment                  | Default
 | `ELASTIC_APM_MAX_QUEUE_SIZE` | `500`
@@ -233,8 +224,9 @@ capacity, old transactions are dropped in favour of new ones.
 
 [float]
 [[config-transaction-sample-rate]]
-==== `ELASTIC_APM_TRANSACTION_SAMPLE_RATE`
+=== `ELASTIC_APM_TRANSACTION_SAMPLE_RATE`
 
+[options="header"]
 |============
 | Environment                           | Default
 | `ELASTIC_APM_TRANSACTION_SAMPLE_RATE` | `1.0`
@@ -247,7 +239,9 @@ transactions, but no context information, tags, or spans.
 
 [float]
 [[config-verify-server-cert]]
-==== `ELASTIC_APM_VERIFY_SERVER_CERT`
+=== `ELASTIC_APM_VERIFY_SERVER_CERT`
+
+[options="header"]
 |============
 | Environment                       | Default
 | `ELASTIC_APM_VERIFY_SERVER_CERT`  | `true`
@@ -259,7 +253,9 @@ changing this setting to `false`.
 
 [float]
 [[config-debug]]
-==== `ELASTIC_APM_DEBUG`
+=== `ELASTIC_APM_DEBUG`
+
+[options="header"]
 |============
 | Environment         | Default
 | `ELASTIC_APM_DEBUG` |

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -281,15 +281,14 @@ tx.Result = "HTTP 2xx"
 tx.Context.SetTag("region", "us-east-1")
 ----
 
-The agent supports ignoring and sampling transactions; ignored transactions will not be
-sent to the server at all, while non-sampled transactions will be sent with limited context
-and without any spans. To determine whether a transaction is ignored, use the
-`Transaction.Ignored` method; if it returns true, any additional instrumentation should
-be avoided. Similarly, you can use the `Transaction.Sampled` method to decide whether or
-not to add to the transaction's context.
+The agent supports sampling transactions: non-sampled transactions will be still be
+reported, but with limited context and without any spans. To determine whether a
+transaction is sampled, use the `Transaction.Sampled` method; if it returns false,
+you should avoid unnecessary storage or processing required for setting transaction
+context.
 
-Once you have started a transaction, you can include it in a `context` object for prpagating
-throughout the application.
+Once you have started a transaction, you can include it in a `context` object for
+propagating throughout the application.
 
 [source,go]
 ----

--- a/env.go
+++ b/env.go
@@ -15,18 +15,17 @@ import (
 )
 
 const (
-	envFlushInterval          = "ELASTIC_APM_FLUSH_INTERVAL"
-	envMaxQueueSize           = "ELASTIC_APM_MAX_QUEUE_SIZE"
-	envMaxSpans               = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
-	envTransactionSampleRate  = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
-	envTransactionIgnoreNames = "ELASTIC_APM_TRANSACTION_IGNORE_NAMES"
-	envSanitizeFieldNames     = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
-	envCaptureBody            = "ELASTIC_APM_CAPTURE_BODY"
-	envServiceName            = "ELASTIC_APM_SERVICE_NAME"
-	envServiceVersion         = "ELASTIC_APM_SERVICE_VERSION"
-	envEnvironment            = "ELASTIC_APM_ENVIRONMENT"
-	envSpanFramesMinDuration  = "ELASTIC_APM_SPAN_FRAMES_MIN_DURATION"
-	envActive                 = "ELASTIC_APM_ACTIVE"
+	envFlushInterval         = "ELASTIC_APM_FLUSH_INTERVAL"
+	envMaxQueueSize          = "ELASTIC_APM_MAX_QUEUE_SIZE"
+	envMaxSpans              = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
+	envTransactionSampleRate = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
+	envSanitizeFieldNames    = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
+	envCaptureBody           = "ELASTIC_APM_CAPTURE_BODY"
+	envServiceName           = "ELASTIC_APM_SERVICE_NAME"
+	envServiceVersion        = "ELASTIC_APM_SERVICE_VERSION"
+	envEnvironment           = "ELASTIC_APM_ENVIRONMENT"
+	envSpanFramesMinDuration = "ELASTIC_APM_SPAN_FRAMES_MIN_DURATION"
+	envActive                = "ELASTIC_APM_ACTIVE"
 
 	defaultFlushInterval           = 10 * time.Second
 	defaultMaxTransactionQueueSize = 500
@@ -124,19 +123,6 @@ func initialSanitizedFieldNamesRegexp() (*regexp.Regexp, error) {
 	if err != nil {
 		_, err = regexp.Compile(value)
 		return nil, errors.Wrapf(err, "invalid %s value", envSanitizeFieldNames)
-	}
-	return re, nil
-}
-
-func initialTransactionIgnoreNamesRegexp() (*regexp.Regexp, error) {
-	value := os.Getenv(envTransactionIgnoreNames)
-	if value == "" {
-		return nil, nil
-	}
-	re, err := regexp.Compile(fmt.Sprintf("(?i:%s)", value))
-	if err != nil {
-		_, err = regexp.Compile(value)
-		return nil, errors.Wrapf(err, "invalid %s value", envTransactionIgnoreNames)
 	}
 	return re, nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -220,38 +220,6 @@ func testTracerCaptureBodyEnv(t *testing.T, envValue string, expectBody bool) {
 	}
 }
 
-func TestTracerTransactionIgnoreNamesEnvInvalid(t *testing.T) {
-	os.Setenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES", "oy(")
-	defer os.Unsetenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES")
-
-	_, err := elasticapm.NewTracer("tracer_testing", "")
-	assert.EqualError(t, err, "invalid ELASTIC_APM_TRANSACTION_IGNORE_NAMES value: error parsing regexp: missing closing ): `oy(`")
-}
-
-func TestTracerTransactionIgnoreNamesEnv(t *testing.T) {
-	type test struct {
-		name    string
-		re      string
-		ignored bool
-	}
-	tests := []test{
-		{name: "matching", re: "foo", ignored: true},
-		{name: "nonmatching", re: "not_foo", ignored: false},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			os.Setenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES", test.re)
-			defer os.Unsetenv("ELASTIC_APM_TRANSACTION_IGNORE_NAMES")
-
-			tracer, _ := elasticapm.NewTracer("tracer_testing", "")
-			defer tracer.Close()
-
-			tx := tracer.StartTransaction("FOO", "type")
-			assert.Equal(t, test.ignored, tx.Ignored())
-		})
-	}
-}
-
 func TestTracerSpanFramesMinDurationEnv(t *testing.T) {
 	os.Setenv("ELASTIC_APM_SPAN_FRAMES_MIN_DURATION", "10ms")
 	defer os.Unsetenv("ELASTIC_APM_SPAN_FRAMES_MIN_DURATION")

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -41,11 +41,6 @@ func (m *middleware) handle(c echo.Context) error {
 	req := c.Request()
 	name := req.Method + " " + c.Path()
 	tx := m.tracer.StartTransaction(name, "request")
-	if tx.Ignored() {
-		tx.Discard()
-		return m.handler(c)
-	}
-
 	ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 	req = apmhttp.RequestWithContext(ctx, req)
 	c.SetRequest(req)

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -73,12 +73,6 @@ func (m *middleware) handle(c *gin.Context) {
 		requestName = routeInfo.transactionName
 	}
 	tx := m.tracer.StartTransaction(requestName, "request")
-	if tx.Ignored() {
-		tx.Discard()
-		c.Next()
-		return
-	}
-
 	ctx := elasticapm.ContextWithTransaction(c.Request.Context(), tx)
 	c.Request = apmhttp.RequestWithContext(ctx, c.Request)
 	defer tx.End()

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -38,11 +38,6 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 			return handler(ctx, req)
 		}
 		tx := opts.tracer.StartTransaction(info.FullMethod, "grpc")
-		if tx.Ignored() {
-			tx.Discard()
-			return handler(ctx, req)
-		}
-
 		ctx = elasticapm.ContextWithTransaction(ctx, tx)
 		defer tx.End()
 

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -34,12 +34,6 @@ func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 			return
 		}
 		tx := opts.tracer.StartTransaction(req.Method+" "+route, "request")
-		if tx.Ignored() {
-			tx.Discard()
-			h(w, req, p)
-			return
-		}
-
 		ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 		req = apmhttp.RequestWithContext(ctx, req)
 		defer tx.End()

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -327,22 +327,6 @@ func TestTracerServiceNameValidation(t *testing.T) {
 	assert.EqualError(t, err, `invalid service name "wot!": character '!' is not in the allowed set (a-zA-Z0-9 _-)`)
 }
 
-func TestTracerTransactionIgnoreNames(t *testing.T) {
-	tracer, _ := elasticapm.NewTracer("tracer_testing", "")
-	defer tracer.Close()
-
-	tracer.SetTransactionIgnoreNames("\\bignored")
-
-	tx := tracer.StartTransaction("iGnoReD", "type") // case-insensitive
-	assert.True(t, tx.Ignored())
-	assert.False(t, tx.Sampled()) // ignored => !sampled
-	tx.Discard()
-
-	tx = tracer.StartTransaction("not_ignored", "type")
-	assert.False(t, tx.Ignored())
-	tx.Discard()
-}
-
 func TestSpanStackTrace(t *testing.T) {
 	tracer, r := transporttest.NewRecorderTracer()
 	defer tracer.Close()


### PR DESCRIPTION
Drop the ability to ignore transactions, and
the Transaction.Ignored() method. These are
causing complications around adding support
for OpenTracing. It's also just more efficient
to keep the filtering outside of transaction
creation, so we don't have to create garbage
that is immediately thrown away. Instrumentation
modules should be responsible for that.