### PR TITLE
 module/apmhttp: set client request URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  - module/apmsql: fix a bug preventing errors from being captured (#160)
  - Introduce `Tracer.StartTransactionOptions`, drop variadic args from `Tracer.StartTransaction` (#165)
  - module/apmgorm: introduce GORM instrumentation module (#169, #170)
+ - module/apmhttp: record outgoing request URLs in span context (#172)
 
 ## [v0.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.4.0)
 

--- a/context.go
+++ b/context.go
@@ -77,10 +77,9 @@ func (c *Context) SetTag(key, value string) {
 
 // SetHTTPRequest sets details of the HTTP request in the context.
 //
-// This function may be used for either clients or servers. For
-// server-side requests, various proxy forwarding headers are taken
-// into account to reconstruct the URL, and determining the client
-// address.
+// This function relates to server-side requests. Various proxy
+// forwarding headers are taken into account to reconstruct the URL,
+// and determining the client address.
 //
 // If the request URL contains user info, it will be removed and
 // excluded from the URL's "full" field.

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -243,9 +243,26 @@ func (v *Span) MarshalFastJSON(w *fastjson.Writer) {
 
 func (v *SpanContext) MarshalFastJSON(w *fastjson.Writer) {
 	w.RawByte('{')
+	first := true
 	if v.Database != nil {
-		w.RawString("\"db\":")
+		const prefix = ",\"db\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
 		v.Database.MarshalFastJSON(w)
+	}
+	if v.HTTP != nil {
+		const prefix = ",\"http\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		v.HTTP.MarshalFastJSON(w)
 	}
 	w.RawByte('}')
 }

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -101,6 +101,17 @@ func TestMarshalTransaction(t *testing.T) {
 					},
 				},
 			},
+			map[string]interface{}{
+				"name":     "GET testing.invalid:8000",
+				"start":    float64(3),
+				"duration": float64(4),
+				"type":     "ext.http",
+				"context": map[string]interface{}{
+					"http": map[string]interface{}{
+						"url": "http://testing.invalid:8000/path?query#fragment",
+					},
+				},
+			},
 		},
 	}
 
@@ -581,6 +592,16 @@ func fakeTransaction() model.Transaction {
 					Statement: `SELECT foo FROM bar WHERE baz LIKE 'qu%x'`,
 					Type:      "sql",
 					User:      "barb",
+				},
+			},
+		}, {
+			Name:     "GET testing.invalid:8000",
+			Start:    3,
+			Duration: 4,
+			Type:     "ext.http",
+			Context: &model.SpanContext{
+				HTTP: &model.HTTPSpanContext{
+					URL: mustParseURL("http://testing.invalid:8000/path?query#fragment"),
 				},
 			},
 		}},

--- a/model/model.go
+++ b/model/model.go
@@ -208,6 +208,9 @@ type SpanContext struct {
 	// Database holds contextual information for database
 	// operation spans.
 	Database *DatabaseSpanContext `json:"db,omitempty"`
+
+	// HTTP holds contextual information for HTTP client request spans.
+	HTTP *HTTPSpanContext `json:"http,omitempty"`
 }
 
 // DatabaseSpanContext holds contextual information for database
@@ -226,6 +229,12 @@ type DatabaseSpanContext struct {
 
 	// User holds the username used for database access.
 	User string `json:"user,omitempty"`
+}
+
+// HTTPSpanContext holds contextual information for HTTP client request spans.
+type HTTPSpanContext struct {
+	// URL is the request URL.
+	URL *url.URL
 }
 
 // Context holds contextual information relating to a transaction or error.
@@ -459,7 +468,8 @@ type RequestSocket struct {
 	RemoteAddress string `json:"remote_address,omitempty"`
 }
 
-// URL represents a request URL.
+// URL represents a server-side (transaction) request URL,
+// broken down into its constituent parts.
 type URL struct {
 	// Full is the full URL, e.g.
 	// "https://example.com:443/search/?q=elasticsearch#top".

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -82,6 +82,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	name := r.requestName(req)
 	spanType := "ext.http"
 	span := tx.StartSpan(name, spanType, elasticapm.SpanFromContext(ctx))
+	span.Context.SetHTTPRequest(req)
 	defer span.End()
 	if !span.Dropped() {
 		traceContext = span.TraceContext()

--- a/spancontext.go
+++ b/spancontext.go
@@ -1,6 +1,8 @@
 package elasticapm
 
 import (
+	"net/http"
+
 	"github.com/elastic/apm-agent-go/model"
 )
 
@@ -8,6 +10,7 @@ import (
 type SpanContext struct {
 	model    model.SpanContext
 	database model.DatabaseSpanContext
+	http     model.HTTPSpanContext
 }
 
 // DatabaseSpanContext holds database span context.
@@ -29,6 +32,7 @@ type DatabaseSpanContext struct {
 func (c *SpanContext) build() *model.SpanContext {
 	switch {
 	case c.model.Database != nil:
+	case c.model.HTTP != nil:
 	default:
 		return nil
 	}
@@ -43,4 +47,13 @@ func (c *SpanContext) reset() {
 func (c *SpanContext) SetDatabase(db DatabaseSpanContext) {
 	c.database = model.DatabaseSpanContext(db)
 	c.model.Database = &c.database
+}
+
+// SetHTTPRequest sets the details of the HTTP request in the context.
+//
+// This function relates to client requests. If the request URL contains
+// user info, it will be removed and excluded from the stored URL.
+func (c *SpanContext) SetHTTPRequest(req *http.Request) {
+	c.http.URL = req.URL
+	c.model.HTTP = &c.http
 }


### PR DESCRIPTION
In the elasticapm package, we introduce a new SpanContext.SetHTTPRequest method which records the URL of an outgoing HTTP request in span context, and later add it to the span model object. Finally we modify the apmhttp client instrumentation to make use of this.

Closes elastic/apm-agent-go#171 