### PR TITLE
 module/apmgorm: fix premature Span.End()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v0.5.1...master)
+## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v0.5.2...master)
+
+## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
+
+ - Fixed premature Span.End() in apmgorm callback, causing a data-race with captured errors (#229)
 
 ## [v0.5.1](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.1)
 

--- a/module/apmgorm/context.go
+++ b/module/apmgorm/context.go
@@ -117,7 +117,7 @@ func newAfterCallback(dsnInfo apmsql.DSNInfo) func(*gorm.Scope) {
 			Type:      "sql",
 			User:      dsnInfo.User,
 		})
-		span.End()
+		defer span.End()
 
 		// Capture errors, except for "record not found", which may be expected.
 		for _, err := range scope.DB().GetErrors() {

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package elasticapm
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "0.5.1"
+	AgentVersion = "0.5.2"
 )


### PR DESCRIPTION
The Span.End() call should come after the calls
to CaptureError, which will refer to the span.

Bump version to 0.5.2.

Fixes #229