### PR TITLE
internal/apmschema: vendor JSON schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
 before_install:
   - go get -v golang.org/x/tools/cmd/goimports
   - go get -v golang.org/x/lint/golint
-  - go get -d github.com/elastic/apm-server || true
 
 script:
   - make install check
@@ -29,6 +28,5 @@ jobs:
     - stage: coverage
       go: stable
       script:
-       - go get -d github.com/elastic/apm-server || true
        - make install coverage.txt
        - bash <(curl -s https://codecov.io/bash)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
   PATH: C:\msys64\mingw64\bin;%PATH%
 
 build_script:
-- cmd: go get -d github.com/elastic/apm-server || true
 - cmd: go get -t ./...
 
 test_script:

--- a/internal/apmschema/jsonschema/context.json
+++ b/internal/apmschema/jsonschema/context.json
@@ -1,0 +1,60 @@
+{
+    "$id": "doc/spec/context.json",
+    "title": "Context",
+    "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
+    "type": ["object", "null"],
+    "properties": {
+        "custom": {
+            "description": "An arbitrary mapping of additional metadata to store with the event.",
+            "type": ["object", "null"],
+            "regexProperties": true,
+            "patternProperties": {
+                "^[^.*\"]*$": {}
+            },
+            "additionalProperties": false
+        },
+        "response": {
+            "type": ["object", "null"],
+            "properties": {
+                "finished": {
+                    "description": "A boolean indicating whether the response was finished or not",
+                    "type": ["boolean", "null"]
+                },
+                "headers": {
+                    "description": "A mapping of HTTP headers of the response object",
+                    "type": ["object", "null"],
+                    "properties": {
+                        "content-type": {
+                            "type": ["string", "null"]
+                        }
+                    }
+                },
+                "headers_sent": {
+                    "type": ["boolean", "null"]
+                },
+                "status_code": {
+                    "description": "The HTTP status code of the response.",
+                    "type": ["integer", "null"]
+                }
+            }
+        },
+        "request": {
+            "$ref": "request.json"
+        },
+        "tags": {
+            "type": ["object", "null"],
+            "description": "A flat mapping of user-defined tags with string values.",
+            "regexProperties": true,
+            "patternProperties": {
+                "^[^.*\"]*$": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            },
+            "additionalProperties": false
+        },
+        "user": {
+            "$ref": "user.json"
+        }
+    }
+}

--- a/internal/apmschema/jsonschema/errors/error.json
+++ b/internal/apmschema/jsonschema/errors/error.json
@@ -1,0 +1,118 @@
+{
+    "$id": "docs/spec/errors/error.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "properties": {
+        "context": {
+            "$ref": "./../context.json"
+        },
+        "culprit": {
+            "description": "Function call which was the primary perpetrator of this event.",
+            "type": ["string", "null"]
+        },
+        "exception": {
+            "description": "Information about the originally thrown error.",
+            "type": ["object", "null"],
+            "properties": {
+                "code": {
+                    "type": ["string", "integer", "null"],
+                    "maxLength": 1024,
+                    "description": "The error code set when the error happened, e.g. database error code."
+                },
+                "message": {
+                   "description": "The original error message.",
+                   "type": "string"
+                },
+                "module": {
+                    "description": "Describes the exception type's module namespace.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "attributes": {
+                    "type": ["object", "null"]
+                },
+                "stacktrace": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "./../stacktrace_frame.json"
+                    },
+                    "minItems": 0
+                },
+                "type": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "handled": {
+                    "type": ["boolean", "null"],
+                    "description": "Indicator whether the error was caught somewhere in the code or not."
+                }
+            },
+            "required": ["message"]
+        },
+        "id": {
+            "type": ["string", "null"],
+            "description": "UUID for the error",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+        },
+        "log": {
+            "type": ["object", "null"],
+            "description": "Additional information added when logging the error.",
+            "properties": {
+                "level": {
+                    "description": "The severity of the record.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "logger_name": {
+                    "description": "The name of the logger instance used.",
+                    "type": ["string", "null"],
+                    "default": "default",
+                    "maxLength": 1024
+                },
+                "message": {
+                    "description": "The additionally logged error message.",
+                    "type": "string"
+                },
+                "param_message": {
+                    "description": "A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+
+                },
+                "stacktrace": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "./../stacktrace_frame.json"
+                    },
+                    "minItems": 0
+                }
+            },
+            "required": ["message"]
+        },
+        "timestamp": {
+            "type": ["string","null"],
+            "format": "date-time",
+            "pattern": "Z$",
+            "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
+        },
+        "transaction": {
+            "type": ["object", "null"],
+            "description": "Data for correlating errors with transactions",
+            "properties": {
+                "id": {
+                    "type": ["string", "null"],
+                    "description": "UUID for the transaction",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                }
+            }
+        }
+    },
+    "anyOf": [
+        {
+            "required": ["exception"]
+        },
+        {
+            "required": ["log"]
+        }
+    ]
+}

