### PR TITLE
Transaction.Context methods for setting user IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - module/apmsql: SQL is parsed to generate more useful span names (#129)
  - Basic vgo module added (#136)
  - module/apmhttprouter: added a wrapper type for httprouter.Router to simplify adding routes (#140)
+ - Add Transaction.Context methods for setting user IDs (#144)
 
 ## [v0.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.4.0)
 

--- a/context.go
+++ b/context.go
@@ -179,3 +179,27 @@ func (c *Context) SetHTTPStatusCode(statusCode int) {
 	c.response.StatusCode = statusCode
 	c.model.Response = &c.response
 }
+
+// SetUserID sets the ID of the authenticated user.
+func (c *Context) SetUserID(id string) {
+	c.user.ID = truncateString(id)
+	if c.user.ID != "" {
+		c.model.User = &c.user
+	}
+}
+
+// SetUserEmail sets the email for the authenticated user.
+func (c *Context) SetUserEmail(email string) {
+	c.user.Email = truncateString(email)
+	if c.user.Email != "" {
+		c.model.User = &c.user
+	}
+}
+
+// SetUsername sets the username of the authenticated user.
+func (c *Context) SetUsername(username string) {
+	c.user.Username = truncateString(username)
+	if c.user.Username != "" {
+		c.model.User = &c.user
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,49 @@
+package elasticapm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestContextUser(t *testing.T) {
+	t.Run("email", func(t *testing.T) {
+		tx := testSendTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetUserEmail("testing@host.invalid")
+		})
+		assert.Equal(t, &model.User{Email: "testing@host.invalid"}, tx.Context.User)
+	})
+	t.Run("username", func(t *testing.T) {
+		tx := testSendTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetUsername("schnibble")
+		})
+		assert.Equal(t, &model.User{Username: "schnibble"}, tx.Context.User)
+	})
+	t.Run("id", func(t *testing.T) {
+		tx := testSendTransaction(t, func(tx *elasticapm.Transaction) {
+			tx.Context.SetUserID("123")
+		})
+		assert.Equal(t, &model.User{ID: "123"}, tx.Context.User)
+	})
+}
+
+func testSendTransaction(t *testing.T, f func(tx *elasticapm.Transaction)) model.Transaction {
+	tracer, r := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	tx := tracer.StartTransaction("name", "type")
+	f(tx)
+	tx.End()
+	tracer.Flush(nil)
+
+	payloads := r.Payloads()
+	require.Len(t, payloads, 1)
+	transactions := payloads[0].Transactions()
+	require.Len(t, transactions, 1)
+	return transactions[0]
+}

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -178,6 +178,24 @@ only restriction is that the name may not contain any special characters
 (`.`, `*`, or `"`), and the value must be JSON-encodable. Custom context
 will not be indexed in Elasticsearch, but will be included in the document.
 
+[float]
+[[context-set-username]]
+==== `func (*Context) SetUsername(username string)`
+
+SetUsername records the username of the user associated with the transaction.
+
+[float]
+[[context-set-user-id]]
+==== `func (*Context) SetUserID(id string)`
+
+SetUserID records the ID of the user associated with the transaction.
+
+[float]
+[[context-set-user-email]]
+==== `func (*Context) SetUserEmail(email string)`
+
+SetUserEmail records the email address of the user associated with the transaction.
+
 // -------------------------------------------------------------------------------------------------
 
 [float]

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -281,37 +281,6 @@ func (c *ExceptionCode) isZero() bool {
 	return c.String == "" && c.Number == 0
 }
 
-// MarshalFastJSON writes the JSON representation of c to w.
-func (u *UserID) MarshalFastJSON(w *fastjson.Writer) {
-	if u.String != "" {
-		w.String(u.String)
-		return
-	}
-	w.Float64(u.Number)
-}
-
-// UnmarshalJSON unmarshals the JSON data into c.
-func (u *UserID) UnmarshalJSON(data []byte) error {
-	var v interface{}
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	switch v := v.(type) {
-	case string:
-		u.String = v
-	case float64:
-		u.Number = v
-	default:
-		return errors.Errorf("expected string or number, got %T", v)
-	}
-	return nil
-}
-
-// isZero is used by fastjson to implement omitempty.
-func (u *UserID) isZero() bool {
-	return u.String == "" && u.Number == 0
-}
-
 // MarshalFastJSON writes the JSON representation of b to w.
 func (b *RequestBody) MarshalFastJSON(w *fastjson.Writer) {
 	if b.Form != nil {

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -367,7 +367,7 @@ func (v *User) MarshalFastJSON(w *fastjson.Writer) {
 		}
 		w.String(v.Email)
 	}
-	if !v.ID.isZero() {
+	if v.ID != "" {
 		const prefix = ",\"id\":"
 		if first {
 			first = false
@@ -375,7 +375,7 @@ func (v *User) MarshalFastJSON(w *fastjson.Writer) {
 		} else {
 			w.RawString(prefix)
 		}
-		v.ID.MarshalFastJSON(w)
+		w.String(v.ID)
 	}
 	if v.Username != "" {
 		const prefix = ",\"username\":"

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -349,12 +349,12 @@ func TestMarshalExceptionCode(t *testing.T) {
 func TestMarshalUser(t *testing.T) {
 	user := model.User{
 		Email:    "foo@example.com",
-		ID:       model.UserID{Number: 123},
+		ID:       "123",
 		Username: "bar",
 	}
 	var w fastjson.Writer
 	user.MarshalFastJSON(&w)
-	assert.Equal(t, `{"email":"foo@example.com","id":123,"username":"bar"}`, string(w.Bytes()))
+	assert.Equal(t, `{"email":"foo@example.com","id":"123","username":"bar"}`, string(w.Bytes()))
 }
 
 func TestMarshalStacktraceFrame(t *testing.T) {

--- a/model/model.go
+++ b/model/model.go
@@ -236,16 +236,10 @@ type User struct {
 
 	// ID identifies the user, e.g. a primary key. This may be
 	// a string or number.
-	ID UserID `json:"id,omitempty"`
+	ID string `json:"id,omitempty"`
 
 	// Email holds the email address of the user.
 	Email string `json:"email,omitempty"`
-}
-
-// UserID represents a user ID as either a number or a string.
-type UserID struct {
-	String string
-	Number float64
 }
 
 // Error represents an error occurring in the service.

--- a/validation_test.go
+++ b/validation_test.go
@@ -69,6 +69,14 @@ func TestValidateSpanType(t *testing.T) {
 
 func TestValidateContextUser(t *testing.T) {
 	validateTransaction(t, func(tx *elasticapm.Transaction) {
+		tx.Context.SetUsername(strings.Repeat("x", 1025))
+		tx.Context.SetUserEmail(strings.Repeat("x", 1025))
+		tx.Context.SetUserID(strings.Repeat("x", 1025))
+	})
+}
+
+func TestValidateContextUserBasicAuth(t *testing.T) {
+	validateTransaction(t, func(tx *elasticapm.Transaction) {
 		req, err := http.NewRequest("GET", "/", nil)
 		require.NoError(t, err)
 		req.SetBasicAuth(strings.Repeat("x", 1025), "")


### PR DESCRIPTION
Add methods to Transaction.Context for setting the user ID/username/email. Remove the ability to set a numeric user ID.