### PR TITLE
Add vgo bits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/elastic/apm-agent-go
+
+require github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
We will probably want to add additional vgo modules for the instrumentation modules, that'll be done as a followup.

Closes https://github.com/elastic/apm-agent-go/issues/83