--- a/internal/apmschema/jsonschema/errors/payload.json
+++ b/internal/apmschema/jsonschema/errors/payload.json
@@ -1,0 +1,25 @@
+{
+    "$id": "docs/spec/errors/payload.json",
+    "title": "Errors payload",
+    "description": "List of errors wrapped in an object containing some other attributes normalized away from the errors themselves",
+    "type": "object",
+    "properties": {
+        "service": {
+            "$ref": "../service.json"
+        },
+        "process": {
+            "$ref": "../process.json"
+        },
+        "errors": {
+            "type": "array",
+            "items": {
+                "$ref": "error.json"
+            },
+            "minItems": 1
+        },
+        "system": {
+            "$ref": "../system.json"
+        }
+    },
+    "required": ["service", "errors"]
+}

--- a/internal/apmschema/jsonschema/metrics/metric.json
+++ b/internal/apmschema/jsonschema/metrics/metric.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metrics/metric.json",
+    "type": "object",
+    "description": "Metric data captured by an APM agent",
+    "properties": {
+        "samples": {
+            "type": ["object"],
+            "description": "Sampled application metrics collected from the agent",
+            "regexProperties": true,
+            "patternProperties": {
+                "^[^*\"]*$": {
+                    "$ref": "sample.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tags": {
+            "type": ["object", "null"],
+            "description": "A flat mapping of user-defined tags with string values",
+            "regexProperties": true,
+            "patternProperties": {
+                "^[^*\"]*$": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            },
+            "additionalProperties": false
+        },
+        "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "Z$",
+            "description": "Recorded time of the metric, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
+        }
+    },
+    "required": ["samples", "timestamp"]
+}

--- a/internal/apmschema/jsonschema/metrics/payload.json
+++ b/internal/apmschema/jsonschema/metrics/payload.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metrics/payload.json",
+    "title": "Metrics payload",
+    "description": "Metrics for correlation with other APM data",
+    "type": "object",
+    "properties": {
+        "metrics": {
+            "type": "array",
+            "items": {
+                "$ref": "metric.json"
+            },
+            "minItems": 1
+        },
+        "process": {
+            "$ref": "../process.json"
+        },
+        "service": {
+            "$ref": "../service.json"
+        },
+        "system": {
+            "$ref": "../system.json"
+        }
+    },
+    "required": ["service", "metrics"]
+}

