### PR TITLE
Record event type in ring buffer header

### DIFF
--- a/internal/ringbuffer/buffer.go
+++ b/internal/ringbuffer/buffer.go
@@ -7,22 +7,39 @@ import (
 	"io/ioutil"
 )
 
-// BlockOverhead is the number of additional writes per block of data
-// written to the buffer for block accounting.
-const BlockOverhead = 4
+// BlockHeaderSize is the size of the block header, in bytes.
+const BlockHeaderSize = 5
+
+// BlockTag is a block tag, which can be used for classification.
+type BlockTag uint8
+
+// BlockHeader holds a fixed-size block header.
+type BlockHeader struct {
+	// Tag is the block's tag.
+	Tag BlockTag
+
+	// Size is the size of the block data, in bytes.
+	Size uint32
+}
 
 // Buffer is a ring buffer of byte blocks.
 type Buffer struct {
-	buf     []byte
-	sizebuf [4]byte
-	len     int
-	write   int
-	read    int
+	buf       []byte
+	headerbuf [BlockHeaderSize]byte
+	len       int
+	write     int
+	read      int
+
+	// Evicted will be called when an old block is evicted to make place for a new one.
+	Evicted func(BlockHeader)
 }
 
 // New returns a new Buffer with the given size in bytes.
 func New(size int) *Buffer {
-	return &Buffer{buf: make([]byte, size)}
+	return &Buffer{
+		buf:     make([]byte, size),
+		Evicted: func(BlockHeader) {},
+	}
 }
 
 // Len returns the number of bytes currently in the buffer, including
@@ -36,26 +53,28 @@ func (b *Buffer) Cap() int {
 	return len(b.buf)
 }
 
