### PR TITLE
 module/apmgocql: require Go 1.9+

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,11 @@
 version: build-{build}-{branch}
-clone_folder: C:\Go\src\github.com\elastic\apm-agent-go
+clone_folder: C:\gopath\src\github.com\elastic\apm-agent-go
 shallow_clone: true
 deploy: off
 
 environment:
   PATH: C:\msys64\mingw64\bin;%PATH%
+  GOPATH: C:\gopath
 
 build_script:
 - cmd: go get -t ./...

--- a/module/apmgocql/apmgocql_test.go
+++ b/module/apmgocql/apmgocql_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql_test
 
 import (

--- a/module/apmgocql/doc.go
+++ b/module/apmgocql/doc.go
@@ -1,2 +1,4 @@
+// +build go1.9
+
 // Package apmgocql provides an observer for tracing gocql (Cassandra) query spans.
 package apmgocql

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql
 
 import (

--- a/module/apmgocql/signature.go
+++ b/module/apmgocql/signature.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql
 
 import (

--- a/module/apmgocql/signature_test.go
+++ b/module/apmgocql/signature_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql
 
 import (


### PR DESCRIPTION
gocql now requires Go 1.9, due to its use of math/bits.