### PR TITLE
Pare back the metrics API

### DIFF
--- a/internal/apmschema/jsonschema/context.json
+++ b/internal/apmschema/jsonschema/context.json
@@ -7,7 +7,6 @@
         "custom": {
             "description": "An arbitrary mapping of additional metadata to store with the event.",
             "type": ["object", "null"],
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {}
             },
@@ -44,7 +43,6 @@
         "tags": {
             "type": ["object", "null"],
             "description": "A flat mapping of user-defined tags with string values.",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
                     "type": ["string", "null"],

--- a/internal/apmschema/jsonschema/metrics/metric.json
+++ b/internal/apmschema/jsonschema/metrics/metric.json
@@ -7,7 +7,6 @@
         "samples": {
             "type": ["object"],
             "description": "Sampled application metrics collected from the agent",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^*\"]*$": {
                     "$ref": "sample.json"
@@ -18,7 +17,6 @@
         "tags": {
             "type": ["object", "null"],
             "description": "A flat mapping of user-defined tags with string values",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^*\"]*$": {
                     "type": ["string", "null"],

--- a/internal/apmschema/jsonschema/metrics/sample.json
+++ b/internal/apmschema/jsonschema/metrics/sample.json
@@ -3,71 +3,8 @@
     "$id": "docs/spec/metrics/sample.json",
     "type": ["object", "null"],
     "description": "A single metric sample.",
-    "anyOf": [
-        {
-            "properties": {
-                "type": {
-                    "description": "Counters and gauges capture a single value at a point in time.  Counter are cumulative, strictly increasing or decreasing, and typically most useful with derivative aggregations.  Gauges increase and decrease over time.",
-                    "enum": ["counter", "gauge"]
-                },
-                "unit": {
-                    "type": ["string", "null"]
-                },
-                "value": {"type": "number"}
-            },
-            "required": ["type", "value"]
-        },
-        {
-            "properties": {
-                "type": {
-                    "description": "Summary metrics capture client-side aggregations describing the distribution of a metric",
-                    "enum": ["summary"]
-                },
-                "unit": {
-                    "description": "The unit of measurement of this metric eg: bytes. Only informational at this time",
-                    "type": ["string", "null"]
-                },
-                "count": {
-                    "description": "The total count of all observations for this metric",
-                    "type": "number"
-                },
-                "sum": {
-                    "description": "The sum of all observations for this metric",
-                    "type": "number"
-                },
-                "stddev": {
-                    "description": "The standard deviation describing this metric",
-                    "type": ["number", "null"]
-                },
-                "min": {
-                    "description": "The minimum value observed for this metric",
-                    "type": ["number", "null"]
-                },
-                "max": {
-                    "description": "The maximum value observed for this metric",
-                    "type": ["number", "null"]
-                },
-                "quantiles": {
-                    "description": "A list of quantiles describing the metric",
-                    "type": ["array", "null"],
-                    "items": {
-                        "descrption": "A [quantile, value] tuple",
-                        "type": ["array", "null"],
-                        "items": [
-                            {
-                                "type": "number",
-                                "minimum": 0, "maximum": 1
-                            },
-                            {
-                                "type": "number"
-                            }
-                        ],
-                        "maxItems": 2,
-                        "minItems": 2
-                    }
-                }
-            },
-            "required": ["type", "count", "sum"]
-        }
-    ]
+    "properties": {
+        "value": {"type": "number"}
+    },
+    "required": ["value"]
 }

--- a/internal/apmschema/jsonschema/transactions/mark.json
+++ b/internal/apmschema/jsonschema/transactions/mark.json
@@ -2,7 +2,6 @@
     "$id": "docs/spec/transactions/mark.json",
     "type": ["object", "null"],
     "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
-    "regexProperties": true,
     "patternProperties": {
         "^[^.*\"]*$": {
             "type": ["number", "null"]

--- a/internal/apmschema/jsonschema/transactions/transaction.json
+++ b/internal/apmschema/jsonschema/transactions/transaction.json
@@ -46,7 +46,6 @@
         "marks": {
             "type": ["object", "null"],
             "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
                     "$ref": "mark.json"

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -29,81 +29,53 @@ func TestTracerMetricsBuiltin(t *testing.T) {
 	assert.Nil(t, builtinMetrics.Labels)
 	assert.NotEmpty(t, builtinMetrics.Timestamp)
 
-	gcPct := builtinMetrics.Samples["go.mem.gc.cpu.pct"]
+	gcPct := builtinMetrics.Samples["golang.heap.gc.cpu_fraction"]
 	if assert.NotNil(t, gcPct.Value) && runtime.GOOS == "linux" {
 		// NOTE(axw) on Windows and macOS, sometimes
 		// MemStats.GCCPUFraction is outside the expected
 		// range [0,1). We should isolate the issue and
 		// report it upstream.
 		assert.Condition(t, func() bool {
-			return *gcPct.Value >= 0 && *gcPct.Value <= 100
-		}, "value: %v", *gcPct.Value)
+			return gcPct.Value >= 0 && gcPct.Value <= 1
+		}, "value: %v", gcPct.Value)
 	}
 
-	var dummy float64 = 123
-	maybeSetFloat64 := func(ptr *float64, to float64) {
-		if ptr != nil {
-			*ptr = to
-		}
-	}
-	for _, m := range builtinMetrics.Samples {
-		maybeSetFloat64(m.Value, dummy)
-		if m.Count != nil {
-			*m.Count = uint64(dummy)
-		}
-		maybeSetFloat64(m.Sum, dummy)
-		maybeSetFloat64(m.Min, dummy)
-		maybeSetFloat64(m.Max, dummy)
-		maybeSetFloat64(m.Stddev, dummy)
-		for i := range m.Quantiles {
-			m.Quantiles[i].Value = dummy
-		}
-	}
+	expected := []string{
+		"golang.goroutines",
+		"golang.heap.allocations.mallocs",
+		"golang.heap.allocations.frees",
+		"golang.heap.allocations.objects",
+		"golang.heap.allocations.total",
+		"golang.heap.allocations.allocated",
+		"golang.heap.allocations.idle",
+		"golang.heap.allocations.active",
+		"golang.heap.system.total",
+		"golang.heap.system.obtained",
+		"golang.heap.system.stack",
+		"golang.heap.system.released",
+		"golang.heap.gc.next_gc_limit",
+		"golang.heap.gc.total_count",
+		"golang.heap.gc.total_pause.ns",
+		"golang.heap.gc.cpu_fraction",
+		"golang.heap.gc.pause.min.ns",
+		"golang.heap.gc.pause.max.ns",
+		"golang.heap.gc.pause.percentile.25.ns",
+		"golang.heap.gc.pause.percentile.50.ns",
+		"golang.heap.gc.pause.percentile.75.ns",
 
-	counterMetric := func(unit string) model.Metric {
-		return model.Metric{Type: "counter", Unit: unit, Value: &dummy}
+		"agent.transactions.sent",
+		"agent.transactions.dropped",
+		"agent.transactions.send_errors",
+		"agent.errors.sent",
+		"agent.errors.dropped",
+		"agent.errors.send_errors",
 	}
-	gaugeMetric := func(unit string) model.Metric {
-		return model.Metric{Type: "gauge", Unit: unit, Value: &dummy}
+	for _, name := range expected {
+		assert.Contains(t, builtinMetrics.Samples, name)
 	}
-
-	gcSummaryMetric := model.Metric{
-		Type:  "summary",
-		Unit:  "sec",
-		Count: newUint64(uint64(dummy)),
-		Sum:   newFloat64(dummy),
-		Quantiles: []model.Quantile{
-			{Quantile: 0, Value: dummy},
-			{Quantile: 0.25, Value: dummy},
-			{Quantile: 0.5, Value: dummy},
-			{Quantile: 0.75, Value: dummy},
-			{Quantile: 1, Value: dummy},
-		},
+	for name := range builtinMetrics.Samples {
+		assert.Contains(t, expected, name)
 	}
-
-	assert.Equal(t, map[string]model.Metric{
-		"go.goroutines": gaugeMetric(""),
-
-		"go.mem.heap.mallocs":       counterMetric(""),
-		"go.mem.heap.frees":         counterMetric(""),
-		"go.mem.heap.alloc":         gaugeMetric("byte"),
-		"go.mem.heap.alloc_total":   counterMetric("byte"),
-		"go.mem.heap.idle":          gaugeMetric("byte"),
-		"go.mem.heap.inuse":         gaugeMetric("byte"),
-		"go.mem.heap.alloc_objects": gaugeMetric(""),
-		"go.mem.sys":                gaugeMetric("byte"),
-		"go.mem.gc.cpu.pct":         gaugeMetric(""),
-		"go.mem.gc.last":            gaugeMetric("sec"),
-		"go.mem.gc.next":            gaugeMetric("byte"),
-		"go.mem.gc.pause":           gcSummaryMetric,
-
-		"elasticapm.transactions.sent":        counterMetric(""),
-		"elasticapm.transactions.dropped":     counterMetric(""),
-		"elasticapm.transactions.send_errors": counterMetric(""),
-		"elasticapm.errors.sent":              counterMetric(""),
-		"elasticapm.errors.dropped":           counterMetric(""),
-		"elasticapm.errors.send_errors":       counterMetric(""),
-	}, builtinMetrics.Samples)
 }
 
 func TestTracerMetricsGatherer(t *testing.T) {
@@ -112,11 +84,11 @@ func TestTracerMetricsGatherer(t *testing.T) {
 
 	tracer.RegisterMetricsGatherer(elasticapm.GatherMetricsFunc(
 		func(ctx context.Context, m *elasticapm.Metrics) error {
-			m.AddCounter("http.request", "", []elasticapm.MetricLabel{
+			m.Add("http.request", []elasticapm.MetricLabel{
 				{Name: "code", Value: "400"},
 				{Name: "path", Value: "/"},
 			}, 3)
-			m.AddCounter("http.request", "", []elasticapm.MetricLabel{
+			m.Add("http.request", []elasticapm.MetricLabel{
 				{Name: "code", Value: "200"},
 			}, 4)
 			return nil
@@ -131,23 +103,13 @@ func TestTracerMetricsGatherer(t *testing.T) {
 	require.Len(t, metrics, 3)
 
 	assert.Equal(t, model.StringMap{{Key: "code", Value: "200"}}, metrics[1].Labels)
-	assert.Equal(t, map[string]model.Metric{
-		"http.request": {
-			Type:  "counter",
-			Value: newFloat64(4),
-		},
-	}, metrics[1].Samples)
+	assert.Equal(t, map[string]model.Metric{"http.request": {Value: 4}}, metrics[1].Samples)
 
 	assert.Equal(t, model.StringMap{
 		{Key: "code", Value: "400"},
 		{Key: "path", Value: "/"},
 	}, metrics[2].Labels)
-	assert.Equal(t, map[string]model.Metric{
-		"http.request": {
-			Type:  "counter",
-			Value: newFloat64(3),
-		},
-	}, metrics[2].Samples)
+	assert.Equal(t, map[string]model.Metric{"http.request": {Value: 3}}, metrics[2].Samples)
 }
 
 func TestTracerMetricsDeregister(t *testing.T) {
@@ -156,7 +118,7 @@ func TestTracerMetricsDeregister(t *testing.T) {
 
 	g := elasticapm.GatherMetricsFunc(
 		func(ctx context.Context, m *elasticapm.Metrics) error {
-			m.AddCounter("with_labels", "", []elasticapm.MetricLabel{
+			m.Add("with_labels", []elasticapm.MetricLabel{
 				{Name: "code", Value: "200"},
 			}, 4)
 			return nil
@@ -172,12 +134,4 @@ func TestTracerMetricsDeregister(t *testing.T) {
 
 	metrics := payloads[0].Metrics()
 	require.Len(t, metrics, 1) // just the builtin/unlabeled metrics
-}
-
-func newUint64(v uint64) *uint64 {
-	return &v
-}
-
-func newFloat64(f float64) *float64 {
-	return &f
 }

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -438,26 +438,6 @@ func (*StringMapItem) MarshalFastJSON(*fastjson.Writer) {
 	panic("unreachable")
 }
 
-// MarshalFastJSON writes the JSON representation of q to w.
-func (q *Quantile) MarshalFastJSON(w *fastjson.Writer) {
-	w.RawByte('[')
-	w.Float64(q.Quantile)
-	w.RawByte(',')
-	w.Float64(q.Value)
-	w.RawByte(']')
-}
-
-// UnmarshalJSON unmarshals the JSON data into q.
-func (q *Quantile) UnmarshalJSON(data []byte) error {
-	var values []float64
-	if err := json.Unmarshal(data, &values); err != nil {
-		return err
-	}
-	q.Quantile = values[0]
-	q.Value = values[1]
-	return nil
-}
-
 func (id *UUID) isZero() bool {
 	return *id == UUID{}
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -778,47 +778,8 @@ func (v *Metrics) MarshalFastJSON(w *fastjson.Writer) {
 
 func (v *Metric) MarshalFastJSON(w *fastjson.Writer) {
 	w.RawByte('{')
-	w.RawString("\"type\":")
-	w.String(v.Type)
-	if v.Count != nil {
-		w.RawString(",\"count\":")
-		w.Uint64(*v.Count)
-	}
-	if v.Max != nil {
-		w.RawString(",\"max\":")
-		w.Float64(*v.Max)
-	}
-	if v.Min != nil {
-		w.RawString(",\"min\":")
-		w.Float64(*v.Min)
-	}
-	if v.Quantiles != nil {
-		w.RawString(",\"quantiles\":")
-		w.RawByte('[')
-		for i, v := range v.Quantiles {
-			if i != 0 {
-				w.RawByte(',')
-			}
-			v.MarshalFastJSON(w)
-		}
-		w.RawByte(']')
-	}
-	if v.Stddev != nil {
-		w.RawString(",\"stddev\":")
-		w.Float64(*v.Stddev)
-	}
-	if v.Sum != nil {
-		w.RawString(",\"sum\":")
-		w.Float64(*v.Sum)
-	}
-	if v.Unit != "" {
-		w.RawString(",\"unit\":")
-		w.String(v.Unit)
-	}
-	if v.Value != nil {
-		w.RawString(",\"value\":")
-		w.Float64(*v.Value)
-	}
+	w.RawString("\"value\":")
+	w.Float64(v.Value)
 	w.RawByte('}')
 }
 

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -122,29 +122,11 @@ func TestMarshalMetrics(t *testing.T) {
 			"foo": "bar",
 		},
 		"samples": map[string]interface{}{
-			"counter_metric": map[string]interface{}{
-				"type":  "counter",
-				"unit":  "byte",
+			"metric_one": map[string]interface{}{
 				"value": float64(1024),
 			},
-			"gauge_metric": map[string]interface{}{
-				"type":  "gauge",
+			"metric_two": map[string]interface{}{
 				"value": float64(-66.6),
-			},
-			"summary_metric": map[string]interface{}{
-				"type":   "summary",
-				"count":  float64(3),
-				"sum":    float64(300),
-				"stddev": float64(40.82),
-				"min":    float64(50),
-				"max":    float64(150),
-				"quantiles": []interface{}{
-					[]interface{}{float64(0.00), float64(50)},
-					[]interface{}{float64(0.25), float64(50)},
-					[]interface{}{float64(0.50), float64(100)},
-					[]interface{}{float64(0.75), float64(100)},
-					[]interface{}{float64(1.00), float64(100)},
-				},
 			},
 		},
 	}
@@ -589,30 +571,8 @@ func fakeMetrics() *model.Metrics {
 		Timestamp: model.Time(time.Unix(123, 0).UTC()),
 		Labels:    model.StringMap{{Key: "foo", Value: "bar"}},
 		Samples: map[string]model.Metric{
-			"counter_metric": {
-				Type:  "counter",
-				Unit:  "byte",
-				Value: newFloat64(1024),
-			},
-			"gauge_metric": {
-				Type:  "gauge",
-				Value: newFloat64(-66.6),
-			},
-			"summary_metric": {
-				Type:   "summary",
-				Count:  newUint64(3),
-				Sum:    newFloat64(300),
-				Stddev: newFloat64(40.82),
-				Min:    newFloat64(50),
-				Max:    newFloat64(150),
-				Quantiles: []model.Quantile{
-					{Quantile: 0, Value: 50},
-					{Quantile: 0.25, Value: 50},
-					{Quantile: 0.5, Value: 100},
-					{Quantile: 0.75, Value: 100},
-					{Quantile: 1, Value: 100},
-				},
-			},
+			"metric_one": {Value: 1024},
+			"metric_two": {Value: -66.6},
 		},
 	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -501,36 +501,6 @@ type Metrics struct {
 
 // Metric holds metric values.
 type Metric struct {
-	// Type is the metric type: "counter", "gauge", or "summary".
-	Type string `json:"type"`
-
-	// Unit holds the metric unit, e.g. "byte", or "sec".
-	Unit string `json:"unit,omitempty"`
-
-	// Value holds the value for gauge and counter metrics.
-	Value *float64 `json:"value,omitempty"`
-
-	// Count holds the count for summary metrics.
-	Count *uint64 `json:"count,omitempty"`
-
-	// Sum holds the sum for summary metrics.
-	Sum *float64 `json:"sum,omitempty"`
-
-	// Min holds the minimum value for summary metrics.
-	Min *float64 `json:"min,omitempty"`
-
-	// Max holds the maximum value for summary metrics.
-	Max *float64 `json:"max,omitempty"`
-
-	// Stddev holds the standard deviation for summary metrics.
-	Stddev *float64 `json:"stddev,omitempty"`
-
-	// Quantiles holds φ-quantiles for summary metrics.
-	Quantiles []Quantile `json:"quantiles,omitempty"`
-}
-
-// Quantile represents a φ-quantile for a summary metric.
-type Quantile struct {
-	Quantile float64
-	Value    float64
+	// Value holds the metric value.
+	Value float64 `json:"value"`
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -206,28 +206,10 @@ func TestValidateErrorLog(t *testing.T) {
 
 func TestValidateMetrics(t *testing.T) {
 	gather := func(ctx context.Context, m *elasticapm.Metrics) error {
-		m.AddCounter("counter", "", nil, -66)
-		m.AddCounter("counter_with_labels", "", []elasticapm.MetricLabel{
+		m.Add("without_labels", nil, -66)
+		m.Add("with_labels", []elasticapm.MetricLabel{
 			{Name: "name", Value: "value"},
 		}, -66)
-		m.AddCounter("counter_with_unit", "bytes", nil, -66)
-		m.AddGauge("gauge", "", nil, 123.45)
-
-		min := float64(-66)
-		max := float64(66)
-		stddev := float64(2)
-		m.AddSummary("summary", "", nil, elasticapm.SummaryMetric{
-			Count:  123,
-			Sum:    456,
-			Min:    &min,
-			Max:    &max,
-			Stddev: &stddev,
-			Quantiles: map[float64]float64{
-				0.25: 1,
-				0.50: 2,
-				0.75: 3,
-			},
-		})
 		return nil
 	}
 


### PR DESCRIPTION
For the initial implementation of metrics, we won't support specifying metric types or units, nor will we support summary metrics (in the API, schema, or wire protocol; bridges may still transform and send them). This is in line with existing metrics in the Elastic Stack (namely Metricbeat), and how they are today interpreted in Kibana.

Also, rename some of the builtin metrics to align with Metricbeat.