### PR TITLE
Expose Name, Type fields of Span, Transaction

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -32,8 +32,8 @@ func (s *sender) sendTransactions(ctx context.Context, transactions []*Transacti
 
 	for _, tx := range transactions {
 		s.modelTransactions = append(s.modelTransactions, model.Transaction{
-			Name:      truncateString(tx.name),
-			Type:      truncateString(tx.txType),
+			Name:      truncateString(tx.Name),
+			Type:      truncateString(tx.Type),
 			ID:        tx.id,
 			Result:    truncateString(tx.Result),
 			Timestamp: model.Time(tx.Timestamp.UTC()),
@@ -53,8 +53,8 @@ func (s *sender) sendTransactions(ctx context.Context, transactions []*Transacti
 			for _, span := range tx.spans {
 				s.modelSpans = append(s.modelSpans, model.Span{
 					ID:       &span.id,
-					Name:     truncateString(span.name),
-					Type:     truncateString(span.spanType),
+					Name:     truncateString(span.Name),
+					Type:     truncateString(span.Type),
 					Start:    span.Timestamp.Sub(tx.Timestamp).Seconds() * 1000,
 					Duration: span.Duration.Seconds() * 1000,
 					Context:  span.Context.build(),

--- a/span.go
+++ b/span.go
@@ -43,8 +43,8 @@ func (tx *Transaction) StartSpan(name, spanType string, parent *Span) *Span {
 	tx.spans = append(tx.spans, span)
 	tx.mu.Unlock()
 
-	span.name = name
-	span.spanType = spanType
+	span.Name = name
+	span.Type = spanType
 	span.Timestamp = time.Now()
 	if parent != nil {
 		span.parent = parent.id
@@ -57,8 +57,8 @@ type Span struct {
 	tx        *Transaction // nil if span is dropped
 	id        int64
 	parent    int64
-	name      string
-	spanType  string
+	Name      string
+	Type      string
 	Timestamp time.Time
 	Duration  time.Duration
 	Context   SpanContext
@@ -130,7 +130,7 @@ func (s *Span) finalize(end time.Time) {
 	if s.Duration < 0 {
 		// s.End was never called, so mark it as truncated and
 		// truncate its duration to the end of the transaction.
-		s.spanType += ".truncated"
+		s.Type += ".truncated"
 		s.Duration = end.Sub(s.Timestamp)
 	}
 	s.mu.Unlock()

--- a/transaction.go
+++ b/transaction.go
@@ -26,8 +26,8 @@ func (t *Tracer) StartTransaction(name, transactionType string, opts ...Transact
 		}
 		tx.rand = rand.New(rand.NewSource(seed))
 	}
-	tx.name = name
-	tx.txType = transactionType
+	tx.Name = name
+	tx.Type = transactionType
 
 	var txOpts transactionOptions
 	for _, o := range opts {
@@ -62,13 +62,13 @@ func (t *Tracer) StartTransaction(name, transactionType string, opts ...Transact
 
 // Transaction describes an event occurring in the monitored service.
 type Transaction struct {
+	Name      string
+	Type      string
 	Timestamp time.Time
 	Duration  time.Duration
 	Context   Context
 	Result    string
 	id        [16]byte
-	name      string
-	txType    string
 
 	tracer                *Tracer
 	sampled               bool


### PR DESCRIPTION
As it says on the tin. The name and type can
be changed any time before the End method is
invoked.

Closes #110 