### PR TITLE
docs: use shared attributes

### DIFF
--- a/docs/contributing.asciidoc
+++ b/docs/contributing.asciidoc
@@ -6,7 +6,7 @@ The Go APM Agent is open source and we love to receive contributions from our co
 There are many ways to contribute, from writing tutorials or blog posts, improving the
 documentation, submitting bug reports and feature requests or writing code.
 
-You can get in touch with us through https://discuss.elastic.co/c/apm[Discuss].
+You can get in touch with us through {apm-forum}[Discuss].
 Feedback and ideas are always welcome.
 
 [float]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -9,6 +9,8 @@ ifdef::env-github[]
 endif::[]
 
 ifndef::env-github[]
+:branch: current
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::./introduction.asciidoc[Introduction]
 include::./instrumenting.asciidoc[Instrumenting]
 include::./configuration.asciidoc[Configuration]

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -14,8 +14,8 @@ https://golang.org/pkg/database/sql/[database/sql] drivers, and APIs for custom 
 The agent is only one of multiple components you need to get started with APM.
 Please also have a look at the documentation for
 
- * https://www.elastic.co/guide/en/apm/server/current/index.html[APM Server]
- * https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[Elasticsearch]
+ * {apm-server-ref}/index.html[APM Server]
+ * {ref}/index.html[Elasticsearch]
 
 ifdef::env-github[]
 NOTE: For the best reading experience, please head over to this document at https://www.elastic.co/guide/en/apm/agent/go/current/index.html[elastic.co]


### PR DESCRIPTION
Use the shared attributes provided
by elastic/docs for linking to other
product docs, forums, etc.

Requires https://github.com/elastic/docs/pull/369