--- a/internal/apmschema/jsonschema/metrics/sample.json
+++ b/internal/apmschema/jsonschema/metrics/sample.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metrics/sample.json",
+    "type": ["object", "null"],
+    "description": "A single metric sample.",
+    "anyOf": [
+        {
+            "properties": {
+                "type": {
+                    "description": "Counters and gauges capture a single value at a point in time.  Counter are cumulative, strictly increasing or decreasing, and typically most useful with derivative aggregations.  Gauges increase and decrease over time.",
+                    "enum": ["counter", "gauge"]
+                },
+                "unit": {
+                    "type": ["string", "null"]
+                },
+                "value": {"type": "number"}
+            },
+            "required": ["type", "value"]
+        },
+        {
+            "properties": {
+                "type": {
+                    "description": "Summary metrics capture client-side aggregations describing the distribution of a metric",
+                    "enum": ["summary"]
+                },
+                "unit": {
+                    "description": "The unit of measurement of this metric eg: bytes. Only informational at this time",
+                    "type": ["string", "null"]
+                },
+                "count": {
+                    "description": "The total count of all observations for this metric",
+                    "type": "number"
+                },
+                "sum": {
+                    "description": "The sum of all observations for this metric",
+                    "type": "number"
+                },
+                "stddev": {
+                    "description": "The standard deviation describing this metric",
+                    "type": ["number", "null"]
+                },
+                "min": {
+                    "description": "The minimum value observed for this metric",
+                    "type": ["number", "null"]
+                },
+                "max": {
+                    "description": "The maximum value observed for this metric",
+                    "type": ["number", "null"]
+                },
+                "quantiles": {
+                    "description": "A list of quantiles describing the metric",
+                    "type": ["array", "null"],
+                    "items": {
+                        "descrption": "A [quantile, value] tuple",
+                        "type": ["array", "null"],
+                        "items": [
+                            {
+                                "type": "number",
+                                "minimum": 0, "maximum": 1
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ],
+                        "maxItems": 2,
+                        "minItems": 2
+                    }
+                }
+            },
+            "required": ["type", "count", "sum"]
+        }
+    ]
+}

--- a/internal/apmschema/jsonschema/process.json
+++ b/internal/apmschema/jsonschema/process.json
@@ -1,0 +1,28 @@
+{
+  "$id": "doc/spec/process.json",
+  "title": "Process",
+  "type": ["object", "null"],
+  "properties": {
+      "pid": {
+          "description": "Process ID of the service",
+          "type": ["integer"]
+      },
+      "ppid": {
+          "description": "Parent process ID of the service",
+          "type": ["integer", "null"]
+      },
+      "title": {
+          "type": ["string", "null"],
+          "maxLength": 1024
+      },
+      "argv": {
+        "description": "Command line arguments used to start this process",
+        "type": ["array", "null"],
+        "minItems": 0,
+        "items": {
+           "type": "string"
+        }
+    }
+  },
+  "required": ["pid"]
+}

