### PR TITLE
.travis.yml: fix coverage.txt output from docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ jobs:
         - docker
       script:
         - scripts/docker-compose-testing up -d --build
-        - scripts/docker-compose-testing run --rm go-agent-tests make coverage > coverage.txt
+        - scripts/docker-compose-testing run -T --rm go-agent-tests make coverage > coverage.txt
         - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Pass "-T" to docker-compose run to ensure stdout
and stderr are separated, otherwise coverage.txt
gets messed up.