### PR TITLE
Add ELASTIC_APM_SERVER_TIMEOUT config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - module/apmhttprouter: added a wrapper type for httprouter.Router to simplify adding routes (#140)
  - Add Transaction.Context methods for setting user IDs (#144)
  - module/apmgocql: new instrumentation module, providing an observer for gocql (#148)
+ - Add ELASTIC\_APM\_SERVER\_TIMEOUT config (#157)
 
 ## [v0.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.4.0)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -28,6 +28,19 @@ that the server certificate can be verified. You can also disable certificate
 verification with <<config-verify-server-cert>>.
 
 [float]
+[[config-server-timeout]]
+=== `ELASTIC_APM_SERVER_TIMEOUT`
+
+[options="header"]
+|============
+| Environment                  | Default | Example
+| `ELASTIC_APM_SERVER_TIMEOUT` | `30s`   | `30s`
+|============
+
+The timeout for requests made to your Elastic APM server. When set to zero
+or a negative value, timeouts will be disabled.
+
+[float]
 [[config-secret-token]]
 === `ELASTIC_APM_SECRET_TOKEN`
 

--- a/env.go
+++ b/env.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-agent-go/internal/apmconfig"
 )
 
 const (
@@ -51,11 +53,11 @@ var (
 )
 
 func initialFlushInterval() (time.Duration, error) {
-	return parseEnvDuration(envFlushInterval, "s", defaultFlushInterval)
+	return apmconfig.ParseDurationEnv(envFlushInterval, "s", defaultFlushInterval)
 }
 
 func initialMetricsInterval() (time.Duration, error) {
-	return parseEnvDuration(envMetricsInterval, "s", defaultMetricsInterval)
+	return apmconfig.ParseDurationEnv(envMetricsInterval, "s", defaultMetricsInterval)
 }
 
 func initialMaxTransactionQueueSize() (int, error) {
@@ -148,7 +150,7 @@ func initialService() (name, version, environment string) {
 }
 
 func initialSpanFramesMinDuration() (time.Duration, error) {
-	return parseEnvDuration(envSpanFramesMinDuration, "", defaultSpanFramesMinDuration)
+	return apmconfig.ParseDurationEnv(envSpanFramesMinDuration, "", defaultSpanFramesMinDuration)
 }
 
 func initialActive() (bool, error) {
@@ -161,26 +163,4 @@ func initialActive() (bool, error) {
 		return false, errors.Wrapf(err, "failed to parse %s", envActive)
 	}
 	return active, nil
-}
-
-func parseEnvDuration(envKey, defaultSuffix string, defaultDuration time.Duration) (time.Duration, error) {
-	value := os.Getenv(envKey)
-	if value == "" {
-		return defaultDuration, nil
-	}
-	d, err := time.ParseDuration(value)
-	if err != nil && defaultSuffix != "" {
-		// We allow the value to have no suffix, in which case we append
-		// defaultSuffix ("s" for flush interval) for compatibility with
-		// configuration for other Elastic APM agents.
-		var err2 error
-		d, err2 = time.ParseDuration(value + defaultSuffix)
-		if err2 == nil {
-			err = nil
-		}
-	}
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed to parse %s", envKey)
-	}
-	return d, nil
 }

--- a/internal/apmconfig/duration.go
+++ b/internal/apmconfig/duration.go
@@ -1,0 +1,25 @@
+package apmconfig
+
+import (
+	"time"
+)
+
+// ParseDuration parses value as a duration, appending defaultSuffix if value
+// does not have one.
+func ParseDuration(value, defaultSuffix string) (time.Duration, error) {
+	d, err := time.ParseDuration(value)
+	if err != nil && defaultSuffix != "" {
+		// We allow the value to have no suffix, in which case we append
+		// defaultSuffix ("s" for flush interval) for compatibility with
+		// configuration for other Elastic APM agents.
+		var err2 error
+		d, err2 = time.ParseDuration(value + defaultSuffix)
+		if err2 == nil {
+			err = nil
+		}
+	}
+	if err != nil {
+		return 0, err
+	}
+	return d, nil
+}

--- a/internal/apmconfig/env.go
+++ b/internal/apmconfig/env.go
@@ -1,0 +1,24 @@
+package apmconfig
+
+import (
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ParseDurationEnv gets the value of the environment variable envKey
+// and, if set, parses it as a duration. If the value has no suffix,
+// defaultSuffix is appended. If the environment variable is unset,
+// defaultDuration is returned.
+func ParseDurationEnv(envKey, defaultSuffix string, defaultDuration time.Duration) (time.Duration, error) {
+	value := os.Getenv(envKey)
+	if value == "" {
+		return defaultDuration, nil
+	}
+	d, err := ParseDuration(value, defaultSuffix)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to parse %s", envKey)
+	}
+	return d, nil
+}

--- a/internal/apmconfig/env_test.go
+++ b/internal/apmconfig/env_test.go
@@ -1,0 +1,34 @@
+package apmconfig_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go/internal/apmconfig"
+)
+
+func TestParseDurationEnv(t *testing.T) {
+	const envKey = "ELASTIC_APM_TEST_DURATION"
+	os.Setenv(envKey, "")
+
+	d, err := apmconfig.ParseDurationEnv(envKey, "s", 42*time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 42*time.Second, d)
+
+	os.Setenv(envKey, "5")
+	d, err = apmconfig.ParseDurationEnv(envKey, "s", 42*time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Second, d)
+
+	os.Setenv(envKey, "5ms")
+	d, err = apmconfig.ParseDurationEnv(envKey, "s", 42*time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Millisecond, d)
+
+	os.Setenv(envKey, "5")
+	_, err = apmconfig.ParseDurationEnv(envKey, "", 42*time.Second)
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: time: missing unit in duration 5")
+}


### PR DESCRIPTION
Defaults to 30s, but can be overridden. If set to a non-positive value, timeout is disabled.

Closes elastic/apm-agent-go#155 