### PR TITLE
Require unit for durations (ms, s, or m)

### DIFF
--- a/env.go
+++ b/env.go
@@ -60,11 +60,11 @@ var (
 )
 
 func initialRequestDuration() (time.Duration, error) {
-	return apmconfig.ParseDurationEnv(envAPIRequestTime, "", defaultAPIRequestTime)
+	return apmconfig.ParseDurationEnv(envAPIRequestTime, defaultAPIRequestTime)
 }
 
 func initialMetricsInterval() (time.Duration, error) {
-	return apmconfig.ParseDurationEnv(envMetricsInterval, "s", defaultMetricsInterval)
+	return apmconfig.ParseDurationEnv(envMetricsInterval, defaultMetricsInterval)
 }
 
 func initialAPIBufferSize() (int, error) {
@@ -181,7 +181,7 @@ func initialService() (name, version, environment string) {
 }
 
 func initialSpanFramesMinDuration() (time.Duration, error) {
-	return apmconfig.ParseDurationEnv(envSpanFramesMinDuration, "", defaultSpanFramesMinDuration)
+	return apmconfig.ParseDurationEnv(envSpanFramesMinDuration, defaultSpanFramesMinDuration)
 }
 
 func initialActive() (bool, error) {

--- a/env_test.go
+++ b/env_test.go
@@ -58,13 +58,13 @@ func TestTracerRequestTimeEnvInvalid(t *testing.T) {
 		os.Setenv("ELASTIC_APM_API_REQUEST_TIME", "aeon")
 		defer os.Unsetenv("ELASTIC_APM_API_REQUEST_TIME")
 		_, err := elasticapm.NewTracer("tracer_testing", "")
-		assert.EqualError(t, err, "failed to parse ELASTIC_APM_API_REQUEST_TIME: time: invalid duration aeon")
+		assert.EqualError(t, err, "failed to parse ELASTIC_APM_API_REQUEST_TIME: invalid duration aeon")
 	})
 	t.Run("missing_suffix", func(t *testing.T) {
 		os.Setenv("ELASTIC_APM_API_REQUEST_TIME", "1")
 		defer os.Unsetenv("ELASTIC_APM_API_REQUEST_TIME")
 		_, err := elasticapm.NewTracer("tracer_testing", "")
-		assert.EqualError(t, err, "failed to parse ELASTIC_APM_API_REQUEST_TIME: time: missing unit in duration 1")
+		assert.EqualError(t, err, "failed to parse ELASTIC_APM_API_REQUEST_TIME: missing unit in duration 1 (allowed units: ms, s, m)")
 	})
 }
 
@@ -292,7 +292,7 @@ func TestTracerSpanFramesMinDurationEnvInvalid(t *testing.T) {
 	defer os.Unsetenv("ELASTIC_APM_SPAN_FRAMES_MIN_DURATION")
 
 	_, err := elasticapm.NewTracer("tracer_testing", "")
-	assert.EqualError(t, err, "failed to parse ELASTIC_APM_SPAN_FRAMES_MIN_DURATION: time: invalid duration aeon")
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_SPAN_FRAMES_MIN_DURATION: invalid duration aeon")
 }
 
 func TestTracerActive(t *testing.T) {

--- a/internal/apmconfig/duration.go
+++ b/internal/apmconfig/duration.go
@@ -1,25 +1,56 @@
 package apmconfig
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
+	"unicode"
 )
 
