### PR TITLE
transport: fix tests

### DIFF
--- a/transport/default_test.go
+++ b/transport/default_test.go
@@ -3,7 +3,6 @@ package transport_test
 import (
 	"context"
 	"net"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -32,14 +31,16 @@ func TestInitDefault(t *testing.T) {
 
 func TestInitDefaultDiscard(t *testing.T) {
 	var h recordingHandler
-	server := &http.Server{Handler: &h}
+	server := httptest.NewUnstartedServer(&h)
 	defer server.Close()
 
 	lis, err := net.Listen("tcp", "localhost:8200")
 	if err != nil {
 		t.Skipf("cannot listen on default server address: %s", err)
 	}
-	go server.Serve(lis)
+	server.Listener.Close()
+	server.Listener = lis
+	server.Start()
 
 	defer patchEnv("ELASTIC_APM_SERVER_URL", "")()
 

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -33,18 +33,21 @@ func init() {
 
 func TestNewHTTPTransportDefaultURL(t *testing.T) {
 	var h recordingHandler
-	server := &http.Server{Handler: &h}
+	server := httptest.NewUnstartedServer(&h)
 	defer server.Close()
 
 	lis, err := net.Listen("tcp", "localhost:8200")
 	if err != nil {
 		t.Skipf("cannot listen on default server address: %s", err)
 	}
-	go server.Serve(lis)
+	server.Listener.Close()
+	server.Listener = lis
+	server.Start()
 
 	transport, err := transport.NewHTTPTransport("", "")
 	assert.NoError(t, err)
-	transport.SendTransactions(context.Background(), &model.TransactionsPayload{})
+	err = transport.SendTransactions(context.Background(), &model.TransactionsPayload{})
+	assert.NoError(t, err)
 	assert.Len(t, h.requests, 1)
 }
 
@@ -57,7 +60,8 @@ func TestHTTPTransportEnvURL(t *testing.T) {
 
 	transport, err := transport.NewHTTPTransport("", "")
 	assert.NoError(t, err)
-	transport.SendTransactions(context.Background(), &model.TransactionsPayload{})
+	err = transport.SendTransactions(context.Background(), &model.TransactionsPayload{})
+	assert.NoError(t, err)
 	assert.Len(t, h.requests, 1)
 }
 


### PR DESCRIPTION
Use httptest rather than http.Server, to avoid
issues relating to servers advertising support
for keep-alive and closing idle connections.