### PR TITLE
Add jitter to grace period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  - Implement v2 intake protocol (#180)
  - Unexport Transaction.Timestamp and Span.Timestamp (#207)
+ - Add jitter (+/-10%) to backoff on transport error (#212)
 
 ## [v0.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.0)
 

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package elasticapm
 
 import (
+	"math/rand"
 	"os"
 	"regexp"
 	"runtime"
@@ -108,4 +109,13 @@ func nextGracePeriod(p time.Duration) time.Duration {
 		}
 	}
 	return p
+}
+
+// jitterDuration returns d +/- some multiple of d in the range [0,j].
+func jitterDuration(d time.Duration, rng *rand.Rand, j float64) time.Duration {
+	if d == 0 || j == 0 {
+		return d
+	}
+	r := (rng.Float64() * j * 2) - j
+	return d + time.Duration(float64(d)*r)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,7 @@
 package elasticapm
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -28,4 +29,13 @@ func TestGracePeriod(t *testing.T) {
 		seq = append(seq, p)
 	}
 	t.Fatal("failed to find fixpoint")
+}
+
+func TestJitterDuration(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	assert.Equal(t, time.Duration(0), jitterDuration(0, rng, 0.1))
+	assert.Equal(t, time.Second, jitterDuration(time.Second, rng, 0))
+	for i := 0; i < 100; i++ {
+		assert.InDelta(t, time.Second, jitterDuration(time.Second, rng, 0.1), float64(100*time.Millisecond))
+	}
 }


### PR DESCRIPTION
When backing off due to transport errors,
add +/-10% to the grace period to prevent
agents synchronising their retries.