### PR TITLE
module/apmhttp: support ELASTIC_APM_IGNORE_URLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - Add Transaction.Context methods for setting user IDs (#144)
  - module/apmgocql: new instrumentation module, providing an observer for gocql (#148)
  - Add ELASTIC\_APM\_SERVER\_TIMEOUT config (#157)
+ - Add ELASTIC\_APM\_IGNORE\_URLS config (#158)
 
 ## [v0.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.4.0)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -119,6 +119,24 @@ Enable or disable the tracer. If set to false, then the Go agent does not send
 any data to the Elastic APM server, and instrumentation overhead is minimized.
 
 [float]
+[[config-ignore-urls]]
+=== `ELASTIC_APM_IGNORE_URLS`
+
+[options="header"]
+|============
+| Environment               | Default | Example
+| `ELASTIC_APM_IGNORE_URLS` |         | `/heartbeat\|/_internal/.*`
+|============
+
+A regular expression matching the request line of HTTP requests for which
+transactions should not be reported.
+
+The pattern specified in `ELASTIC_APM_IGNORE_URLS` is treated
+case-insensitively by default. To override this behavior and match case-sensitively,
+wrap the value like `(?-i:<value>)`. For a full definition of Go's regular
+expression syntax, see https://golang.org/pkg/regexp/syntax/.
+
+[float]
 [[config-sanitize-field-names]]
 === `ELASTIC_APM_SANITIZE_FIELD_NAMES`
 

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -27,7 +27,11 @@ func init() {
 // By default, the middleware will use elasticapm.DefaultTracer.
 // Use WithTracer to specify an alternative tracer.
 func Middleware(engine *gin.Engine, o ...Option) gin.HandlerFunc {
-	m := &middleware{engine: engine, tracer: elasticapm.DefaultTracer}
+	m := &middleware{
+		engine:         engine,
+		tracer:         elasticapm.DefaultTracer,
+		requestIgnorer: apmhttp.DefaultServerRequestIgnorer(),
+	}
 	for _, o := range o {
 		o(m)
 	}
@@ -35,8 +39,9 @@ func Middleware(engine *gin.Engine, o ...Option) gin.HandlerFunc {
 }
 
 type middleware struct {
-	engine *gin.Engine
-	tracer *elasticapm.Tracer
+	engine         *gin.Engine
+	tracer         *elasticapm.Tracer
+	requestIgnorer apmhttp.RequestIgnorerFunc
 
 	setRouteMapOnce sync.Once
 	routeMap        map[string]map[string]routeInfo
@@ -47,7 +52,7 @@ type routeInfo struct {
 }
 
 func (m *middleware) handle(c *gin.Context) {
-	if !m.tracer.Active() {
+	if !m.tracer.Active() || m.requestIgnorer(c.Request) {
 		c.Next()
 		return
 	}
@@ -127,5 +132,17 @@ func WithTracer(t *elasticapm.Tracer) Option {
 	}
 	return func(m *middleware) {
 		m.tracer = t
+	}
+}
+
+// WithRequestIgnorer returns a Option which sets r as the
+// function to use to determine whether or not a request should
+// be ignored. If r is nil, all requests will be reported.
+func WithRequestIgnorer(r apmhttp.RequestIgnorerFunc) Option {
+	if r == nil {
+		r = apmhttp.IgnoreNone
+	}
+	return func(m *middleware) {
+		m.requestIgnorer = r
 	}
 }

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -33,7 +33,7 @@ func WrapRoundTripper(r http.RoundTripper, o ...ClientOption) http.RoundTripper 
 	rt := &roundTripper{
 		r:              r,
 		requestName:    ClientRequestName,
-		requestIgnorer: ignoreNone,
+		requestIgnorer: IgnoreNone,
 	}
 	for _, o := range o {
 		o(rt)

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -24,7 +24,7 @@ func Wrap(h http.Handler, o ...ServerOption) http.Handler {
 		handler:        h,
 		tracer:         elasticapm.DefaultTracer,
 		requestName:    ServerRequestName,
-		requestIgnorer: ignoreNone,
+		requestIgnorer: DefaultServerRequestIgnorer(),
 	}
 	for _, o := range o {
 		o(handler)
@@ -212,10 +212,6 @@ type responseWriterHijackerPusher struct {
 	http.Pusher
 }
 
-func ignoreNone(*http.Request) bool {
-	return false
-}
-
 // ServerOption sets options for tracing server requests.
 type ServerOption func(*handler)
 
@@ -265,7 +261,7 @@ type RequestIgnorerFunc func(*http.Request) bool
 // be ignored. If r is nil, all requests will be reported.
 func WithServerRequestIgnorer(r RequestIgnorerFunc) ServerOption {
 	if r == nil {
-		r = ignoreNone
+		r = IgnoreNone
 	}
 	return func(h *handler) {
 		h.requestIgnorer = r

--- a/module/apmhttp/ignorer.go
+++ b/module/apmhttp/ignorer.go
@@ -1,0 +1,54 @@
+package apmhttp
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"sync"
+)
+
+const (
+	envIgnoreURLs = "ELASTIC_APM_IGNORE_URLS"
+)
+
+var (
+	defaultServerRequestIgnorerOnce sync.Once
+	defaultServerRequestIgnorer     RequestIgnorerFunc = IgnoreNone
+)
+
+// DefaultServerRequestIgnorer returns the default RequestIgnorer to use in
+// handlers. If ELASTIC_APM_IGNORE_URLS is set to a valid regular expression,
+// then it will be used to ignore matching requests; otherwise none are ignored.
+func DefaultServerRequestIgnorer() RequestIgnorerFunc {
+	defaultServerRequestIgnorerOnce.Do(func() {
+		value := os.Getenv(envIgnoreURLs)
+		if value == "" {
+			return
+		}
+		re, err := regexp.Compile(fmt.Sprintf("(?i:%s)", value))
+		if err == nil {
+			defaultServerRequestIgnorer = NewRegexpRequestIgnorer(re)
+		}
+	})
+	return defaultServerRequestIgnorer
+}
+
+// NewRegexpRequestIgnorer returns a RequestIgnorerFunc which matches requests'
+// URLs against re. Note that for server requests, typically only Path and
+// possibly RawQuery will be set, so the regular expression should take this
+// into account.
+func NewRegexpRequestIgnorer(re *regexp.Regexp) RequestIgnorerFunc {
+	if re == nil {
+		panic("re == nil")
+	}
+	return func(r *http.Request) bool {
+		fmt.Println(re.String(), r.URL.String(), re.MatchString(r.URL.String()))
+		return re.MatchString(r.URL.String())
+	}
+}
+
+// IgnoreNone is a RequestIgnorerFunc which ignores no requests.
+func IgnoreNone(*http.Request) bool {
+	return false
+}

--- a/module/apmhttp/ignorer_test.go
+++ b/module/apmhttp/ignorer_test.go
@@ -1,0 +1,54 @@
+package apmhttp_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+)
+
+func TestDefaultServerRequestIgnorer(t *testing.T) {
+	r1 := &http.Request{URL: &url.URL{Path: "/foo"}}
+	r2 := &http.Request{URL: &url.URL{Path: "/foo", RawQuery: "bar=baz"}}
+	r3 := &http.Request{URL: &url.URL{Scheme: "http", Host: "testing.invalid", Path: "/foo", RawQuery: "bar=baz"}}
+
+	testDefaultServerRequestIgnorer(t, "", r1, false)
+	testDefaultServerRequestIgnorer(t, "", r2, false)
+	testDefaultServerRequestIgnorer(t, "", r3, false)
+	testDefaultServerRequestIgnorer(t, "[", r1, false) // invalid regexp matches nothing
+
+	testDefaultServerRequestIgnorer(t, "/foo", r1, true)
+	testDefaultServerRequestIgnorer(t, "/foo", r2, true)
+	testDefaultServerRequestIgnorer(t, "/foo", r3, true)
+	testDefaultServerRequestIgnorer(t, "/FOO", r3, true) // case insensitive by default
+
+	testDefaultServerRequestIgnorer(t, "/foo\\?bar=baz", r1, false)
+	testDefaultServerRequestIgnorer(t, "/foo\\?bar=baz", r2, true)
+	testDefaultServerRequestIgnorer(t, "/foo\\?bar=baz", r3, true)
+
+	testDefaultServerRequestIgnorer(t, "http://.*", r1, false)
+	testDefaultServerRequestIgnorer(t, "http://.*", r2, false)
+	testDefaultServerRequestIgnorer(t, "http://.*", r3, true)
+}
+
+func testDefaultServerRequestIgnorer(t *testing.T, ignoreURLs string, r *http.Request, expect bool) {
+	testName := fmt.Sprintf("%s_%s", ignoreURLs, r.URL.String())
+	t.Run(testName, func(t *testing.T) {
+		if os.Getenv("_INSIDE_TEST") != "1" {
+			cmd := exec.Command(os.Args[0], "-test.run=^"+regexp.QuoteMeta(t.Name())+"$")
+			cmd.Env = append(os.Environ(), "_INSIDE_TEST=1")
+			cmd.Env = append(cmd.Env, "ELASTIC_APM_IGNORE_URLS="+ignoreURLs)
+			assert.NoError(t, cmd.Run())
+			return
+		}
+		ignorer := apmhttp.DefaultServerRequestIgnorer()
+		assert.Equal(t, expect, ignorer(r))
+	})
+}


### PR DESCRIPTION
Add support for ignoring requests with URLs matching the
regular expression specified in ELASTIC_APM_IGNORE_URLS.
Ignore requests are executed as normal, they just won't
be reported to Elastic APM.

Closes #154 