### PR TITLE
Update TraceContext options

### DIFF
--- a/module/apmhttp/traceheaders_test.go
+++ b/module/apmhttp/traceheaders_test.go
@@ -32,4 +32,6 @@ func TestParseTraceparentHeader(t *testing.T) {
 	assert.Equal(t, "\x0a\xf7\x65\x19\x16\xcd\x43\xdd\x84\x48\xeb\x21\x1c\x80\x31\x9c", string(out.Trace[:]))
 	assert.Equal(t, "\xb7\xad\x6b\x71\x69\x20\x33\x31", string(out.Span[:]))
 	assert.Equal(t, elasticapm.TraceOptions(1), out.Options)
+	assert.True(t, out.Options.Requested())
+	assert.False(t, out.Options.MaybeRecorded())
 }

--- a/tracecontext.go
+++ b/tracecontext.go
@@ -11,7 +11,8 @@ var (
 )
 
 const (
-	traceOptionsSampledFlag = 0x00000001
+	traceOptionsRequestedFlag = 0x01
+	traceOptionsRecordedFlag  = 0x02
 )
 
 // TraceContext holds trace context for an incoming or outgoing request.
@@ -73,16 +74,32 @@ func (id SpanID) String() string {
 // TraceOptions describes the options for a trace.
 type TraceOptions uint8
 
-// Sampled reports whether or not the request should be traced.
-func (o TraceOptions) Sampled() bool {
-	return (o & traceOptionsSampledFlag) == traceOptionsSampledFlag
+// Requested reports whether or not it has been requested that this
+// transaction/span be recorded.
+func (o TraceOptions) Requested() bool {
+	return (o & traceOptionsRequestedFlag) == traceOptionsRequestedFlag
 }
 
-// WithSampled changes the "sampled" flag, and returns the new options without
+// MaybeRecorded reports whether or not the transaction/span may have been
+// (or may be) recorded.
+func (o TraceOptions) MaybeRecorded() bool {
+	return (o & traceOptionsRecordedFlag) == traceOptionsRecordedFlag
+}
+
+// WithRequested changes the "requested" flag, and returns the new options without
 // modifying the original value.
-func (o TraceOptions) WithSampled(sampled bool) TraceOptions {
-	if sampled {
-		return o | traceOptionsSampledFlag
+func (o TraceOptions) WithRequested(requested bool) TraceOptions {
+	if requested {
+		return o | traceOptionsRequestedFlag
 	}
-	return o & (0xFF ^ traceOptionsSampledFlag)
+	return o & (0xFF ^ traceOptionsRequestedFlag)
+}
+
+// WithMaybeRecorded changes the "recorded" flag, and returns the new options
+// without modifying the original value.
+func (o TraceOptions) WithMaybeRecorded(maybeRecorded bool) TraceOptions {
+	if maybeRecorded {
+		return o | traceOptionsRecordedFlag
+	}
+	return o & (0xFF ^ traceOptionsRecordedFlag)
 }

--- a/tracecontext_test.go
+++ b/tracecontext_test.go
@@ -26,13 +26,21 @@ func TestSpanID(t *testing.T) {
 
 func TestTraceOptions(t *testing.T) {
 	opts := elasticapm.TraceOptions(0xFE)
-	assert.False(t, opts.Sampled())
+	assert.False(t, opts.Requested())
+	assert.True(t, opts.MaybeRecorded())
 
-	opts = opts.WithSampled(true)
-	assert.True(t, opts.Sampled())
-	assert.Equal(t, opts, elasticapm.TraceOptions(0xFF))
+	opts = opts.WithRequested(true)
+	assert.True(t, opts.Requested())
+	assert.True(t, opts.MaybeRecorded())
+	assert.Equal(t, elasticapm.TraceOptions(0xFF), opts)
 
-	opts = opts.WithSampled(false)
-	assert.False(t, opts.Sampled())
-	assert.Equal(t, opts, elasticapm.TraceOptions(0xFE))
+	opts = opts.WithRequested(false)
+	assert.False(t, opts.Requested())
+	assert.True(t, opts.MaybeRecorded())
+	assert.Equal(t, elasticapm.TraceOptions(0xFE), opts)
+
+	opts = opts.WithMaybeRecorded(false)
+	assert.False(t, opts.Requested())
+	assert.False(t, opts.MaybeRecorded())
+	assert.Equal(t, elasticapm.TraceOptions(0xFC), opts)
 }


### PR DESCRIPTION
Update TraceContext options to store two bits: requested and recorded.

Closes #176 