--- a/internal/apmschema/jsonschema/request.json
+++ b/internal/apmschema/jsonschema/request.json
@@ -1,0 +1,106 @@
+{
+    "$id": "docs/spec/http.json",
+    "title": "Request",
+    "description": "If a log record was generated as a result of a http request, the http interface can be used to collect this information.",
+    "type": ["object", "null"],
+    "properties": {
+        "body": {
+            "description": "Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.",
+            "type": ["object", "string", "null"]
+        },
+        "env": {
+            "description": "The env variable is a compounded of environment information passed from the webserver.",
+            "type": ["object", "null"],
+            "properties": {}
+        },
+        "headers": {
+            "description": "Should include any headers sent by the requester. Cookies will be taken by headers if supplied.",
+            "type": ["object", "null"],
+            "properties": {
+                "content-type": {
+                    "type": ["string", "null"]
+                },
+                "cookie": {
+                    "description": "Cookies sent with the request. It is expected to have values delimited by semicolons.",
+                    "type": ["string", "null"]
+                },
+                "user-agent": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "http_version": {
+            "description": "HTTP version.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "method": {
+            "description": "HTTP method.",
+            "type": "string",
+            "maxLength": 1024
+        },
+        "socket": {
+            "type": ["object", "null"],
+            "properties": {
+                "encrypted": {
+                    "description": "Indicates whether request was sent as SSL/HTTPS request.",
+                    "type": ["boolean", "null"]
+                },
+                "remote_address": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "url": {
+            "description": "A complete Url, with scheme, host and path.",
+            "type": "object",
+            "properties": {
+                "raw": {
+                    "type": ["string", "null"],
+                    "description": "The raw, unparsed URL of the HTTP request line, e.g https://example.com:443/search?q=elasticsearch. This URL may be absolute or relative. For more details, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2.",
+                    "maxLength": 1024
+                },
+                "protocol": {
+                    "type": ["string", "null"],
+                    "description": "The protocol of the request, e.g. 'https:'.",
+                    "maxLength": 1024
+                },
+                "full": {
+                    "type": ["string", "null"],
+                    "description": "The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.",
+                    "maxLength": 1024
+                },
+                "hostname": {
+                    "type": ["string", "null"],
+                    "description": "The hostname of the request, e.g. 'example.com'.",
+                    "maxLength": 1024
+                },
+                "port": {
+                    "type": ["string", "null"],
+                    "description": "The port of the request, e.g. '443'",
+                    "maxLength": 1024
+                },
+                "pathname": {
+                    "type": ["string", "null"],
+                    "description": "The path of the request, e.g. '/search'",
+                    "maxLength": 1024
+                },
+                "search": {
+                    "description": "The search describes the query string of the request. It is expected to have values delimited by ampersands.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "hash": {
+                    "type": ["string", "null"],
+                    "description": "The hash of the request URL, e.g. 'top'",
+                    "maxLength": 1024
+                }
+            }
+        },
+        "cookies": {
+            "description": "A parsed key-value object of cookies",
+            "type": ["object", "null"]
+        }
+    },
+    "required": ["url", "method"]
+}

--- a/internal/apmschema/jsonschema/service.json
+++ b/internal/apmschema/jsonschema/service.json
@@ -1,0 +1,86 @@
+{
+    "$id": "doc/spec/service.json",
+    "title": "Service",
+    "type": "object",
+    "properties": {
+        "agent": {
+            "description": "Name and version of the Elastic APM agent",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "version": {
+                    "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                    "type": "string",
+                    "maxLength": 1024
+                }
+            },
+            "required": ["name", "version"]
+        },
+        "framework": {
+            "description": "Name and version of the web framework used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": "string",
+                    "maxLength": 1024
+                }
+            },
+            "required": ["name", "version"]
+        },
+        "language": {
+            "description": "Name and version of the programming language used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            },
+            "required": ["name"]
+        },
+        "name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024
+        },
+        "environment": {
+            "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "runtime": {
+            "description": "Name and version of the language runtime running this service",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": "string",
+                    "maxLength": 1024
+                }
+            },
+            "required": ["name", "version"]
+        },
+        "version": {
+            "description": "Version of the service emitting this event",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    },
+    "required": ["agent", "name"]
+}

--- a/internal/apmschema/jsonschema/sourcemaps/payload.json
+++ b/internal/apmschema/jsonschema/sourcemaps/payload.json
@@ -1,0 +1,28 @@
+{
+    "$id": "docs/spec/sourcemaps/sourcemap-metadata.json",
+    "title": "Sourcemap Metadata",
+    "description": "Sourcemap Metadata",
+    "type": "object",
+    "properties": {
+        "bundle_filepath": {
+            "description": "relative path of the minified bundle file",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_version": {
+            "description": "Version of the service emitting this event",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024,
+            "minLength": 1
+        }
+    },
+    "required": ["bundle_filepath", "service_name", "service_version"]
+}

