### PR TITLE
transport: default ELASTIC_APM_SERVER_URL

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -4,7 +4,9 @@
 To adapt the Elastic APM Go agent to your needs, you can configure it using
 environment variables.
 
-In order to send your data to an Elastic APM server, you must at least configure
+By default, the agent will attempt to send data to the Elastic APM Server
+at `http://localhost:8200`, to simplify development and testing. To send
+data to an alternative location, you must configure
 <<config-server-url, ELASTIC_APM_SERVER_URL>>. Depending on the configuration
 of your server, you may also need to set <<config-secret-token, ELASTIC_APM_SECRET_TOKEN>>
 and <<config-verify-server-cert, ELASTIC_APM_VERIFY_SERVER_CERT>>. All other
@@ -16,17 +18,14 @@ variables have usable defaults.
 
 [options="header"]
 |============
-| Environment              | Default  | Example
-| `ELASTIC_APM_SERVER_URL` |          | `http://localhost:8200`
+| Environment              | Default                 | Example
+| `ELASTIC_APM_SERVER_URL` | `http://localhost:8200` | `http://localhost:8200`
 |============
 
 The URL for your Elastic APM server. The server supports both HTTP and HTTPS.
 If you use HTTPS, then you may need to configure your client machines so
 that the server certificate can be verified. You can also disable certificate
 verification with <<config-verify-server-cert>>.
-
-NOTE: If `ELASTIC_APM_SERVER_URL` is not specified, then all transactions and
-errors will be discarded.
 
 [float]
 [[config-secret-token]]

--- a/transport/default.go
+++ b/transport/default.go
@@ -1,8 +1,6 @@
 package transport
 
 import (
-	"os"
-
 	"github.com/elastic/apm-agent-go/internal/apmdebug"
 )
 
@@ -10,9 +8,8 @@ var (
 	// Default is the default Transport, using the
 	// ELASTIC_APM_* environment variables.
 	//
-	// If ELASTIC_APM_SERVER_URL is not defined, then
-	// Defaultwill be set to Discard. If it is defined,
-	// but invalid, then Default will be set to a transport
+	// If ELASTIC_APM_SERVER_URL is set to an invalid
+	// location, Default will be set to a transport
 	// returning an error for every operation.
 	Default Transport
 
@@ -39,11 +36,7 @@ func InitDefault() (Transport, error) {
 }
 
 func getDefault() (Transport, error) {
-	url := os.Getenv(envServerURL)
-	if url == "" {
-		return Discard, nil
-	}
-	t, err := NewHTTPTransport(url, "")
+	t, err := NewHTTPTransport("", "")
 	if err != nil {
 		return discardTransport{err}, err
 	}

--- a/transport/default_test.go
+++ b/transport/default_test.go
@@ -2,6 +2,8 @@ package transport_test
 
 import (
 	"context"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -29,16 +31,26 @@ func TestInitDefault(t *testing.T) {
 }
 
 func TestInitDefaultDiscard(t *testing.T) {
+	var h recordingHandler
+	server := &http.Server{Handler: &h}
+	defer server.Close()
+
+	lis, err := net.Listen("tcp", "localhost:8200")
+	if err != nil {
+		t.Skipf("cannot listen on default server address: %s", err)
+	}
+	go server.Serve(lis)
+
 	defer patchEnv("ELASTIC_APM_SERVER_URL", "")()
 
 	tr, err := transport.InitDefault()
 	assert.NoError(t, err)
 	assert.NotNil(t, tr)
 	assert.Exactly(t, tr, transport.Default)
-	assert.Exactly(t, transport.Discard, tr)
 
 	err = tr.SendTransactions(context.Background(), &model.TransactionsPayload{})
 	assert.NoError(t, err)
+	assert.Len(t, h.requests, 1)
 }
 
 func TestInitDefaultError(t *testing.T) {

--- a/transport/http.go
+++ b/transport/http.go
@@ -36,6 +36,8 @@ var (
 	// Take a copy of the http.DefaultTransport pointer,
 	// in case another package replaces the value later.
 	defaultHTTPTransport = http.DefaultTransport.(*http.Transport)
+
+	defaultServerURL = "http://localhost:8200"
 )
 
 // HTTPTransport is an implementation of Transport, sending payloads via
@@ -58,9 +60,9 @@ type HTTPTransport struct {
 //
 // If the URL specified is the empty string, then NewHTTPTransport will use the
 // value of the ELASTIC_APM_SERVER_URL environment variable, if defined; if
-// the environment variable is also undefined, then an error will be returned.
-// The URL must be the base server URL, excluding any transactions or errors
-// path. e.g. "http://elastic-apm.example:8200".
+// the environment variable is also undefined, then the transport will use the
+// default URL "http://localhost:8200". The URL must be the base server URL,
+// excluding any transactions or errors path. e.g. "http://server.example:8200".
 //
 // If the secret token specified is the empty string, then NewHTTPTransport
 // will use the value of the ELASTIC_APM_SECRET_TOKEN environment variable, if
@@ -77,9 +79,7 @@ func NewHTTPTransport(serverURL, secretToken string) (*HTTPTransport, error) {
 	if serverURL == "" {
 		serverURL = os.Getenv(envServerURL)
 		if serverURL == "" {
-			return nil, errors.Errorf(
-				"URL not specified, and $%s not set", envServerURL,
-			)
+			serverURL = defaultServerURL
 		}
 	}
 	req, err := http.NewRequest("POST", serverURL, nil)


### PR DESCRIPTION
If ELASTIC_APM_SERVER_URL is not specified,
default to http://localhost:8200 like the
other agents.

Fixes #121 