### PR TITLE
module/apmot: don't hold ended transactions/spans

### DIFF
--- a/model/marshal.go
+++ b/model/marshal.go
@@ -238,10 +238,6 @@ func (v *URL) marshalFullURL(w *fastjson.Writer, scheme []byte) bool {
 	return true
 }
 
-func (c *SpanCount) isZero() bool {
-	return *c == SpanCount{}
-}
-
 func (d *SpanCountDropped) isZero() bool {
 	return *d == SpanCountDropped{}
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -143,6 +143,8 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) {
 	v.ID.MarshalFastJSON(w)
 	w.RawString(",\"name\":")
 	w.String(v.Name)
+	w.RawString(",\"span_count\":")
+	v.SpanCount.MarshalFastJSON(w)
 	w.RawString(",\"timestamp\":")
 	v.Timestamp.MarshalFastJSON(w)
 	w.RawString(",\"trace_id\":")
@@ -165,17 +167,15 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) {
 		w.RawString(",\"sampled\":")
 		w.Bool(*v.Sampled)
 	}
-	if !v.SpanCount.isZero() {
-		w.RawString(",\"span_count\":")
-		v.SpanCount.MarshalFastJSON(w)
-	}
 	w.RawByte('}')
 }
 
 func (v *SpanCount) MarshalFastJSON(w *fastjson.Writer) {
 	w.RawByte('{')
+	w.RawString("\"total\":")
+	w.Int64(int64(v.Total))
 	if !v.Dropped.isZero() {
-		w.RawString("\"dropped\":")
+		w.RawString(",\"dropped\":")
 		v.Dropped.MarshalFastJSON(w)
 	}
 	w.RawByte('}')

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -78,6 +78,7 @@ func TestMarshalTransaction(t *testing.T) {
 			},
 		},
 		"span_count": map[string]interface{}{
+			"total": float64(99),
 			"dropped": map[string]interface{}{
 				"total": float64(4),
 			},
@@ -536,6 +537,7 @@ func fakeTransaction() model.Transaction {
 			},
 		},
 		SpanCount: model.SpanCount{
+			Total: 99,
 			Dropped: model.SpanCountDropped{
 				Total: 4,
 			},

--- a/model/model.go
+++ b/model/model.go
@@ -519,8 +519,7 @@ type Time time.Time
 type TraceID [16]byte
 
 // SpanID holds a 64-bit span ID. Despite its name, this is used for
-// both spans and transactions, but only when distributed tracing is
-// enabled.
+// both spans and transactions.
 type SpanID [8]byte
 
 // Metrics holds a set of metric samples, with an optional set of labels.

--- a/model/model.go
+++ b/model/model.go
@@ -140,13 +140,16 @@ type Transaction struct {
 	Sampled *bool `json:"sampled,omitempty"`
 
 	// SpanCount holds statistics on spans within a transaction.
-	SpanCount SpanCount `json:"span_count,omitempty"`
+	SpanCount SpanCount `json:"span_count"`
 }
 
 // SpanCount holds statistics on spans within a transaction.
 type SpanCount struct {
 	// Dropped holds statistics on dropped spans within a transaction.
 	Dropped SpanCountDropped `json:"dropped,omitempty"`
+
+	// Total holds the number of spans recorded within a transaction.
+	Total int `json:"total"`
 }
 
 // SpanCountDropped holds statistics on dropped spans.

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -83,6 +83,7 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 	out.Result = truncateString(tx.Result)
 	out.Timestamp = model.Time(tx.Timestamp.UTC())
 	out.Duration = tx.Duration.Seconds() * 1000
+	out.SpanCount.Total = tx.spansCreated
 	out.SpanCount.Dropped.Total = tx.spansDropped
 
 	if !tx.Sampled() {

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -105,7 +105,9 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span) {
 	out.Name = truncateString(span.Name)
 	out.Type = truncateString(span.Type)
 	out.Timestamp = model.Time(span.Timestamp.UTC())
-	out.Start = span.Timestamp.Sub(span.transactionTimestamp).Seconds() * 1000
+	if !span.transactionTimestamp.IsZero() {
+		out.Start = span.Timestamp.Sub(span.transactionTimestamp).Seconds() * 1000
+	}
 	out.Duration = span.Duration.Seconds() * 1000
 	out.Context = span.Context.build()
 

--- a/module/apmot/context.go
+++ b/module/apmot/context.go
@@ -1,40 +1,35 @@
 package apmot
 
 import (
+	"sync"
+
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/elastic/apm-agent-go"
 )
 
 type spanContext struct {
-	// BUG(axw) spanContext must not hold onto any transaction or
-	// span objects, as an opentracing.SpanContext may outlive the
-	// span to which it relates. To fix this, we need spans at the
-	// top level, and a means of creating them from a TraceContext.
-	//
-	// In most cases this is *probably* OK, because a child-of
-	// relation means that the parent span cannot be ended before
-	// the child. However, there's no guarantee that the ordering
-	// of operations on the OpenTracing API follows the ordering
-	// of the events exactly (e.g. you could complete the entire
-	// business transaction before emitting events, and then emit
-	// events for the transaction and then its spans.)
 	tracer *otTracer // for origin of tx/span
-	tx     *elasticapm.Transaction
-	span   *elasticapm.Span
 
-	traceContext elasticapm.TraceContext
+	txSpanContext *spanContext // spanContext for OT span which created tx
+	traceContext  elasticapm.TraceContext
+	transactionID elasticapm.SpanID
+
+	mu sync.RWMutex
+	tx *elasticapm.Transaction
 }
 
 // ForeachBaggageItem is a no-op; we do not support baggage propagation.
-func (c spanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+func (*spanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
 
-func parentSpanContext(refs []opentracing.SpanReference) (spanContext, bool) {
+func parentSpanContext(refs []opentracing.SpanReference) (*spanContext, bool) {
 	for _, ref := range refs {
 		switch ref.Type {
 		case opentracing.ChildOfRef, opentracing.FollowsFromRef:
-			return ref.ReferencedContext.(spanContext), true
+			if ctx, ok := ref.ReferencedContext.(*spanContext); ok {
+				return ctx, ok
+			}
 		}
 	}
-	return spanContext{}, false
+	return nil, false
 }

--- a/module/apmot/doc.go
+++ b/module/apmot/doc.go
@@ -6,9 +6,6 @@
 //  - logging
 //
 // TODO(axw)
-//  - update spanContext to stop storing objects once we
-//    have completed support for distributed tracing; we
-//    should only store trace context
 //  - investigate injecting native APM transactions/spans
 //    as the parent when starting an OT span. This probably
 //    requires extending the OT API.

--- a/module/apmot/harness_test.go
+++ b/module/apmot/harness_test.go
@@ -51,11 +51,11 @@ func TestHarness(t *testing.T) {
 type harnessAPIProbe struct{}
 
 func (harnessAPIProbe) SameTrace(first, second opentracing.Span) bool {
-	ctx1, ok := first.Context().(spanContext)
+	ctx1, ok := first.Context().(*spanContext)
 	if !ok {
 		return false
 	}
-	ctx2, ok := second.Context().(spanContext)
+	ctx2, ok := second.Context().(*spanContext)
 	if !ok {
 		return false
 	}
@@ -63,11 +63,11 @@ func (harnessAPIProbe) SameTrace(first, second opentracing.Span) bool {
 }
 
 func (harnessAPIProbe) SameSpanContext(span opentracing.Span, sc opentracing.SpanContext) bool {
-	ctx1, ok := span.Context().(spanContext)
+	ctx1, ok := span.Context().(*spanContext)
 	if !ok {
 		return false
 	}
-	ctx2, ok := sc.(spanContext)
+	ctx2, ok := sc.(*spanContext)
 	if !ok {
 		return false
 	}

--- a/span.go
+++ b/span.go
@@ -73,7 +73,9 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 //
 // In most cases, you should use Transaction.StartSpan or Transaction.StartSpanOptions.
 // This method is provided for corner-cases, such as starting a span after the
-// containing transaction's End method has been called.
+// containing transaction's End method has been called. Spans created in this
+// way will not have the "max spans" configuration applied, nor will they be
+// considered in any transaction's span count.
 func (t *Tracer) StartSpan(name, spanType string, transactionID SpanID, opts SpanOptions) *Span {
 	if opts.Parent.Trace.Validate() != nil || opts.Parent.Span.Validate() != nil || transactionID.Validate() != nil {
 		return newDroppedSpan()

--- a/span.go
+++ b/span.go
@@ -1,6 +1,7 @@
 package elasticapm
 
 import (
+	cryptorand "crypto/rand"
 	"encoding/binary"
 	"sync"
 	"time"
@@ -15,31 +16,45 @@ var droppedSpanPool sync.Pool
 
 // StartSpan starts and returns a new Span within the transaction,
 // with the specified name, type, and optional parent span, and
-// with the start time set to the current time relative to the
-// transaction's timestamp.
+// with the start time set to the current time.
 //
 // StartSpan always returns a non-nil Span. Its End method must
 // be called when the span completes.
+//
+// StartSpan is equivalent to calling StartSpanOptions with
+// SpanOptions.Parent set to the trace context of parent if
+// parent is non-nil.
 func (tx *Transaction) StartSpan(name, spanType string, parent *Span) *Span {
+	var parentTraceContext TraceContext
+	if parent != nil {
+		parentTraceContext = parent.TraceContext()
+	}
+	return tx.StartSpanOptions(name, spanType, SpanOptions{
+		Parent: parentTraceContext,
+	})
+}
+
+// StartSpanOptions starts and returns a new Span within the transaction,
+// with the specified name, type, and options.
+//
+// StartSpan always returns a non-nil Span. Its End method must
+// be called when the span completes.
+func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions) *Span {
 	if tx == nil || !tx.Sampled() {
 		return newDroppedSpan()
 	}
-
 	tx.mu.Lock()
 	if tx.maxSpans > 0 && tx.spansCreated >= tx.maxSpans {
 		tx.spansDropped++
 		tx.mu.Unlock()
 		return newDroppedSpan()
 	}
-	span, _ := tx.tracer.spanPool.Get().(*Span)
-	if span == nil {
-		span = &Span{
-			tracer:   tx.tracer,
-			Duration: -1,
-		}
+	transactionID := tx.traceContext.Span
+	if opts.Parent == (TraceContext{}) {
+		opts.Parent = tx.traceContext
 	}
-	var spanID SpanID
-	binary.LittleEndian.PutUint64(spanID[:], tx.rand.Uint64())
+	span := tx.tracer.startSpan(name, spanType, transactionID, opts)
+	binary.LittleEndian.PutUint64(span.traceContext.Span[:], tx.rand.Uint64())
 	// TODO(axw) profile whether it's worthwhile threading and
 	// storing spanFramesMinDuration through to the transaction
 	// and span, or if we can instead unconditionally capture
@@ -49,18 +64,57 @@ func (tx *Transaction) StartSpan(name, spanType string, parent *Span) *Span {
 	span.transactionTimestamp = tx.Timestamp
 	tx.spansCreated++
 	tx.mu.Unlock()
+	return span
+}
 
+// StartSpan returns a new Span with the specified name, type, transaction ID,
+// and options. The parent transaction context and transaction IDs must have
+// valid, non-zero values, or else the span will be dropped.
+//
+// In most cases, you should use Transaction.StartSpan or Transaction.StartSpanOptions.
+// This method is provided for corner-cases, such as starting a span after the
+// containing transaction's End method has been called.
+func (t *Tracer) StartSpan(name, spanType string, transactionID SpanID, opts SpanOptions) *Span {
+	if opts.Parent.Trace.Validate() != nil || opts.Parent.Span.Validate() != nil || transactionID.Validate() != nil {
+		return newDroppedSpan()
+	}
+	if !opts.Parent.Options.MaybeRecorded() {
+		return newDroppedSpan()
+	}
+	var spanID SpanID
+	if _, err := cryptorand.Read(spanID[:]); err != nil {
+		return newDroppedSpan()
+	}
+	span := t.startSpan(name, spanType, transactionID, opts)
+	span.traceContext.Span = spanID
+	// TODO(axw) profile whether it's worthwhile threading and
+	// storing spanFramesMinDuration through to the transaction
+	// and span, or if we can instead unconditionally capture
+	// the stack trace, and make the rendering in the model
+	// writer conditional.
+	t.spanFramesMinDurationMu.RLock()
+	span.stackFramesMinDuration = t.spanFramesMinDuration
+	t.spanFramesMinDurationMu.RUnlock()
+	return span
+}
+
+func (t *Tracer) startSpan(name, spanType string, transactionID SpanID, opts SpanOptions) *Span {
+	span, _ := t.spanPool.Get().(*Span)
+	if span == nil {
+		span = &Span{
+			tracer:   t,
+			Duration: -1,
+		}
+	}
 	span.Name = name
 	span.Type = spanType
-	span.Timestamp = time.Now()
-	if parent != nil {
-		span.traceContext = parent.traceContext
-	} else {
-		span.traceContext = tx.traceContext
+	span.traceContext = opts.Parent
+	span.parentID = opts.Parent.Span
+	span.transactionID = transactionID
+	span.Timestamp = opts.Start
+	if span.Timestamp.IsZero() {
+		span.Timestamp = time.Now()
 	}
-	span.parentID = span.traceContext.Span
-	span.transactionID = tx.traceContext.Span
-	span.traceContext.Span = spanID
 	return span
 }
 
@@ -105,10 +159,7 @@ func (s *Span) reset() {
 	s.tracer.spanPool.Put(s)
 }
 
-// TraceContext returns the span's TraceContext: its trace ID, span ID,
-// and trace options. The values are undefined if distributed tracing
-// is disabled. If the span is dropped, the trace ID and options will
-// be zero.
+// TraceContext returns the span's TraceContext.
 func (s *Span) TraceContext() TraceContext {
 	return s.traceContext
 }
@@ -162,4 +213,14 @@ func (s *Span) enqueue() {
 		s.tracer.statsMu.Unlock()
 		s.reset()
 	}
+}
+
+// SpanOptions holds options for Transaction.StartSpanOptions and Tracer.StartSpan.
+type SpanOptions struct {
+	// Parent, if non-zero, holds the trace context of the parent span.
+	Parent TraceContext
+
+	// Start is the start time of the span. If this has the zero value,
+	// time.Now() will be used instead.
+	Start time.Time
 }

--- a/span_test.go
+++ b/span_test.go
@@ -52,5 +52,7 @@ func TestTracerStartSpan(t *testing.T) {
 	}
 	assert.NotZero(t, payloads.Spans[1].ID)
 
-	// TODO(axw) check total span count for tx is just 1
+	// The span created after the transaction (obviously?)
+	// doesn't get included in the transaction's span count.
+	assert.Equal(t, 1, payloads.Transactions[0].SpanCount.Total)
 }

--- a/span_test.go
+++ b/span_test.go
@@ -1,0 +1,56 @@
+package elasticapm_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestStartSpanTransactionNotSampled(t *testing.T) {
+	tracer, _ := elasticapm.NewTracer("tracer_testing", "")
+	defer tracer.Close()
+	// sample nothing
+	tracer.SetSampler(elasticapm.NewRatioSampler(0, rand.New(rand.NewSource(0))))
+
+	tx := tracer.StartTransaction("name", "type")
+	assert.False(t, tx.Sampled())
+	span := tx.StartSpan("name", "type", nil)
+	assert.True(t, span.Dropped())
+}
+
+func TestTracerStartSpan(t *testing.T) {
+	tracer, r := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	tx := tracer.StartTransaction("name", "type")
+	txTraceContext := tx.TraceContext()
+	span0 := tx.StartSpan("name", "type", nil)
+	span0TraceContext := span0.TraceContext()
+	span0.End()
+	tx.End()
+
+	// Even if the transaction and parent span have been ended,
+	// it is possible to report a span with their IDs.
+	tracer.StartSpan("name", "type", txTraceContext.Span, elasticapm.SpanOptions{
+		Parent: span0TraceContext,
+	}).End()
+
+	tracer.Flush(nil)
+	payloads := r.Payloads()
+	assert.Len(t, payloads.Transactions, 1)
+	assert.Len(t, payloads.Spans, 2)
+
+	assert.Equal(t, payloads.Transactions[0].ID, payloads.Spans[0].ParentID)
+	assert.Equal(t, payloads.Spans[0].ID, payloads.Spans[1].ParentID)
+	for _, span := range payloads.Spans {
+		assert.Equal(t, payloads.Transactions[0].TraceID, span.TraceID)
+		assert.Equal(t, payloads.Transactions[0].ID, span.TransactionID)
+	}
+	assert.NotZero(t, payloads.Spans[1].ID)
+
+	// TODO(axw) check total span count for tx is just 1
+}

--- a/transaction.go
+++ b/transaction.go
@@ -126,9 +126,7 @@ func (tx *Transaction) Sampled() bool {
 	return tx.traceContext.Options.MaybeRecorded()
 }
 
-// TraceContext returns the transaction's TraceContext: its trace ID,
-// span ID, and trace options. The values are undefined if distributed
-// tracing is disabled.
+// TraceContext returns the transaction's TraceContext.
 func (tx *Transaction) TraceContext() TraceContext {
 	return tx.traceContext
 }
@@ -160,9 +158,7 @@ func (tx *Transaction) enqueue() {
 // TransactionOptions holds options for Tracer.StartTransactionOptions.
 type TransactionOptions struct {
 	// TraceContext holds the TraceContext for a new transaction. If this is
-	// zero, and distributed tracing is enabled, a new trace will be started.
-	//
-	// TraceContext is ignored if distributed tracing is disabled.
+	// zero, a new trace will be started.
 	TraceContext TraceContext
 
 	// Start is the start time of the transaction. If this has the


### PR DESCRIPTION
Introduce Tracer.StartSpan, which takes a transaction ID
and parent span/transaction trace context. This method
should only be used when there is no active transaction.

Also introduce Transaction.StartSpanOptions, which takes
a SpanOptions containing an optional start timestamp and
optional parent span trace context. This may be used over
the StartSpan method if the parent span is already ended.
We leave the existing StartSpan method for its simplicity.

In module/apmot, we use Tracer.StartSpan if the transaction
has been ended. Otherwise, we use Transaction.StartSpanOptions,
and pass in the trace context of the parent span or transaction;
this means we no longer pass a parent span object into StartSpan,
so we don't care about whether or not it has been finished.

Finally, we introduce `transaction.span_count.total` to the model,
which records the number of spans created during a transaction.

Fixes #174 
Closes #198