### PR TITLE
Check reused error stacktrace slice correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v0.5.0...master)
+## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v0.5.1...master)
+
+## [v0.5.1](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.1)
+
+ - Fixed a bug causing error stacktraces and culprit to sometimes not be set (#204)
 
 ## [v0.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.0)
 

--- a/error.go
+++ b/error.go
@@ -90,7 +90,7 @@ func (t *Tracer) NewError(err error) *Error {
 	}
 	initException(&e.model.Exception, errors.Cause(err))
 	initStacktrace(e, err)
-	if e.stacktrace == nil {
+	if len(e.stacktrace) == 0 {
 		e.SetStacktrace(2)
 	}
 	return e

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package elasticapm
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "0.5.0"
+	AgentVersion = "0.5.1"
 )


### PR DESCRIPTION
When checking if we should automatically set the
stacktrace for a new error, check the length of
the stacktrace slice is zero rather than checking
that it is nil. The slice may be non-nil for a
reused error object.