### PR TITLE
Unexpose Timestamp from Transaction and Span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v0.5.0...master)
 
  - Implement v2 intake protocol (#180)
+ - Unexport Transaction.Timestamp and Span.Timestamp (#207)
 
 ## [v0.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.0)
 

--- a/gocontext.go
+++ b/gocontext.go
@@ -32,13 +32,18 @@ func TransactionFromContext(ctx context.Context) *Transaction {
 	return tx
 }
 
-// StartSpan starts and returns a new Span within the sampled transaction
-// and parent span in the context, if any. If the span isn't dropped, it
-// will be stored in the resulting context.
-//
-// StartSpan always returns a non-nil Span. Its End method must be called
-// when the span completes.
+// StartSpan is equivalent to calling StartSpanOptions with a zero SpanOptions struct.
 func StartSpan(ctx context.Context, name, spanType string) (*Span, context.Context) {
+	return StartSpanOptions(ctx, name, spanType, SpanOptions{})
+}
+
+// StartSpanOptions starts and returns a new Span within the sampled transaction
+// and parent span in the context, if any. If the span isn't dropped, it will be
+// stored in the resulting context.
+//
+// StartSpanOptions always returns a non-nil Span. Its End method must be called
+// when the span completes.
+func StartSpanOptions(ctx context.Context, name, spanType string, opts SpanOptions) (*Span, context.Context) {
 	tx := TransactionFromContext(ctx)
 	span := tx.StartSpan(name, spanType, SpanFromContext(ctx))
 	if !span.Dropped() {

--- a/model/model.go
+++ b/model/model.go
@@ -164,22 +164,11 @@ type Span struct {
 	// Name holds the name of the span.
 	Name string `json:"name"`
 
-	// Timestamp holds the time at which the span started.
-	//
-	// TODO(axw) according to the spec, this should be set to the timestamp
-	// of the transaction, not the span, and "start" is used as an offset.
-	// This requires keeping track of the transaction timestamp, which is
-	// not ideal. We are considering changing to have this be the span's
-	// timestamp instead: https://github.com/elastic/apm-dev/issues/282.
+	// Timestamp holds the time at which the span's transaction started.
 	Timestamp Time `json:"timestamp"`
 
 	// Start is the start time of the span, in milliseconds relative to
 	// the containing transaction's timestamp.
-	//
-	// TODO(axw) we currently never set this, so it's always reported as
-	// zero. We are considering updating the schema, server, and UI to use
-	// @timestamp to mean the span's start time if it is set:
-	// https://github.com/elastic/apm-dev/issues/282.
 	Start float64 `json:"start"`
 
 	// Duration holds the duration of the span, in milliseconds.

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -81,7 +81,7 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 	out.Name = truncateString(tx.Name)
 	out.Type = truncateString(tx.Type)
 	out.Result = truncateString(tx.Result)
-	out.Timestamp = model.Time(tx.Timestamp.UTC())
+	out.Timestamp = model.Time(tx.timestamp.UTC())
 	out.Duration = tx.Duration.Seconds() * 1000
 	out.SpanCount.Total = tx.spansCreated
 	out.SpanCount.Dropped.Total = tx.spansDropped
@@ -105,10 +105,8 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span) {
 
 	out.Name = truncateString(span.Name)
 	out.Type = truncateString(span.Type)
-	out.Timestamp = model.Time(span.Timestamp.UTC())
-	if !span.transactionTimestamp.IsZero() {
-		out.Start = span.Timestamp.Sub(span.transactionTimestamp).Seconds() * 1000
-	}
+	out.Timestamp = model.Time(span.transactionTimestamp.UTC())
+	out.Start = span.timestamp.Sub(span.transactionTimestamp).Seconds() * 1000
 	out.Duration = span.Duration.Seconds() * 1000
 	out.Context = span.Context.build()
 

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -39,8 +39,9 @@ func NewObserver(o ...Option) *Observer {
 // ObserveBatch observes batch executions, and creates spans for the
 // batch, and sub-spans for each statement therein.
 func (o *Observer) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) {
-	batchSpan, ctx := elasticapm.StartSpan(ctx, "BATCH", "db.cassandra.batch")
-	batchSpan.Timestamp = batch.Start
+	batchSpan, ctx := elasticapm.StartSpanOptions(ctx, "BATCH", "db.cassandra.batch", elasticapm.SpanOptions{
+		Start: batch.Start,
+	})
 	batchSpan.Duration = batch.End.Sub(batch.Start)
 	batchSpan.Context.SetDatabase(elasticapm.DatabaseSpanContext{
 		Type:     "cassandra",
@@ -49,8 +50,9 @@ func (o *Observer) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) 
 	defer batchSpan.End()
 
 	for _, statement := range batch.Statements {
-		span, _ := elasticapm.StartSpan(ctx, querySignature(statement), "db.cassandra.query")
-		span.Timestamp = batchSpan.Timestamp
+		span, _ := elasticapm.StartSpanOptions(ctx, querySignature(statement), "db.cassandra.query", elasticapm.SpanOptions{
+			Start: batch.Start,
+		})
 		span.Duration = batchSpan.Duration
 		span.Context.SetDatabase(elasticapm.DatabaseSpanContext{
 			Type:      "cassandra",
@@ -68,8 +70,9 @@ func (o *Observer) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) 
 
 // ObserveQuery observes query results, and creates spans for them.
 func (o *Observer) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
-	span, _ := elasticapm.StartSpan(ctx, querySignature(query.Statement), "db.cassandra.query")
-	span.Timestamp = query.Start
+	span, _ := elasticapm.StartSpanOptions(ctx, querySignature(query.Statement), "db.cassandra.query", elasticapm.SpanOptions{
+		Start: query.Start,
+	})
 	span.Duration = query.End.Sub(query.Start)
 	span.Context.SetDatabase(elasticapm.DatabaseSpanContext{
 		Type:      "cassandra",

--- a/module/apmot/context.go
+++ b/module/apmot/context.go
@@ -2,6 +2,7 @@ package apmot
 
 import (
 	"sync"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 
@@ -14,6 +15,7 @@ type spanContext struct {
 	txSpanContext *spanContext // spanContext for OT span which created tx
 	traceContext  elasticapm.TraceContext
 	transactionID elasticapm.SpanID
+	startTime     time.Time
 
 	mu sync.RWMutex
 	tx *elasticapm.Transaction

--- a/module/apmot/span.go
+++ b/module/apmot/span.go
@@ -57,10 +57,11 @@ func (s *otSpan) FinishWithOptions(opts opentracing.FinishOptions) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !opts.FinishTime.IsZero() {
+		duration := opts.FinishTime.Sub(s.ctx.startTime)
 		if s.span != nil {
-			s.span.Duration = opts.FinishTime.Sub(s.span.Timestamp)
+			s.span.Duration = duration
 		} else {
-			s.ctx.tx.Duration = opts.FinishTime.Sub(s.ctx.tx.Timestamp)
+			s.ctx.tx.Duration = duration
 		}
 	}
 	if s.span != nil {

--- a/transaction.go
+++ b/transaction.go
@@ -74,9 +74,9 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 			tx.traceContext.Options = o
 		}
 	}
-	tx.Timestamp = opts.Start
-	if tx.Timestamp.IsZero() {
-		tx.Timestamp = time.Now()
+	tx.timestamp = opts.Start
+	if tx.timestamp.IsZero() {
+		tx.timestamp = time.Now()
 	}
 	return tx
 }
@@ -85,12 +85,12 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 type Transaction struct {
 	Name         string
 	Type         string
-	Timestamp    time.Time
 	Duration     time.Duration
 	Context      Context
 	Result       string
 	traceContext TraceContext
 	parentSpan   SpanID
+	timestamp    time.Time
 
 	tracer                *Tracer
 	maxSpans              int
@@ -134,11 +134,11 @@ func (tx *Transaction) TraceContext() TraceContext {
 // End enqueues tx for sending to the Elastic APM server; tx must not
 // be used after this.
 //
-// If tx.Duration has not been set, End will set it to the elapsed
-// time since tx.Timestamp.
+// If tx.Duration has not been set, End will set it to the elapsed time
+// since the transaction's start time.
 func (tx *Transaction) End() {
 	if tx.Duration < 0 {
-		tx.Duration = time.Since(tx.Timestamp)
+		tx.Duration = time.Since(tx.timestamp)
 	}
 	tx.enqueue()
 }


### PR DESCRIPTION
If you want to specify the timestamp for a
transaction or span, you must now supply those
when constructing them via TransactionOptions
or SpanOptions. This enables us to store the
transaction timestamp on the span object, so
we can report the transaction timestamp and
calculate the start offset.

Closes #207 