-// ParseDuration parses value as a duration, appending defaultSuffix if value
-// does not have one.
-func ParseDuration(value, defaultSuffix string) (time.Duration, error) {
-	d, err := time.ParseDuration(value)
-	if err != nil && defaultSuffix != "" {
-		// We allow the value to have no suffix, in which case we append
-		// defaultSuffix ("s" for flush interval) for compatibility with
-		// configuration for other Elastic APM agents.
-		var err2 error
-		d, err2 = time.ParseDuration(value + defaultSuffix)
-		if err2 == nil {
-			err = nil
+// ParseDuration parses s as a duration, accepting a subset
+// of the syntax supported by time.ParseDuration.
+//
+// Valid time units are "ms", "s", "m".
+func ParseDuration(s string) (time.Duration, error) {
+	orig := s
+	var mul time.Duration = 1
+	if strings.HasPrefix(s, "-") {
+		mul = -1
+		s = s[1:]
+	}
+
+	sep := -1
+	for i, c := range s {
+		if sep == -1 {
+			if c < '0' || c > '9' {
+				sep = i
+				break
+			}
 		}
 	}
-	if err != nil {
-		return 0, err
+	if sep == -1 {
+		return 0, fmt.Errorf("missing unit in duration %s (allowed units: ms, s, m)", orig)
 	}
-	return d, nil
+
+	n, err := strconv.ParseInt(s[:sep], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %s", orig)
+	}
+	switch s[sep:] {
+	case "ms":
+		mul *= time.Millisecond
+	case "s":
+		mul *= time.Second
+	case "m":
+		mul *= time.Minute
+	default:
+		for _, c := range s[sep:] {
+			if unicode.IsSpace(c) {
+				return 0, fmt.Errorf("invalid character %q in duration %s", c, orig)
+			}
+		}
+		return 0, fmt.Errorf("invalid unit in duration %s (allowed units: ms, s, m)", orig)
+	}
+	return mul * time.Duration(n), nil
 }

--- a/internal/apmconfig/env.go
+++ b/internal/apmconfig/env.go
@@ -9,15 +9,14 @@ import (
 )
 
 // ParseDurationEnv gets the value of the environment variable envKey
-// and, if set, parses it as a duration. If the value has no suffix,
-// defaultSuffix is appended. If the environment variable is unset,
-// defaultDuration is returned.
-func ParseDurationEnv(envKey, defaultSuffix string, defaultDuration time.Duration) (time.Duration, error) {
+// and, if set, parses it as a duration. If the environment variable
+// is unset, defaultDuration is returned.
+func ParseDurationEnv(envKey string, defaultDuration time.Duration) (time.Duration, error) {
 	value := os.Getenv(envKey)
 	if value == "" {
 		return defaultDuration, nil
 	}
-	d, err := ParseDuration(value, defaultSuffix)
+	d, err := ParseDuration(value)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to parse %s", envKey)
 	}

--- a/internal/apmconfig/env_test.go
+++ b/internal/apmconfig/env_test.go
@@ -14,23 +14,40 @@ func TestParseDurationEnv(t *testing.T) {
 	const envKey = "ELASTIC_APM_TEST_DURATION"
 	os.Setenv(envKey, "")
 
-	d, err := apmconfig.ParseDurationEnv(envKey, "s", 42*time.Second)
+	d, err := apmconfig.ParseDurationEnv(envKey, 42*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 42*time.Second, d)
 
-	os.Setenv(envKey, "5")
-	d, err = apmconfig.ParseDurationEnv(envKey, "s", 42*time.Second)
+	os.Setenv(envKey, "5s")
+	d, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 5*time.Second, d)
 
 	os.Setenv(envKey, "5ms")
-	d, err = apmconfig.ParseDurationEnv(envKey, "s", 42*time.Second)
+	d, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 5*time.Millisecond, d)
 
+	os.Setenv(envKey, "5m")
+	d, err = apmconfig.ParseDurationEnv(envKey, 42*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, d)
+
+	os.Setenv(envKey, "5 h")
+	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: invalid character ' ' in duration 5 h")
+
+	os.Setenv(envKey, "5h")
+	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: invalid unit in duration 5h (allowed units: ms, s, m)")
+
 	os.Setenv(envKey, "5")
-	_, err = apmconfig.ParseDurationEnv(envKey, "", 42*time.Second)
-	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: time: missing unit in duration 5")
+	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: missing unit in duration 5 (allowed units: ms, s, m)")
+
+	os.Setenv(envKey, "blah")
+	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: invalid duration blah")
 }
 
 func TestParseBoolEnv(t *testing.T) {

--- a/transport/http.go
+++ b/transport/http.go
@@ -93,9 +93,7 @@ func NewHTTPTransport(serverURL, secretToken string) (*HTTPTransport, error) {
 	}
 	client := &http.Client{Transport: httpTransport}
 
-	// TODO(axw) need to redefine meaning of the timeout
-	// for streaming. Should be an idle timeout?
-	timeout, err := apmconfig.ParseDurationEnv(envServerTimeout, "s", defaultServerTimeout)
+	timeout, err := apmconfig.ParseDurationEnv(envServerTimeout, defaultServerTimeout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Stop using time.ParseDuration, and implement our own, more constrained parser.

Closes elastic/apm-agent-go#189 