### PR TITLE
elasticapm: set model.Span.Start

### DIFF
--- a/modelwriter.go
+++ b/modelwriter.go
@@ -105,6 +105,7 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span) {
 	out.Name = truncateString(span.Name)
 	out.Type = truncateString(span.Type)
 	out.Timestamp = model.Time(span.Timestamp.UTC())
+	out.Start = span.Timestamp.Sub(span.transactionTimestamp).Seconds() * 1000
 	out.Duration = span.Duration.Seconds() * 1000
 	out.Context = span.Context.build()
 

--- a/module/apmgocql/apmgocql_test.go
+++ b/module/apmgocql/apmgocql_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql_test
 
 import (

--- a/module/apmgocql/doc.go
+++ b/module/apmgocql/doc.go
@@ -1,2 +1,4 @@
+// +build go1.9
+
 // Package apmgocql provides an observer for tracing gocql (Cassandra) query spans.
 package apmgocql

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql
 
 import (

--- a/module/apmgocql/signature.go
+++ b/module/apmgocql/signature.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql
 
 import (

--- a/module/apmgocql/signature_test.go
+++ b/module/apmgocql/signature_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgocql
 
 import (

--- a/span.go
+++ b/span.go
@@ -46,6 +46,7 @@ func (tx *Transaction) StartSpan(name, spanType string, parent *Span) *Span {
 	// the stack trace, and make the rendering in the model
 	// writer conditional.
 	span.stackFramesMinDuration = tx.spanFramesMinDuration
+	span.transactionTimestamp = tx.Timestamp
 	tx.spansCreated++
 	tx.mu.Unlock()
 
@@ -70,6 +71,11 @@ type Span struct {
 	parentID               SpanID
 	transactionID          SpanID
 	stackFramesMinDuration time.Duration
+
+	// TODO(axw) drop this (or update API) when elastic/apm-server#1340 is resolved.
+	// We currently set this based on the value of tx.Timestamp at the time StartSpan
+	// is called. This doesn't allow for tx.Timestamp to be updated, breaking the API.
+	transactionTimestamp time.Time
 
 	Name      string
 	Type      string


### PR DESCRIPTION
Until elastic/apm-server#1340 is resolved,
keep setting span.start. The way we set it
is unsound, assuming the transaction timestamp
cannot change after construction. If we do
not go ahead with making span.start optional,
we'll have to adjust the API.