### PR TITLE
Change error.id to 128-bit

### DIFF
--- a/error.go
+++ b/error.go
@@ -374,9 +374,9 @@ type ErrorLogRecord struct {
 }
 
 // ErrorID uniquely identifies an error.
-type ErrorID SpanID
+type ErrorID TraceID
 
 // String returns id in its hex-encoded format.
 func (id ErrorID) String() string {
-	return SpanID(id).String()
+	return TraceID(id).String()
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -423,7 +423,9 @@ func (v *User) MarshalFastJSON(w *fastjson.Writer) {
 
 func (v *Error) MarshalFastJSON(w *fastjson.Writer) {
 	w.RawByte('{')
-	w.RawString("\"timestamp\":")
+	w.RawString("\"id\":")
+	v.ID.MarshalFastJSON(w)
+	w.RawString(",\"timestamp\":")
 	v.Timestamp.MarshalFastJSON(w)
 	if v.Context != nil {
 		w.RawString(",\"context\":")
@@ -436,10 +438,6 @@ func (v *Error) MarshalFastJSON(w *fastjson.Writer) {
 	if !v.Exception.isZero() {
 		w.RawString(",\"exception\":")
 		v.Exception.MarshalFastJSON(w)
-	}
-	if !v.ID.isZero() {
-		w.RawString(",\"id\":")
-		v.ID.MarshalFastJSON(w)
 	}
 	if !v.Log.isZero() {
 		w.RawString(",\"log\":")

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -162,63 +162,25 @@ func TestMarshalMetrics(t *testing.T) {
 	assert.Equal(t, expect, decoded)
 }
 
-/*
-	expect := map[string]interface{}{
-		"process": map[string]interface{}{
-			"pid":   float64(1234),
-			"ppid":  float64(1),
-			"title": "my-fake-service",
-			"argv":  []interface{}{"my-fake-service", "-f", "config.yml"},
-		},
-		"service": map[string]interface{}{
-			"environment": "dev",
-			"agent": map[string]interface{}{
-				"name":    "go",
-				"version": "0.1.0",
-			},
-			"framework": map[string]interface{}{
-				"name":    "gin",
-				"version": "1.0",
-			},
-			"language": map[string]interface{}{
-				"name":    "go",
-				"version": "1.10",
-			},
-			"runtime": map[string]interface{}{
-				"name":    "go",
-				"version": "gc 1.10",
-			},
-			"name":    "fake-service",
-			"version": "1.0.0-rc1",
-		},
-		"system": map[string]interface{}{
-			"architecture": "x86_64",
-			"hostname":     "host.example",
-			"platform":     "linux",
-		},
-		"transactions": []interface{}{},
-	}
-*/
-
 func TestMarshalError(t *testing.T) {
 	var e model.Error
 	time, err := time.Parse("2006-01-02T15:04:05.999Z", "1970-01-01T00:02:03Z")
 	assert.NoError(t, err)
 	e.Timestamp = model.Time(time)
 
-	// All error IDs are optional
+	// The primary error ID is required, all other IDs are optional
 	var w fastjson.Writer
 	e.MarshalFastJSON(&w)
-	assert.Equal(t, `{"timestamp":"1970-01-01T00:02:03Z"}`, string(w.Bytes()))
+	assert.Equal(t, `{"id":"00000000000000000000000000000000","timestamp":"1970-01-01T00:02:03Z"}`, string(w.Bytes()))
 
-	e.ID = model.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+	e.ID = model.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	e.TransactionID = model.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
 	e.TraceID = model.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	e.ParentID = model.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
 	w.Reset()
 	e.MarshalFastJSON(&w)
 	assert.Equal(t,
-		`{"timestamp":"1970-01-01T00:02:03Z","id":"0102030405060708","parent_id":"0102030405060708","trace_id":"0102030405060708090a0b0c0d0e0f10","transaction_id":"0102030405060708"}`,
+		`{"id":"000102030405060708090a0b0c0d0e0f","timestamp":"1970-01-01T00:02:03Z","parent_id":"0102030405060708","trace_id":"0102030405060708090a0b0c0d0e0f10","transaction_id":"0102030405060708"}`,
 		string(w.Bytes()),
 	)
 }

--- a/model/model.go
+++ b/model/model.go
@@ -268,8 +268,8 @@ type Error struct {
 	// Timestamp holds the time at which the error occurred.
 	Timestamp Time `json:"timestamp"`
 
-	// ID holds the 64-bit hex-encoded error ID.
-	ID SpanID `json:"id,omitempty"`
+	// ID holds the 128-bit hex-encoded error ID.
+	ID TraceID `json:"id"`
 
 	// TraceID holds the ID of the trace within which the error occurred.
 	TraceID TraceID `json:"trace_id,omitempty"`

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -117,7 +117,7 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span) {
 
 func (w *modelWriter) buildModelError(e *Error) {
 	// TODO(axw) move the model type outside of Error
-	e.model.ID = model.SpanID(e.ID)
+	e.model.ID = model.TraceID(e.ID)
 	e.model.TraceID = model.TraceID(e.TraceID)
 	e.model.ParentID = model.SpanID(e.ParentID)
 	e.model.TransactionID = model.SpanID(e.TransactionID)


### PR DESCRIPTION
Same format as trace ID. This is due to the
fact that errors may be reported independently
of traces.

Closes elastic/apm-agent-go#225 