### PR TITLE
 module/apmot: initial tracer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - Introduce `Tracer.StartTransactionOptions`, drop variadic args from `Tracer.StartTransaction` (#165)
  - module/apmgorm: introduce GORM instrumentation module (#169, #170)
  - module/apmhttp: record outgoing request URLs in span context (#172)
+ - module/apmot: introduce OpenTracing implementation (#173)
 
 ## [v0.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.4.0)
 

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -74,7 +74,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	distributedTracing := traceContext.Span != (elasticapm.SpanID{})
 	if !tx.Sampled() {
 		if distributedTracing {
-			req.Header.Set(traceparentHeader, FormatTraceparentHeader(traceContext))
+			req.Header.Set(TraceparentHeader, FormatTraceparentHeader(traceContext))
 		}
 		return r.r.RoundTrip(req)
 	}
@@ -89,7 +89,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if distributedTracing {
-		req.Header.Set(traceparentHeader, FormatTraceparentHeader(traceContext))
+		req.Header.Set(TraceparentHeader, FormatTraceparentHeader(traceContext))
 	}
 	ctx = elasticapm.ContextWithSpan(ctx, span)
 	req = RequestWithContext(ctx, req)

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -77,7 +77,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // returned with the transaction added to its context.
 func StartTransaction(tracer *elasticapm.Tracer, name string, req *http.Request) (*elasticapm.Transaction, *http.Request) {
 	var opts elasticapm.TransactionOptions
-	if v := req.Header.Get(traceparentHeader); v != "" {
+	if v := req.Header.Get(TraceparentHeader); v != "" {
 		c, err := ParseTraceparentHeader(v)
 		if err == nil {
 			opts.TraceContext = c

--- a/module/apmhttp/traceheaders.go
+++ b/module/apmhttp/traceheaders.go
@@ -11,10 +11,12 @@ import (
 )
 
 const (
-	// NOTE: at this time, the W3c Trace-Context headers are not finalised.
+	// TraceparentHeader is the HTTP header for trace propagation.
+	//
+	// NOTE: at this time, the W3C Trace-Context headers are not finalised.
 	// To avoid producing possibly invalid traceparent headers, we will
 	// use an alternative name until the format is frozen.
-	traceparentHeader = "Elastic-Apm-Traceparent"
+	TraceparentHeader = "Elastic-Apm-Traceparent"
 )
 
 // FormatTraceparentHeader formats the given trace context as a

--- a/module/apmot/context.go
+++ b/module/apmot/context.go
@@ -1,0 +1,40 @@
+package apmot
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/elastic/apm-agent-go"
+)
+
+type spanContext struct {
+	// BUG(axw) spanContext must not hold onto any transaction or
+	// span objects, as an opentracing.SpanContext may outlive the
+	// span to which it relates. To fix this, we need spans at the
+	// top level, and a means of creating them from a TraceContext.
+	//
+	// In most cases this is *probably* OK, because a child-of
+	// relation means that the parent span cannot be ended before
+	// the child. However, there's no guarantee that the ordering
+	// of operations on the OpenTracing API follows the ordering
+	// of the events exactly (e.g. you could complete the entire
+	// business transaction before emitting events, and then emit
+	// events for the transaction and then its spans.)
+	tracer *otTracer // for origin of tx/span
+	tx     *elasticapm.Transaction
+	span   *elasticapm.Span
+
+	traceContext elasticapm.TraceContext
+}
+
+// ForeachBaggageItem is a no-op; we do not support baggage propagation.
+func (c spanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+func parentSpanContext(refs []opentracing.SpanReference) (spanContext, bool) {
+	for _, ref := range refs {
+		switch ref.Type {
+		case opentracing.ChildOfRef, opentracing.FollowsFromRef:
+			return ref.ReferencedContext.(spanContext), true
+		}
+	}
+	return spanContext{}, false
+}

--- a/module/apmot/doc.go
+++ b/module/apmot/doc.go
@@ -1,0 +1,15 @@
+// Package apmot provides an Elastic APM implementation of the OpenTracing API.
+//
+// Things not implemented by this tracer:
+//  - binary propagation format
+//  - baggage
+//  - logging
+//
+// TODO(axw)
+//  - update spanContext to stop storing objects once we
+//    have completed support for distributed tracing; we
+//    should only store trace context
+//  - investigate injecting native APM transactions/spans
+//    as the parent when starting an OT span. This probably
+//    requires extending the OT API.
+package apmot

--- a/module/apmot/example_test.go
+++ b/module/apmot/example_test.go
@@ -1,0 +1,51 @@
+package apmot_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+func Example() {
+	tracer, apmtracer, recorder := newTestTracer()
+	defer apmtracer.Close()
+	opentracing.SetGlobalTracer(tracer)
+	defer opentracing.SetGlobalTracer(nil)
+
+	parent := opentracing.StartSpan("Parent")
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("span_%d", i)
+		parent.LogEvent(fmt.Sprintf("Starting %s", id))
+		child := opentracing.StartSpan(id, opentracing.ChildOf(parent.Context()))
+		time.Sleep(10 * time.Millisecond)
+		child.Finish()
+	}
+	parent.LogEvent("A Log")
+	parent.Finish()
+	apmtracer.Flush(nil)
+
+	payloads := recorder.Payloads()
+	if len(payloads) != 1 {
+		panic(fmt.Errorf("expected 1 payload, got %d", len(payloads)))
+	}
+	transactions := payloads[0].Transactions()
+	if len(transactions) != 1 {
+		panic(fmt.Errorf("expected 1 transaction, got %d", len(transactions)))
+	}
+	transaction := transactions[0]
+	fmt.Printf("transaction: %s/%s\n", transaction.Name, transaction.Type)
+	fmt.Println("spans:")
+	for _, span := range transaction.Spans {
+		fmt.Printf(" - %s/%s\n", span.Name, span.Type)
+	}
+
+	// Output:
+	// transaction: Parent/unknown
+	// spans:
+	//  - span_0/unknown
+	//  - span_1/unknown
+	//  - span_2/unknown
+	//  - span_3/unknown
+	//  - span_4/unknown
+}

--- a/module/apmot/harness_test.go
+++ b/module/apmot/harness_test.go
@@ -1,0 +1,75 @@
+package apmot
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/harness"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestHarness(t *testing.T) {
+	// NOTE(axw) we do not support binary propagation, but we patch in
+	// basic support *for the tests only* so we can check compatibility
+	// with the HTTP and text formats.
+	binaryInject = func(w io.Writer, traceContext elasticapm.TraceContext) error {
+		return json.NewEncoder(w).Encode(apmhttp.FormatTraceparentHeader(traceContext))
+	}
+	binaryExtract = func(r io.Reader) (elasticapm.TraceContext, error) {
+		var headerValue string
+		if err := json.NewDecoder(r).Decode(&headerValue); err != nil {
+			return elasticapm.TraceContext{}, err
+		}
+		return apmhttp.ParseTraceparentHeader(headerValue)
+	}
+	defer func() {
+		binaryInject = binaryInjectUnsupported
+		binaryExtract = binaryExtractUnsupported
+	}()
+
+	newTracer := func() (opentracing.Tracer, func()) {
+		apmtracer, err := elasticapm.NewTracer("transporttest", "")
+		if err != nil {
+			panic(err)
+		}
+		apmtracer.Transport = transporttest.Discard
+		tracer := New(WithTracer(apmtracer))
+		return tracer, apmtracer.Close
+	}
+	harness.RunAPIChecks(t, newTracer,
+		harness.CheckExtract(true),
+		harness.CheckInject(true),
+		harness.UseProbe(harnessAPIProbe{}),
+	)
+}
+
+type harnessAPIProbe struct{}
+
+func (harnessAPIProbe) SameTrace(first, second opentracing.Span) bool {
+	ctx1, ok := first.Context().(spanContext)
+	if !ok {
+		return false
+	}
+	ctx2, ok := second.Context().(spanContext)
+	if !ok {
+		return false
+	}
+	return ctx1.traceContext.Trace == ctx2.traceContext.Trace
+}
+
+func (harnessAPIProbe) SameSpanContext(span opentracing.Span, sc opentracing.SpanContext) bool {
+	ctx1, ok := span.Context().(spanContext)
+	if !ok {
+		return false
+	}
+	ctx2, ok := sc.(spanContext)
+	if !ok {
+		return false
+	}
+	return ctx1.traceContext == ctx2.traceContext
+}

--- a/module/apmot/span.go
+++ b/module/apmot/span.go
@@ -1,0 +1,258 @@
+package apmot
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+)
+
+// otSpan wraps elasticapm objects to implement the opentracing.Span interface.
+type otSpan struct {
+	tracer *otTracer
+
+	mu   sync.Mutex
+	tx   *elasticapm.Transaction
+	span *elasticapm.Span
+	tags opentracing.Tags
+	ctx  spanContext
+}
+
+// SetOperationName sets or changes the operation name.
+func (s *otSpan) SetOperationName(operationName string) opentracing.Span {
+	if s.tx != nil {
+		s.tx.Name = operationName
+	} else {
+		s.span.Name = operationName
+	}
+	return s
+}
+
+// SetTag adds or changes a tag.
+func (s *otSpan) SetTag(key string, value interface{}) opentracing.Span {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.tags == nil {
+		s.tags = make(opentracing.Tags, 1)
+	}
+	s.tags[key] = value
+	return s
+}
+
+// Finish ends the span; this (or FinishWithOptions) must be the last method
+// call on the span, except for calls to Context which may be called at any
+// time.
+func (s *otSpan) Finish() {
+	s.FinishWithOptions(opentracing.FinishOptions{})
+}
+
+// FinishWithOptions is like Finish, but provides explicit control over the
+// end timestamp and log data.
+func (s *otSpan) FinishWithOptions(opts opentracing.FinishOptions) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !opts.FinishTime.IsZero() {
+		if s.span != nil {
+			s.span.Duration = opts.FinishTime.Sub(s.span.Timestamp)
+		} else {
+			s.tx.Duration = opts.FinishTime.Sub(s.tx.Timestamp)
+		}
+	}
+	if s.span != nil {
+		s.setSpanContext()
+		s.span.End()
+	} else {
+		s.setTransactionContext()
+		s.tx.End()
+	}
+}
+
+// Tracer returns the Tracer that created this span.
+func (s *otSpan) Tracer() opentracing.Tracer {
+	return s.tracer
+}
+
+// Context returns the span's current context.
+//
+// It is valid to call Context after calling Finish or FinishWithOptions.
+// The resulting context is also valid after the span is finished.
+func (s *otSpan) Context() opentracing.SpanContext {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ctx
+}
+
+// SetBaggageItem is a no-op; we do not support baggage.
+func (s *otSpan) SetBaggageItem(key, val string) opentracing.Span {
+	// We do not support baggage.
+	return s
+}
+
+// BaggageItem returns the empty string; we do not support baggage.
+func (s *otSpan) BaggageItem(key string) string {
+	return ""
+}
+
+func (*otSpan) LogKV(keyValues ...interface{}) {
+	// No-op.
+}
+
+func (*otSpan) LogFields(fields ...log.Field) {
+	// No-op.
+}
+
+func (*otSpan) LogEvent(event string) {
+	// No-op.
+}
+
+func (*otSpan) LogEventWithPayload(event string, payload interface{}) {
+	// No-op.
+}
+
+func (*otSpan) Log(ld opentracing.LogData) {
+	// No-op.
+}
+
+func (s *otSpan) setSpanContext() {
+	var (
+		dbContext       elasticapm.DatabaseSpanContext
+		component       string
+		httpURL         string
+		httpMethod      string
+		haveDBContext   bool
+		haveHTTPContext bool
+	)
+	for k, v := range s.tags {
+		switch k {
+		case "component":
+			component = fmt.Sprint(v)
+		case "db.instance":
+			dbContext.Instance = fmt.Sprint(v)
+			haveDBContext = true
+		case "db.statement":
+			dbContext.Statement = fmt.Sprint(v)
+			haveDBContext = true
+		case "db.type":
+			dbContext.Type = fmt.Sprint(v)
+			haveDBContext = true
+		case "db.user":
+			dbContext.User = fmt.Sprint(v)
+			haveDBContext = true
+		case "http.url":
+			haveHTTPContext = true
+			httpURL = fmt.Sprint(v)
+		case "http.method":
+			haveHTTPContext = true
+			httpMethod = fmt.Sprint(v)
+
+		// Elastic APM-specific tags:
+		case "type":
+			s.span.Type = fmt.Sprint(v)
+		}
+	}
+	switch {
+	case haveHTTPContext:
+		if s.span.Type == "" {
+			s.span.Type = "ext.http"
+		}
+		url, err := url.Parse(httpURL)
+		if err == nil {
+			var req http.Request
+			req.ProtoMajor = 1 // Assume HTTP/1.1
+			req.ProtoMinor = 1
+			req.Method = httpMethod
+			req.URL = url
+			s.span.Context.SetHTTPRequest(&req)
+		}
+	case haveDBContext:
+		if s.span.Type == "" {
+			dbType := "sql"
+			if dbContext.Type != "" {
+				dbType = dbContext.Type
+			}
+			s.span.Type = fmt.Sprintf("db.%s.query", dbType)
+		}
+		s.span.Context.SetDatabase(dbContext)
+	}
+	if s.span.Type == "" {
+		s.span.Type = component
+		if s.span.Type == "" {
+			s.span.Type = "unknown"
+		}
+	}
+}
+
+func (s *otSpan) setTransactionContext() {
+	var (
+		component      string
+		httpMethod     string
+		httpStatusCode = -1
+		httpURL        string
+		isError        bool
+	)
+	for k, v := range s.tags {
+		switch k {
+		case "component":
+			component = fmt.Sprint(v)
+		case "http.method":
+			httpMethod = fmt.Sprint(v)
+		case "http.status_code":
+			if code, ok := v.(uint16); ok {
+				httpStatusCode = int(code)
+			}
+		case "http.url":
+			httpURL = fmt.Sprint(v)
+		case "error":
+			isError, _ = v.(bool)
+
+		// Elastic APM-specific tags:
+		case "type":
+			s.tx.Type = fmt.Sprint(v)
+		case "result":
+			s.tx.Result = fmt.Sprint(v)
+		case "user.id":
+			s.tx.Context.SetUserID(fmt.Sprint(v))
+		case "user.email":
+			s.tx.Context.SetUserEmail(fmt.Sprint(v))
+		case "user.username":
+			s.tx.Context.SetUsername(fmt.Sprint(v))
+
+		default:
+			s.tx.Context.SetTag(k, fmt.Sprint(v))
+		}
+	}
+	if s.tx.Type == "" {
+		if httpURL != "" {
+			s.tx.Type = "request"
+		} else if component != "" {
+			s.tx.Type = component
+		} else {
+			s.tx.Type = "unknown"
+		}
+	}
+	if s.tx.Result == "" {
+		if httpStatusCode != -1 {
+			s.tx.Result = apmhttp.StatusCodeResult(httpStatusCode)
+			s.tx.Context.SetHTTPStatusCode(httpStatusCode)
+		} else if isError {
+			s.tx.Result = "error"
+		}
+	}
+	if httpURL != "" {
+		uri, err := url.ParseRequestURI(httpURL)
+		if err == nil {
+			var req http.Request
+			req.ProtoMajor = 1 // Assume HTTP/1.1
+			req.ProtoMinor = 1
+			req.Method = httpMethod
+			req.URL = uri
+			s.tx.Context.SetHTTPRequest(&req)
+		}
+	}
+}

--- a/module/apmot/tracer.go
+++ b/module/apmot/tracer.go
@@ -1,0 +1,172 @@
+package apmot
+
+import (
+	"io"
+	"net/http"
+	"net/textproto"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+)
+
+// New returns a new opentracing.Tracer backed by the supplied
+// Elastic APM tracer.
+//
+// By default, the returned tracer will use elasticapm.DefaultTracer.
+// This can be overridden by using a WithTracer option.
+func New(opts ...Option) opentracing.Tracer {
+	t := &otTracer{tracer: elasticapm.DefaultTracer}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// otTracer is an opentracing.Tracer backed by an elasticapm.Tracer.
+type otTracer struct {
+	tracer *elasticapm.Tracer
+}
+
+// StartSpan starts a new OpenTracing span with the given name and zero or more options.
+func (t *otTracer) StartSpan(name string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	sso := opentracing.StartSpanOptions{}
+	for _, o := range opts {
+		o.Apply(&sso)
+	}
+	return t.StartSpanWithOptions(name, sso)
+}
+
+// StartSpanWithOptions starts a new OpenTracing span with the given
+// name and options.
+func (t *otTracer) StartSpanWithOptions(name string, opts opentracing.StartSpanOptions) opentracing.Span {
+	ctx := spanContext{tracer: t}
+	parentCtx, _ := parentSpanContext(opts.References)
+	if parentCtx.tracer == t && parentCtx.tx != nil {
+		// tx is non-nil, which means the parent is a process-local
+		// transaction or span. Create a sub-span.
+		ctx.tx = parentCtx.tx
+		ctx.span = ctx.tx.StartSpan(name, "", parentCtx.span)
+		if !opts.StartTime.IsZero() {
+			ctx.span.Timestamp = opts.StartTime
+		}
+		ctx.traceContext = ctx.span.TraceContext()
+	} else {
+		// tx is nil or comes from another tracer, so we must create
+		// a new transaction. It's possible that we have a non-local
+		// parent transaction, so pass in the (possibly-zero) trace
+		// context.
+		ctx.tx = t.tracer.StartTransactionOptions(name, "", elasticapm.TransactionOptions{
+			TraceContext: parentCtx.traceContext,
+			Start:        opts.StartTime,
+		})
+		ctx.traceContext = ctx.tx.TraceContext()
+	}
+	// Because the Context method can be called at any time after
+	// the span is finished, we cannot pool the objects.
+	return &otSpan{
+		tracer: t,
+		tx:     ctx.tx,
+		span:   ctx.span,
+		tags:   opts.Tags,
+		ctx:    ctx,
+	}
+}
+
+func (t *otTracer) Inject(sc opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	spanContext, ok := sc.(spanContext)
+	if !ok {
+		return opentracing.ErrInvalidSpanContext
+	}
+	switch format {
+	case opentracing.TextMap, opentracing.HTTPHeaders:
+		writer, ok := carrier.(opentracing.TextMapWriter)
+		if !ok {
+			return opentracing.ErrInvalidCarrier
+		}
+		headerValue := apmhttp.FormatTraceparentHeader(spanContext.traceContext)
+		writer.Set(apmhttp.TraceparentHeader, headerValue)
+		return nil
+	case opentracing.Binary:
+		writer, ok := carrier.(io.Writer)
+		if !ok {
+			return opentracing.ErrInvalidCarrier
+		}
+		return binaryInject(writer, spanContext.traceContext)
+	default:
+		return opentracing.ErrUnsupportedFormat
+	}
+}
+
+func (t *otTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	switch format {
+	case opentracing.TextMap, opentracing.HTTPHeaders:
+		var headerValue string
+		switch carrier := carrier.(type) {
+		case opentracing.HTTPHeadersCarrier:
+			headerValue = http.Header(carrier).Get(apmhttp.TraceparentHeader)
+		case opentracing.TextMapReader:
+			carrier.ForeachKey(func(key, val string) error {
+				if textproto.CanonicalMIMEHeaderKey(key) == apmhttp.TraceparentHeader {
+					headerValue = val
+					return io.EOF // arbitrary error to break loop
+				}
+				return nil
+			})
+		default:
+			return nil, opentracing.ErrInvalidCarrier
+		}
+		if headerValue == "" {
+			return nil, opentracing.ErrSpanContextNotFound
+		}
+		traceContext, err := apmhttp.ParseTraceparentHeader(headerValue)
+		if err != nil {
+			return nil, err
+		}
+		return spanContext{tracer: t, traceContext: traceContext}, nil
+	case opentracing.Binary:
+		reader, ok := carrier.(io.Reader)
+		if !ok {
+			return nil, opentracing.ErrInvalidCarrier
+		}
+		traceContext, err := binaryExtract(reader)
+		if err != nil {
+			return nil, err
+		}
+		return spanContext{tracer: t, traceContext: traceContext}, nil
+	default:
+		return nil, opentracing.ErrUnsupportedFormat
+	}
+}
+
+// Option sets options for the OpenTracing Tracer implementation.
+type Option func(*otTracer)
+
+// WithTracer returns an Option which sets t as the underlying
+// elasticapm.Tracer for constructing an OpenTracing Tracer.
+func WithTracer(t *elasticapm.Tracer) Option {
+	if t == nil {
+		panic("t == nil")
+	}
+	return func(o *otTracer) {
+		o.tracer = t
+	}
+}
+
+// TODO(axw) handle binary format once Trace-Context defines one.
+// OpenTracing mandates that all implementations "MUST" support all
+// of the builtin formats.
+
+var (
+	binaryInject  = binaryInjectUnsupported
+	binaryExtract = binaryExtractUnsupported
+)
+
+func binaryInjectUnsupported(w io.Writer, traceContext elasticapm.TraceContext) error {
+	return opentracing.ErrUnsupportedFormat
+}
+
+func binaryExtractUnsupported(r io.Reader) (elasticapm.TraceContext, error) {
+	return elasticapm.TraceContext{}, opentracing.ErrUnsupportedFormat
+}

--- a/module/apmot/tracer_test.go
+++ b/module/apmot/tracer_test.go
@@ -1,0 +1,187 @@
+package apmot_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/model"
+	"github.com/elastic/apm-agent-go/module/apmot"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestTransactionType(t *testing.T) {
+	tracer, apmtracer, recorder := newTestTracer()
+	defer apmtracer.Close()
+
+	type test struct {
+		Tag  opentracing.Tag
+		Type string
+	}
+	tests := []test{
+		{Tag: opentracing.Tag{Key: "component", Value: "foo"}, Type: "foo"},
+		{Tag: opentracing.Tag{Key: "http.url", Value: "http://host/path"}, Type: "request"},
+		{Tag: opentracing.Tag{Key: "foo", Value: "bar"}, Type: "unknown"}, // default
+		{Tag: opentracing.Tag{Key: "type", Value: "baz"}, Type: "baz"},
+	}
+	for _, test := range tests {
+		span := tracer.StartSpan("name", test.Tag)
+		span.Finish()
+	}
+
+	apmtracer.Flush(nil)
+	require.Len(t, recorder.Payloads(), 1)
+	transactions := recorder.Payloads()[0].Transactions()
+	require.Len(t, transactions, len(tests))
+	for i, test := range tests {
+		assert.Equal(t, test.Type, transactions[i].Type)
+	}
+}
+
+func TestHTTPTransaction(t *testing.T) {
+	tracer, apmtracer, recorder := newTestTracer()
+	defer apmtracer.Close()
+
+	span := tracer.StartSpan("name")
+	ext.HTTPUrl.Set(span, "/foo?bar=baz")
+	ext.HTTPMethod.Set(span, "POST")
+	ext.HTTPStatusCode.Set(span, 404)
+	span.Finish()
+
+	apmtracer.Flush(nil)
+	require.Len(t, recorder.Payloads(), 1)
+	transactions := recorder.Payloads()[0].Transactions()
+	require.Len(t, transactions, 1)
+	transaction := transactions[0]
+	assert.Equal(t, "request", transaction.Type)
+	assert.Equal(t, "HTTP 4xx", transaction.Result)
+	assert.Equal(t, &model.Request{
+		Method:      "POST",
+		HTTPVersion: "1.1",
+		URL: model.URL{
+			Protocol: "http",
+			Path:     "/foo",
+			Search:   "bar=baz",
+		},
+	}, transaction.Context.Request)
+}
+
+func TestSpanType(t *testing.T) {
+	tracer, apmtracer, recorder := newTestTracer()
+	defer apmtracer.Close()
+
+	type test struct {
+		Tag  opentracing.Tag
+		Type string
+	}
+	tests := []test{
+		{Tag: opentracing.Tag{Key: "component", Value: "foo"}, Type: "foo"},
+		{Tag: opentracing.Tag{Key: "db.type", Value: "sql"}, Type: "db.sql.query"},
+		{Tag: opentracing.Tag{Key: "http.url", Value: "http://testing.invalid:8000"}, Type: "ext.http"},
+		{Tag: opentracing.Tag{Key: "foo", Value: "bar"}, Type: "unknown"}, // default
+		{Tag: opentracing.Tag{Key: "type", Value: "baz"}, Type: "baz"},
+	}
+
+	txSpan := tracer.StartSpan("tx")
+	for _, test := range tests {
+		span := tracer.StartSpan("child", opentracing.ChildOf(txSpan.Context()), test.Tag)
+		ext.SpanKindRPCClient.Set(span)
+		span.Finish()
+	}
+	txSpan.Finish()
+
+	apmtracer.Flush(nil)
+	require.Len(t, recorder.Payloads(), 1)
+	transactions := recorder.Payloads()[0].Transactions()
+	require.Len(t, transactions, 1)
+	require.Len(t, transactions[0].Spans, len(tests))
+	for i, test := range tests {
+		assert.Equal(t, test.Type, transactions[0].Spans[i].Type)
+	}
+}
+
+func TestDBSpan(t *testing.T) {
+	tracer, apmtracer, recorder := newTestTracer()
+	defer apmtracer.Close()
+
+	txSpan := tracer.StartSpan("tx")
+	span := tracer.StartSpan("child", opentracing.ChildOf(txSpan.Context()))
+	ext.DBInstance.Set(span, "test_db")
+	ext.DBStatement.Set(span, "SELECT * FROM foo")
+	ext.DBType.Set(span, "hbase")
+	ext.DBUser.Set(span, "jean")
+	span.Finish()
+	txSpan.Finish()
+
+	apmtracer.Flush(nil)
+	require.Len(t, recorder.Payloads(), 1)
+	transactions := recorder.Payloads()[0].Transactions()
+	require.Len(t, transactions, 1)
+	require.Len(t, transactions[0].Spans, 1)
+	modelSpan := transactions[0].Spans[0]
+	assert.Equal(t, "db.hbase.query", modelSpan.Type)
+	assert.Equal(t, &model.SpanContext{
+		Database: &model.DatabaseSpanContext{
+			Instance:  "test_db",
+			Statement: "SELECT * FROM foo",
+			Type:      "hbase",
+			User:      "jean",
+		},
+	}, modelSpan.Context)
+}
+
+func TestHTTPSpan(t *testing.T) {
+	tracer, apmtracer, recorder := newTestTracer()
+	defer apmtracer.Close()
+
+	clientURL := "https://root:hunter2@testing.invalid:8443/foo?bar:baz"
+	url, err := url.Parse(clientURL)
+	require.NoError(t, err)
+	url.User = nil // user/password should be stripped off
+
+	txSpan := tracer.StartSpan("tx")
+	span := tracer.StartSpan("child", opentracing.ChildOf(txSpan.Context()))
+	ext.HTTPMethod.Set(span, "GET")
+	ext.HTTPUrl.Set(span, clientURL)
+	span.Finish()
+	txSpan.Finish()
+
+	apmtracer.Flush(nil)
+	require.Len(t, recorder.Payloads(), 1)
+	transactions := recorder.Payloads()[0].Transactions()
+	require.Len(t, transactions, 1)
+	require.Len(t, transactions[0].Spans, 1)
+	modelSpan := transactions[0].Spans[0]
+	assert.Equal(t, "ext.http", modelSpan.Type)
+	assert.Equal(t, &model.SpanContext{
+		HTTP: &model.HTTPSpanContext{URL: url},
+	}, modelSpan.Context)
+}
+
+func TestStartSpanRemoteParent(t *testing.T) {
+	tracer1, apmtracer1, recorder1 := newTestTracer()
+	defer apmtracer1.Close()
+	tracer2, apmtracer2, recorder2 := newTestTracer()
+	defer apmtracer1.Close()
+
+	parentSpan := tracer1.StartSpan("parent")
+	childSpan := tracer2.StartSpan("child", opentracing.ChildOf(parentSpan.Context()))
+	childSpan.Finish()
+	parentSpan.Finish()
+
+	apmtracer1.Flush(nil)
+	apmtracer2.Flush(nil)
+	require.Len(t, recorder1.Payloads(), 1)
+	require.Len(t, recorder2.Payloads(), 1)
+}
+
+func newTestTracer() (opentracing.Tracer, *elasticapm.Tracer, *transporttest.RecorderTransport) {
+	apmtracer, recorder := transporttest.NewRecorderTracer()
+	tracer := apmot.New(apmot.WithTracer(apmtracer))
+	return tracer, apmtracer, recorder
+}

--- a/scripts/Dockerfile-testing
+++ b/scripts/Dockerfile-testing
@@ -18,6 +18,10 @@ RUN go get -v github.com/julienschmidt/httprouter
 RUN go get -v github.com/labstack/echo
 RUN go get -v github.com/lib/pq
 RUN go get -v github.com/mattn/go-sqlite3
+RUN go get -v github.com/opentracing/opentracing-go
+RUN go get -v github.com/opentracing/opentracing-go/ext
+RUN go get -v github.com/opentracing/opentracing-go/harness
+RUN go get -v github.com/opentracing/opentracing-go/log
 RUN go get -v github.com/pkg/errors
 RUN go get -v github.com/prometheus/client_golang/prometheus
 RUN go get -v github.com/prometheus/client_model/go


### PR DESCRIPTION
Implement an OpenTracing tracer on top of the
core API. Root spans create transactions, and
child spans create spans or transactions,
depending on whether or not the parent is
remote.

Neither baggage nor logging are supported,
nor is the binary propagation format. We use
the (draft) W3C Trace-Context, for which there
is not yet a binary format.

There is a bug in the span context which we
cannot fix until spans are top-level objects,
which will happen with the v2 API. We will
revisit this when the v2 API is supported. The
bug is unlikely to affect anyone, since it will
only occur if you attempt to use span context
after the span has been finished/ended.

In line with the Elastic APM Java agent's
implementation, we support several custom tags:

  - type (transaction or span type)
  - user.id, user.email, user.username (transaction user context)
  - result (transaction result)