--- a/internal/apmschema/jsonschema/stacktrace_frame.json
+++ b/internal/apmschema/jsonschema/stacktrace_frame.json
@@ -1,0 +1,62 @@
+{
+    "$id": "docs/spec/stacktrace_frame.json",
+    "title": "Stacktrace",
+    "type": "object",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
+    "properties": {
+        "abs_path": {
+            "description": "The absolute path of the file involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "colno": {
+            "description": "Column number",
+            "type": ["integer", "null"]
+        },
+        "context_line": {
+            "description": "The line of code part of the stack frame",
+            "type": ["string", "null"]
+        },
+        "filename": {
+            "description": "The relative filename of the code involved in the stack frame, used e.g. to do error checksumming",
+            "type": "string"
+        },
+        "function": {
+            "description": "The function involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "library_frame": {
+            "description": "A boolean, indicating if this frame is from a library or user code",
+            "type": ["boolean", "null"]
+        },
+        "lineno": {
+            "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
+            "type": "integer"
+        },
+        "module": {
+            "description": "The module to which frame belongs to",
+            "type": ["string", "null"]
+        },
+        "post_context": {
+            "description": "The lines of code after the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "pre_context": {
+            "description": "The lines of code before the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "vars": {
+            "description": "Local variables for this stack frame",
+            "type": ["object", "null"],
+            "properties": {}
+        }
+    },
+    "required": ["filename", "lineno"]
+}

--- a/internal/apmschema/jsonschema/system.json
+++ b/internal/apmschema/jsonschema/system.json
@@ -1,0 +1,22 @@
+{
+    "$id": "doc/spec/system.json",
+    "title": "System",
+    "type": ["object", "null"],
+    "properties": {
+        "architecture": {
+            "description": "Architecture of the system the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "hostname": {
+            "description": "Hostname of the system the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "platform": {
+            "description": "Name of the system platform the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    }
+}

--- a/internal/apmschema/jsonschema/transactions/mark.json
+++ b/internal/apmschema/jsonschema/transactions/mark.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/transactions/mark.json",
+    "type": ["object", "null"],
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
+    "regexProperties": true,
+    "patternProperties": {
+        "^[^.*\"]*$": {
+            "type": ["number", "null"]
+        }
+    },
+    "additionalProperties": false
+}

--- a/internal/apmschema/jsonschema/transactions/payload.json
+++ b/internal/apmschema/jsonschema/transactions/payload.json
@@ -1,0 +1,25 @@
+{
+    "$id": "docs/spec/transactions/payload.json",
+    "title": "Transactions payload",
+    "description": "List of transactions wrapped in an object containing some other attributes normalized away from the transactions themselves",
+    "type": "object",
+    "properties": {
+        "service": {
+            "$ref": "../service.json"
+        },
+        "process": {
+            "$ref": "../process.json"
+        },
+        "system": {
+            "$ref": "../system.json"
+        },
+        "transactions": {
+            "type": "array",
+            "items": {
+                "$ref": "transaction.json"
+            },
+            "minItems": 1
+        }
+    },
+    "required": ["service", "transactions"]
+}

--- a/internal/apmschema/jsonschema/transactions/span.json
+++ b/internal/apmschema/jsonschema/transactions/span.json
@@ -1,0 +1,84 @@
+{
+    "$id": "docs/spec/transactions/span.json",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": ["integer", "null"],
+            "description": "The locally unique ID of the span."
+        },
+        "context": {
+            "type": ["object", "null"],
+            "description": "Any other arbitrary data captured by the agent, optionally provided by the user",
+            "properties": {
+                "db": {
+                    "type": ["object", "null"],
+                    "description": "An object containing contextual data for database spans",
+                    "properties": {
+                        "instance": {
+                           "type": ["string", "null"],
+                           "description": "Database instance name"
+                        },
+                        "statement": {
+                           "type": ["string", "null"],
+                           "description": "A database statement (e.g. query) for the given database type"
+                        },
+                        "type": {
+                           "type": ["string", "null"],
+                           "description": "Database type. For any SQL database, \"sql\". For others, the lower-case database category, e.g. \"cassandra\", \"hbase\", or \"redis\""
+                        },
+                        "user": {
+                           "type": ["string", "null"],
+                           "description": "Username for accessing database"
+                        }
+                    }
+                },
+                "http": {
+                    "type": ["object", "null"],
+                    "description": "An object containing contextual data of the related http request.",
+                    "properties": {
+                        "url": {
+                            "type": ["string", "null"],
+                            "description": "The raw url of the correlating http request."
+                        }
+                    }
+                }
+            }
+        },
+        "duration": {
+            "type": "number",
+            "description": "Duration of the span in milliseconds"
+        },
+        "name": {
+            "type": "string",
+            "description": "Generic designation of a span in the scope of a transaction",
+            "maxLength": 1024
+        },
+        "parent": {
+            "type": ["integer", "null"],
+            "description": "The locally unique ID of the parent of the span."
+        },
+        "stacktrace": {
+            "type": ["array", "null"],
+            "description": "List of stack frames with variable attributes (eg: lineno, filename, etc)",
+            "items": {
+                "$ref": "../stacktrace_frame.json"
+            },
+            "minItems": 0
+        },
+        "start": {
+            "type": "number",
+            "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
+        },
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
+            "maxLength": 1024
+        }
+    },
+    "dependencies": {
+        "parent": {
+            "required": ["id"]
+        }
+    },
+    "required": ["duration", "name", "start", "type"]
+}

