### PR TITLE
module/apmhttprouter: add Router and New

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -193,6 +193,27 @@ func main() {
 
 https://github.com/julienschmidt/httprouter/pull/139[httprouter does not provide a means of obtaining the matched route], hence the route must be passed into the wrapper.
 
+Alternatively you can use the apmhttprouter.Router type, which wraps httprouter.Router,
+providing the same API and instrumenting added routes. To use this wrapper type, you
+should rewrite your use of `httprouter.New` to `apmhttprouter.New`; the returned type
+is `*apmhttprouter.Router`, and not `*httprouter.Router`.
+
+[source,go]
+----
+import (
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/elastic/apm-agent-go/module/apmhttprouter"
+)
+
+func main() {
+	router := apmhttprouter.New()
+
+	router.GET(route, h)
+	...
+}
+----
+
 ===== module/apmlambda
 Package apmlambda intercepts requests to your AWS Lambda function invocations.
 

--- a/module/apmhttprouter/router.go
+++ b/module/apmhttprouter/router.go
@@ -1,0 +1,79 @@
+package apmhttprouter
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// Router wraps an httprouter.Router, instrumenting all added routes
+// except static content served with ServeFiles.
+type Router struct {
+	*httprouter.Router
+	opts []Option
+}
+
+// New returns a new Router which will instrument all added routes
+// except static content served with ServeFiles.
+func New(o ...Option) *Router {
+	return &Router{
+		Router: httprouter.New(),
+		opts:   o,
+	}
+}
+
+// DELETE calls r.Router.DELETE with a wrapped handler.
+func (r *Router) DELETE(path string, handle httprouter.Handle) {
+	r.Router.DELETE(path, Wrap(handle, path, r.opts...))
+}
+
+// GET calls r.Router.GET with a wrapped handler.
+func (r *Router) GET(path string, handle httprouter.Handle) {
+	r.Router.GET(path, Wrap(handle, path, r.opts...))
+}
+
+// HEAD calls r.Router.HEAD with a wrapped handler.
+func (r *Router) HEAD(path string, handle httprouter.Handle) {
+	r.Router.HEAD(path, Wrap(handle, path, r.opts...))
+}
+
+// Handle calls r.Router.Handle with a wrapped handler.
+func (r *Router) Handle(method, path string, handle httprouter.Handle) {
+	r.Router.Handle(method, path, Wrap(handle, path, r.opts...))
+}
+
+// HandlerFunc is equivalent to r.Router.HandlerFunc, but traces requests.
+func (r *Router) HandlerFunc(method, path string, handler http.HandlerFunc) {
+	r.Handler(method, path, handler)
+}
+
+// Handler is equivalent to r.Router.Handler, but traces requests.
+func (r *Router) Handler(method, path string, handler http.Handler) {
+	r.Handle(method, path, func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, httprouter.ParamsKey, p)
+		req = req.WithContext(ctx)
+		handler.ServeHTTP(w, req)
+	})
+}
+
+// OPTIONS is equivalent to r.Router.OPTIONS, but traces requests.
+func (r *Router) OPTIONS(path string, handle httprouter.Handle) {
+	r.Router.OPTIONS(path, Wrap(handle, path, r.opts...))
+}
+
+// PATCH is equivalent to r.Router.PATCH, but traces requests.
+func (r *Router) PATCH(path string, handle httprouter.Handle) {
+	r.Router.PATCH(path, Wrap(handle, path, r.opts...))
+}
+
+// POST is equivalent to r.Router.POST, but traces requests.
+func (r *Router) POST(path string, handle httprouter.Handle) {
+	r.Router.POST(path, Wrap(handle, path, r.opts...))
+}
+
+// PUT is equivalent to r.Router.PUT, but traces requests.
+func (r *Router) PUT(path string, handle httprouter.Handle) {
+	r.Router.PUT(path, Wrap(handle, path, r.opts...))
+}

--- a/module/apmhttprouter/router_test.go
+++ b/module/apmhttprouter/router_test.go
@@ -1,0 +1,90 @@
+package apmhttprouter_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/module/apmhttprouter"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestRouter(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+	router := apmhttprouter.New(apmhttprouter.WithTracer(tracer))
+
+	router.DELETE("/DELETE", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+	router.GET("/GET", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+	router.HEAD("/HEAD", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+	router.OPTIONS("/OPTIONS", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+	router.PATCH("/PATCH", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+	router.POST("/POST", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+	router.PUT("/PUT", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+
+	w := httptest.NewRecorder()
+	methods := []string{"DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"}
+	for _, method := range methods {
+		sendRequest(router, w, method, "/"+method)
+	}
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	require.Len(t, payloads, 1)
+	transactions := payloads[0].Transactions()
+	require.Len(t, transactions, len(methods))
+	names := transactionNames(transactions)
+	for _, method := range methods {
+		assert.Contains(t, names, method+" /"+method)
+	}
+
+	// Test router.Handle.
+	router.Handle("GET", "/handle", func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {})
+	sendRequest(router, w, "GET", "/handle")
+	tracer.Flush(nil)
+	payloads = transport.Payloads()
+	require.Len(t, payloads, 2)
+	transactions = payloads[1].Transactions()
+	require.Len(t, transactions, 1)
+	assert.Equal(t, "GET /handle", transactions[0].Name)
+}
+
+func TestRouterHTTPHandler(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+	router := apmhttprouter.New(apmhttprouter.WithTracer(tracer))
+
+	router.Handler("GET", "/handler", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	router.HandlerFunc("GET", "/handlerfunc", func(http.ResponseWriter, *http.Request) {})
+
+	w := httptest.NewRecorder()
+	sendRequest(router, w, "GET", "/handler")
+	sendRequest(router, w, "GET", "/handlerfunc")
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	require.Len(t, payloads, 1)
+	transactions := payloads[0].Transactions()
+	require.Len(t, transactions, 2)
+
+	names := transactionNames(transactions)
+	assert.Contains(t, names, "GET /handler")
+	assert.Contains(t, names, "GET /handlerfunc")
+}
+
+func transactionNames(transactions []model.Transaction) []string {
+	names := make([]string, len(transactions))
+	for i, tx := range transactions {
+		names[i] = tx.Name
+	}
+	return names
+}
+
+func sendRequest(r *apmhttprouter.Router, w http.ResponseWriter, method, path string) {
+	req, _ := http.NewRequest(method, "http://server.testing"+path, nil)
+	r.ServeHTTP(w, req)
+}


### PR DESCRIPTION
Add a Router type and accompanying New
constructor function, mirroring the
httprouter API. New takes options just
like Wrap does. Added routes will be
instrumented, and options will be passed
onto the Wrap method internally.

Closes #138