### PR TITLE
ELASTIC_APM_DEBUG controls logging

### DIFF
--- a/builtin_metrics.go
+++ b/builtin_metrics.go
@@ -78,9 +78,7 @@ func (g *builtinMetricsGatherer) gatherMemStatsMetrics(m *Metrics) {
 }
 
 func (g *builtinMetricsGatherer) gatherTracerStatsMetrics(m *Metrics) {
-	g.tracer.statsMu.Lock()
-	stats := g.tracer.stats
-	g.tracer.statsMu.Unlock()
+	stats := g.tracer.Stats()
 
 	const p = "agent"
 	m.Add(p+".send_errors", nil, float64(stats.Errors.SendStream))

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -293,8 +293,8 @@ changing this setting to `false`.
 
 `ELASTIC_APM_DEBUG` can be used to debug issues with the Elastic APM Go agent
 or your instrumentation. The value should be a comma-separated list of key=value
-debug directives. Currently we support just one: `tracetransport=1`.
+debug directives. Currently we support just one: `log=1`.
 
-By setting `ELASTIC_APM_DEBUG="tracetransport=1"`, the Go agent will log all
-transport calls to the terminal.
+By setting `ELASTIC_APM_DEBUG="log=1"`, the Go agent will log messages to the
+terminal, as well as to the tracer's programatically configured logger, if any.
 


### PR DESCRIPTION
Change ELASTIC_APM_DEBUG to control logging.
If you set ELASTIC_APM_DEBUG="log=1", then
the tracer will log messages to stderr as
well as to a logger specified via SetLogger.

Also, don't update "sent" stats until the
request has completed successfully. If the
request fails, we don't increment the stats;
the events may have been sent, or they may
have been lost. We instead increment the
errors.send_stream counter.