### PR TITLE
module/apmsql: fix error capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - module/apmgocql: new instrumentation module, providing an observer for gocql (#148)
  - Add ELASTIC\_APM\_SERVER\_TIMEOUT config (#157)
  - Add ELASTIC\_APM\_IGNORE\_URLS config (#158)
+ - module/apmsql: fix a bug preventing errors from being captured (#160)
 
 ## [v0.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.4.0)
 

--- a/module/apmsql/apmsql_go110_test.go
+++ b/module/apmsql/apmsql_go110_test.go
@@ -19,7 +19,7 @@ func TestConnect(t *testing.T) {
 
 	// Note: only in Go 1.10 do we have context during connection.
 
-	tx := withTransaction(t, func(ctx context.Context) {
+	tx, _ := withTransaction(t, func(ctx context.Context) {
 		err := db.PingContext(ctx)
 		assert.NoError(t, err)
 	})

--- a/module/apmsql/stmt.go
+++ b/module/apmsql/stmt.go
@@ -46,7 +46,7 @@ func (s *stmt) ColumnConverter(idx int) driver.ValueConverter {
 
 func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (_ driver.Result, resultError error) {
 	span, ctx := s.startSpan(ctx, s.conn.driver.execSpanType)
-	defer s.conn.finishSpan(ctx, span, resultError)
+	defer s.conn.finishSpan(ctx, span, &resultError)
 	if s.stmtExecContext != nil {
 		return s.stmtExecContext.ExecContext(ctx, args)
 	}
@@ -64,7 +64,7 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (_ dri
 
 func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (_ driver.Rows, resultError error) {
 	span, ctx := s.startSpan(ctx, s.conn.driver.querySpanType)
-	defer s.conn.finishSpan(ctx, span, resultError)
+	defer s.conn.finishSpan(ctx, span, &resultError)
 	if s.stmtQueryContext != nil {
 		return s.stmtQueryContext.QueryContext(ctx, args)
 	}


### PR DESCRIPTION
We were passing the (initial nil) error value
to finishSpan by mistake. Pass a pointer to the
result error var instead, to capture the final
value.

Fixes #159