### PR TITLE
elasticapm: introduce StartTransactionOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@
  - Support for the experimental metrics API added (#94)
  - module/apmsql: SQL is parsed to generate more useful span names (#129)
  - Basic vgo module added (#136)
- - module/apmhttprouter: added a wrapper type for httprouter.Router to simplify adding routes (#140)
- - Add Transaction.Context methods for setting user IDs (#144)
+ - module/apmhttprouter: added a wrapper type for `httprouter.Router` to simplify adding routes (#140)
+ - Add `Transaction.Context` methods for setting user IDs (#144)
  - module/apmgocql: new instrumentation module, providing an observer for gocql (#148)
- - Add ELASTIC\_APM\_SERVER\_TIMEOUT config (#157)
- - Add ELASTIC\_APM\_IGNORE\_URLS config (#158)
+ - Add `ELASTIC_APM_SERVER_TIMEOUT` config (#157)
+ - Add `ELASTIC_APM_IGNORE_URLS` config (#158)
  - module/apmsql: fix a bug preventing errors from being captured (#160)
+ - Introduce `Tracer.StartTransactionOptions`, drop variadic args from `Tracer.StartTransaction` (#165)
 
 ## [v0.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.4.0)
 

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -76,14 +76,14 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // If the transaction is not ignored, the request will be
 // returned with the transaction added to its context.
 func StartTransaction(tracer *elasticapm.Tracer, name string, req *http.Request) (*elasticapm.Transaction, *http.Request) {
-	var traceContext elasticapm.TraceContext
+	var opts elasticapm.TransactionOptions
 	if v := req.Header.Get(traceparentHeader); v != "" {
 		c, err := ParseTraceparentHeader(v)
 		if err == nil {
-			traceContext = c
+			opts.TraceContext = c
 		}
 	}
-	tx := tracer.StartTransaction(name, "request", elasticapm.WithTraceContext(traceContext))
+	tx := tracer.StartTransactionOptions(name, "request", opts)
 	ctx := elasticapm.ContextWithTransaction(req.Context(), tx)
 	req = RequestWithContext(ctx, req)
 	return tx, req


### PR DESCRIPTION
Introduce Tracer.StartTransactionOptions, a variant
of Tracer.StartTransaction which accepts a third
parameter of type TransactionOptions. This replaces
the TransactionOption functional options; StartTransaction
no longer accepts variadic arguments.

The purpose of this is to avoid allocations due to
closures in hot code paths, such as starting transactions
in http middleware, where setting trace context will
be commonplace.