### PR TITLE
scripts: add -coverpkg to test_coverage.sh

### DIFF
--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -3,7 +3,7 @@
 set -e
 
 for pkg in $(go list ./...); do
-    go test -coverprofile=profile.out -covermode=atomic $pkg 1>&2
+    go test -coverpkg=github.com/elastic/apm-agent-go/... -coverprofile=profile.out -covermode=atomic $pkg 1>&2
     if [ -f profile.out ]; then
         cat profile.out
         rm profile.out


### PR DESCRIPTION
When running coverage tests, record coverage for
all packages under apm-agent-go. This will give
us the total coverage for all packages regardless
of where the tests lie.