--- a/internal/apmschema/jsonschema/transactions/transaction.json
+++ b/internal/apmschema/jsonschema/transactions/transaction.json
@@ -1,0 +1,77 @@
+{
+    "$id": "docs/spec/transactions/transaction.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "properties": {
+        "context": {
+            "$ref": "../context.json"
+        },
+        "duration": {
+            "type": "number",
+            "description": "How long the transaction took to complete, in ms with 3 decimal points"
+        },
+        "id": {
+            "type": "string",
+            "description": "UUID for the transaction, referred by its spans",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+        },
+        "name": {
+            "type": ["string","null"],
+            "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
+            "maxLength": 1024
+        },
+        "result": {
+            "type": ["string", "null"],
+            "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
+            "maxLength": 1024
+        },
+        "timestamp": {
+            "type": ["string", "null"],
+            "pattern": "Z$",
+            "format": "date-time",
+            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
+        },
+        "spans": {
+            "type": ["array", "null"],
+            "items": {
+                "$ref": "span.json"
+            },
+            "minItems": 0
+        },
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+            "maxLength": 1024
+        },
+        "marks": {
+            "type": ["object", "null"],
+            "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
+            "regexProperties": true,
+            "patternProperties": {
+                "^[^.*\"]*$": {
+                    "$ref": "mark.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "sampled": {
+            "type": ["boolean", "null"],
+            "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+        },
+        "span_count": {
+            "type": ["object", "null"],
+            "properties": {
+                "dropped": {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "total": {
+                            "type": ["integer","null"],
+                            "description": "Number of spans that have been dropped by the agent recording the transaction."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "required": ["id", "duration", "type"]
+}

--- a/internal/apmschema/jsonschema/user.json
+++ b/internal/apmschema/jsonschema/user.json
@@ -1,0 +1,23 @@
+{
+    "$id": "docs/spec/user.json",
+    "title": "User",
+    "description": "Describes the authenticated User for a request.",
+    "type": ["object", "null"],
+    "properties": {
+        "id": {
+            "description": "Identifier of the logged in user, e.g. the primary key of the user",
+            "type": ["string", "integer", "null"],
+            "maxLength": 1024
+        },
+        "email": {
+            "description": "Email of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "username": {
+            "description": "The username of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    }
+}

--- a/internal/apmschema/schema.go
+++ b/internal/apmschema/schema.go
@@ -1,0 +1,41 @@
+package apmschema
+
+import (
+	"go/build"
+	"log"
+	"path"
+	"path/filepath"
+
+	"github.com/santhosh-tekuri/jsonschema"
+)
+
+var (
+	// Transactions is the compiled JSON Schema for a transactions payload.
+	Transactions *jsonschema.Schema
+
+	// Errors is the compiled JSON Schema for an errors payload.
+	Errors *jsonschema.Schema
+
+	// Metrics is the compiled JSON Schema for a metrics payload.
+	Metrics *jsonschema.Schema
+)
+
+func init() {
+	pkg, err := build.Default.Import("github.com/elastic/apm-agent-go/internal/apmschema", "", build.FindOnly)
+	if err != nil {
+		log.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.Draft = jsonschema.Draft4
+	schemaDir := path.Join(filepath.ToSlash(pkg.Dir), "jsonschema")
+	compile := func(filepath string, out **jsonschema.Schema) {
+		schema, err := compiler.Compile("file://" + path.Join(schemaDir, filepath))
+		if err != nil {
+			log.Fatal(err)
+		}
+		*out = schema
+	}
+	compile("transactions/payload.json", &Transactions)
+	compile("errors/payload.json", &Errors)
+	compile("metrics/payload.json", &Metrics)
+}

--- a/internal/apmschema/update.sh
+++ b/internal/apmschema/update.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -ex
+
+FILES=( \
+    "errors/error.json" \
+    "errors/payload.json" \
+    "sourcemaps/payload.json" \
+    "transactions/mark.json" \
+    "transactions/payload.json" \
+    "transactions/span.json" \
+    "transactions/transaction.json" \
+    "metrics/payload.json" \
+    "metrics/metric.json" \
+    "metrics/sample.json" \
+    "context.json" \
+    "process.json" \
+    "request.json" \
+    "service.json" \
+    "stacktrace_frame.json" \
+    "system.json" \
+    "user.json" \
+)
+
+mkdir -p jsonschema/errors jsonschema/transactions jsonschema/sourcemaps jsonschema/metrics
+
+for i in "${FILES[@]}"; do
+  o=jsonschema/$i
+  curl -sf https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/${i} --compressed -o $o
+done

--- a/model/gofuzz.go
+++ b/model/gofuzz.go
@@ -6,9 +6,8 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/elastic/apm-agent-go/internal/apmschema"
 	"github.com/elastic/apm-agent-go/internal/fastjson"
-	error_processor "github.com/elastic/apm-server/processor/error"
-	transaction_processor "github.com/elastic/apm-server/processor/transaction"
 )
 
 func Fuzz(data []byte) int {
@@ -32,10 +31,6 @@ func Fuzz(data []byte) int {
 	}
 
 	if len(payload.Errors) != 0 {
-		p := error_processor.NewProcessor()
-		if err := p.Validate(raw); err != nil {
-			return 0
-		}
 		payload := ErrorsPayload{
 			Service: payload.Service,
 			Process: payload.Process,
@@ -44,20 +39,12 @@ func Fuzz(data []byte) int {
 		}
 		var w fastjson.Writer
 		payload.MarshalFastJSON(&w)
-		raw := make(map[string]interface{})
-		if err := json.Unmarshal(w.Bytes(), &raw); err != nil {
-			return -1
-		}
-		if err := p.Validate(raw); err != nil {
+		if err := apmschema.Errors.Validate(bytes.NewReader(w.Bytes())); err != nil {
 			panic(err)
 		}
 	}
 
 	if len(payload.Transactions) != 0 {
-		p := transaction_processor.NewProcessor()
-		if err := p.Validate(raw); err != nil {
-			return 0
-		}
 		payload := TransactionsPayload{
 			Service:      payload.Service,
 			Process:      payload.Process,
@@ -66,11 +53,7 @@ func Fuzz(data []byte) int {
 		}
 		var w fastjson.Writer
 		payload.MarshalFastJSON(&w)
-		raw := make(map[string]interface{})
-		if err := json.Unmarshal(w.Bytes(), &raw); err != nil {
-			return -1
-		}
-		if err := p.Validate(raw); err != nil {
+		if err := apmschema.Transactions.Validate(bytes.NewReader(w.Bytes())); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
Vendor the JSON schema in internal/apmschema;
parse them when importing that package. This
is intended for testing only; all tests have
been updated to use this.