### PR TITLE
Change name of "metric" stream object

### DIFF
--- a/modelwriter.go
+++ b/modelwriter.go
@@ -64,7 +64,7 @@ func (w *modelWriter) writeError(e *Error) {
 // writeMetrics encodes m as JSON to the buffer, and then resets m.
 func (w *modelWriter) writeMetrics(m *Metrics) {
 	for _, m := range m.metrics {
-		w.json.RawString(`{"metrics":`)
+		w.json.RawString(`{"metricset":`)
 		m.MarshalFastJSON(&w.json)
 		w.json.RawByte('}')
 		w.buffer.WriteBlock(w.json.Bytes(), metricsBlockTag)

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -74,7 +74,7 @@ func (r *RecorderTransport) record(stream io.Reader) error {
 	for {
 		var payload struct {
 			Error       *model.Error       `json:"error"`
-			Metrics     *model.Metrics     `json:"metrics"`
+			Metrics     *model.Metrics     `json:"metricset"`
 			Span        *model.Span        `json:"span"`
 			Transaction *model.Transaction `json:"transaction"`
 		}

--- a/validation_test.go
+++ b/validation_test.go
@@ -286,7 +286,7 @@ func (t *validatingTransport) SendStream(ctx context.Context, r io.Reader) error
 				switch k {
 				case "error":
 					schema = apmschema.Error
-				case "metrics":
+				case "metricset":
 					schema = apmschema.Metrics
 				case "span":
 					schema = apmschema.Span


### PR DESCRIPTION
The server previously expected "metric", and we were wrongly writing it as "metrics". In v2, it will be changed to "metricset" - see https://github.com/elastic/apm-server/pull/1359.