-// WriteTo writes the oldest block in b to w, and returns its size in bytes.
-func (b *Buffer) WriteTo(w io.Writer) (written int64, err error) {
+// WriteBlockTo writes the oldest block in b to w, returning the block header and the number of bytes written to w.
+func (b *Buffer) WriteBlockTo(w io.Writer) (header BlockHeader, written int64, err error) {
 	if b.len == 0 {
-		return 0, io.EOF
+		return header, 0, io.EOF
 	}
-	if n := copy(b.sizebuf[:], b.buf[b.read:]); n < len(b.sizebuf) {
-		b.read = copy(b.sizebuf[n:], b.buf[:])
+	if n := copy(b.headerbuf[:], b.buf[b.read:]); n < len(b.headerbuf) {
+		b.read = copy(b.headerbuf[n:], b.buf[:])
 	} else {
 		b.read = (b.read + n) % b.Cap()
 	}
-	b.len -= len(b.sizebuf)
-	size := int(binary.LittleEndian.Uint32(b.sizebuf[:]))
+	b.len -= len(b.headerbuf)
+	header.Tag = BlockTag(b.headerbuf[0])
+	header.Size = binary.LittleEndian.Uint32(b.headerbuf[1:])
+	size := int(header.Size)
 
 	if b.read+size > b.Cap() {
 		tail := b.buf[b.read:]
 		n, err := w.Write(tail)
 		if err != nil {
 			b.read = (b.read + size) % b.Cap()
-			b.len -= size + len(b.sizebuf)
-			return int64(n), err
+			b.len -= size + len(b.headerbuf)
+			return header, int64(n), err
 		}
 		size -= n
 		written = int64(n)
@@ -64,30 +83,35 @@ func (b *Buffer) WriteTo(w io.Writer) (written int64, err error) {
 	}
 	n, err := w.Write(b.buf[b.read : b.read+size])
 	if err != nil {
-		return written + int64(n), err
+		return header, written + int64(n), err
 	}
 	written += int64(n)
 	b.read = (b.read + size) % b.Cap()
 	b.len -= size
-	return written, nil
+	return header, written, nil
 }
 
-// Write writes p as a block to b.
+// WriteBlock writes p as a block to b, with tag t.
 //
-// If len(p)+BlockOverhead > b.Cap(), bytes.ErrTooLarge will be returned.
+// If len(p)+BlockHeaderSize > b.Cap(), bytes.ErrTooLarge will be returned.
 // If the buffer does not currently have room for the block, then the
 // oldest blocks will be evicted until enough room is available.
-func (b *Buffer) Write(p []byte) (int, error) {
+func (b *Buffer) WriteBlock(p []byte, tag BlockTag) (int, error) {
 	lenp := len(p)
-	if lenp+BlockOverhead > b.Cap() {
+	if lenp+BlockHeaderSize > b.Cap() {
 		return 0, bytes.ErrTooLarge
 	}
-	for lenp+BlockOverhead > b.Cap()-b.Len() {
-		b.WriteTo(ioutil.Discard)
+	for lenp+BlockHeaderSize > b.Cap()-b.Len() {
+		header, _, err := b.WriteBlockTo(ioutil.Discard)
+		if err != nil {
+			return 0, err
+		}
+		b.Evicted(header)
 	}
-	binary.LittleEndian.PutUint32(b.sizebuf[:], uint32(lenp))
-	if n := copy(b.buf[b.write:], b.sizebuf[:]); n < len(b.sizebuf) {
-		b.write = copy(b.buf, b.sizebuf[n:])
+	b.headerbuf[0] = uint8(tag)
+	binary.LittleEndian.PutUint32(b.headerbuf[1:], uint32(lenp))
+	if n := copy(b.buf[b.write:], b.headerbuf[:]); n < len(b.headerbuf) {
+		b.write = copy(b.buf, b.headerbuf[n:])
 	} else {
 		b.write = (b.write + n) % b.Cap()
 	}
@@ -96,6 +120,6 @@ func (b *Buffer) Write(p []byte) (int, error) {
 	} else {
 		b.write = (b.write + n) % b.Cap()
 	}
-	b.len += lenp + BlockOverhead
+	b.len += lenp + BlockHeaderSize
 	return lenp, nil
 }

--- a/internal/ringbuffer/buffer_test.go
+++ b/internal/ringbuffer/buffer_test.go
@@ -2,6 +2,7 @@ package ringbuffer
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -9,6 +10,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestBlockHeaderSize(t *testing.T) {
+	size := binary.Size(BlockHeader{})
+	assert.Equal(t, BlockHeaderSize, size)
+}
 
 func TestBuffer(t *testing.T) {
 	b := New(150)
@@ -18,17 +24,17 @@ func TestBuffer(t *testing.T) {
 	const block = `{"transaction":{"duration":0,"id":"00000000-0000-0000-0000-000000000000","name":"","timestamp":"0001-01-01T00:00:00Z","type":""}}`
 
 	for i := 0; i < 10; i++ {
-		b.Write([]byte(block))
+		b.WriteBlock([]byte(block), 0)
 		blen := b.Len()
 		assert.NotEqual(t, 0, blen)
 		assert.Equal(t, 150, b.Cap())
 
 		var bb bytes.Buffer
-		n, err := b.WriteTo(&bb)
-		assert.Equal(t, int64(blen-BlockOverhead), n)
+		_, n, err := b.WriteBlockTo(&bb)
+		assert.Equal(t, int64(blen-BlockHeaderSize), n)
 		assert.Equal(t, block, bb.String())
 		assert.Equal(t, 0, b.Len())
-		n, err = b.WriteTo(&bb)
+		_, n, err = b.WriteBlockTo(&bb)
 		assert.Zero(t, n)
 		assert.Equal(t, io.EOF, err)
 	}
@@ -36,18 +42,28 @@ func TestBuffer(t *testing.T) {
 
 func TestBufferEviction(t *testing.T) {
 	const block = `{"transaction":{"duration":0,"id":"00000000-0000-0000-0000-000000000000","name":"","timestamp":"0001-01-01T00:00:00Z","type":""}}`
+
+	var evicted []BlockHeader
 	b := New(300)
-	for i := 0; i < 100; i++ {
-		b.Write([]byte(block))
+	b.Evicted = func(h BlockHeader) {
+		evicted = append(evicted, h)
 	}
-	assert.Equal(t, len(block)*2+2*BlockOverhead, b.Len())
+	for i := 0; i < 100; i++ {
+		b.WriteBlock([]byte(block), BlockTag(i))
+	}
+	assert.Equal(t, len(block)*2+2*BlockHeaderSize, b.Len())
 
 	for i := 0; i < 2; i++ {
 		var bb bytes.Buffer
-		b.WriteTo(&bb)
+		b.WriteBlockTo(&bb)
 		assert.Equal(t, block, bb.String())
 	}
 	assert.Equal(t, 0, b.Len())
+	assert.Len(t, evicted, 98)
+	for i, h := range evicted {
+		assert.Equal(t, BlockTag(i), h.Tag)
+		assert.Equal(t, uint32(len(block)), h.Size)
+	}
 }
 
 func BenchmarkWrite(b *testing.B) {
@@ -56,7 +72,7 @@ func BenchmarkWrite(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		n, err := buf.Write(data[:])
+		n, err := buf.WriteBlock(data[:], 0)
 		if err != nil {
 			panic(err)
 		}
@@ -64,16 +80,16 @@ func BenchmarkWrite(b *testing.B) {
 	}
 }
 
-func BenchmarkWriteTo(b *testing.B) {
+func BenchmarkWriteBlockTo(b *testing.B) {
 	data := []byte(strings.Repeat("*", 300))
-	buf := New(b.N * (len(data) + BlockOverhead))
+	buf := New(b.N * (len(data) + BlockHeaderSize))
 	for i := 0; i < b.N; i++ {
-		buf.Write(data[:])
+		buf.WriteBlock(data[:], 0)
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		n, err := buf.WriteTo(ioutil.Discard)
+		_, n, err := buf.WriteBlockTo(ioutil.Discard)
 		if err != nil {
 			panic(err)
 		}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -293,9 +293,8 @@ func TestTracerBufferSize(t *testing.T) {
 	assert.NotEqual(t, len(p.Transactions), len(p2.Transactions))
 	assert.NotEqual(t, fmt.Sprint(len(p.Transactions)), p2.Transactions[len(p.Transactions)].Name)
 
-	// BUG(axw) we should be keeping track of which entities
-	// we drop from the buffer and reflecting those in stats.
-	assert.Equal(t, uint64(0), tracer.Stats().TransactionsDropped)
+	// We record the type of event in the buffer, in order to keep the dropped stats accurate.
+	assert.Equal(t, uint64(1000-len(p2.Transactions)), tracer.Stats().TransactionsDropped)
 }
 
 func TestTracerBodyUnread(t *testing.T) {


### PR DESCRIPTION
Update internal/ringbuffer, extending the header
to include a single byte tag as well as the data
size. Add an "Evicted" function field to Buffer,
which will be called with the block header for
evicted blocks.

We use this in the tracer to update the dropped
stats when the buffer is full. We also now more
accurately update the sent stats when extracting
from the buffer (writing to zlib), rather than when
writing to the buffer.