### PR TITLE
Decouple elasticapm/opentracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Require units for size configuration (#223)
  - Require units for duration configuration (#211)
  - Add support for multiple server URLs with failover (#233)
+ - Add support for mixing OpenTracing spans with native transactions/spans (#235)
 
 ## [v0.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.0)
 

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -57,6 +57,34 @@ func main() {
 ----
 
 [float]
+[[opentracing-mixed]]
+=== Mixing Native and OpenTracing APIs
+
+When you import `apmot`, transactions and spans created with the <<api, native API>>
+will be made available as OpenTracing spans, enabling you to mix the use of the
+native and OpenTracing APIs. e.g.:
+
+[source,go]
+----
+// Transaction created through native API.
+transaction := elasticapm.DefaultTracer.StartTransaction("GET /", "request")
+ctx := elasticapm.ContextWithTransaction(context.Background(), transaction)
+
+// Span created through OpenTracing API will be a child of the transaction.
+otSpan, ctx := opentracing.StartSpanFromContext(ctx, "ot-span")
+
+// Span created through the native API will be a child of the span created
+// above via the OpenTracing API.
+apmSpan, ctx := elasticapm.StartSpan(ctx, "apm-span", "apm-span")
+----
+
+The `opentracing.SpanFromContext` function will return an `opentracing.Span`
+that wraps either an `elasticapm.Span` or `elasticapm.Transaction`. These span
+objects are intended only for passing in context when creating a new span
+through the OpenTracing API, and are not fully functional spans. In particular,
+the `Finish` method is a no-op, and the `Tracer` method returns a no-op tracer.
+
+[float]
 [[opentracing-apm-tags]]
 === Elastic APM specific tags
 

--- a/gocontext.go
+++ b/gocontext.go
@@ -2,34 +2,36 @@ package elasticapm
 
 import (
 	"context"
+
+	"github.com/elastic/apm-agent-go/internal/apmcontext"
 )
 
 // ContextWithSpan returns a copy of parent in which the given span
 // is stored, associated with the key ContextSpanKey.
 func ContextWithSpan(parent context.Context, s *Span) context.Context {
-	return context.WithValue(parent, contextSpanKey{}, s)
+	return apmcontext.ContextWithSpan(parent, s)
 }
 
 // ContextWithTransaction returns a copy of parent in which the given
 // transaction is stored, associated with the key ContextTransactionKey.
 func ContextWithTransaction(parent context.Context, t *Transaction) context.Context {
-	return context.WithValue(parent, contextTransactionKey{}, t)
+	return apmcontext.ContextWithTransaction(parent, t)
 }
 
 // SpanFromContext returns the current Span in context, if any. The span must
-// have been added to the context previously using either ContextWithSpan
-// or SetSpanInContext.
+// have been added to the context previously using ContextWithSpan, or the
+// top-level StartSpan function.
 func SpanFromContext(ctx context.Context) *Span {
-	span, _ := ctx.Value(contextSpanKey{}).(*Span)
-	return span
+	value, _ := apmcontext.SpanFromContext(ctx).(*Span)
+	return value
 }
 
 // TransactionFromContext returns the current Transaction in context, if any.
-// The transaction must have been added to the context previously using either
-// ContextWithTransaction or SetTransactionInContext.
+// The transaction must have been added to the context previously using
+// ContextWithTransaction.
 func TransactionFromContext(ctx context.Context) *Transaction {
-	tx, _ := ctx.Value(contextTransactionKey{}).(*Transaction)
-	return tx
+	value, _ := apmcontext.TransactionFromContext(ctx).(*Transaction)
+	return value
 }
 
 // StartSpan is equivalent to calling StartSpanOptions with a zero SpanOptions struct.
@@ -47,7 +49,7 @@ func StartSpanOptions(ctx context.Context, name, spanType string, opts SpanOptio
 	tx := TransactionFromContext(ctx)
 	span := tx.StartSpan(name, spanType, SpanFromContext(ctx))
 	if !span.Dropped() {
-		ctx = context.WithValue(ctx, contextSpanKey{}, span)
+		ctx = ContextWithSpan(ctx, span)
 	}
 	return span, ctx
 }
@@ -77,6 +79,3 @@ func CaptureError(ctx context.Context, err error) *Error {
 	e.Handled = true
 	return e
 }
-
-type contextSpanKey struct{}
-type contextTransactionKey struct{}

--- a/internal/apmcontext/context.go
+++ b/internal/apmcontext/context.go
@@ -1,0 +1,61 @@
+package apmcontext
+
+import "context"
+
+var (
+	// ContextWithSpan takes a context and span and returns a new context
+	// from which the span can be extracted using SpanFromContext.
+	//
+	// ContextWithSpan is used by elasticapm.ContextWithSpan. It is a
+	// variable to allow other packages, such as apmot, to replace it
+	// at package init time.
+	ContextWithSpan = DefaultContextWithSpan
+
+	// ContextWithTransaction takes a context and transaction and returns
+	// a new context from which the transaction can be extracted using
+	// TransactionFromContext.
+	//
+	// ContextWithTransaction is used by elasticapm.ContextWithTransaction.
+	// It is a variable to allow other packages, such as apmot, to replace
+	// it at package init time.
+	ContextWithTransaction = DefaultContextWithTransaction
+
+	// SpanFromContext returns a span included in the context using
+	// ContextWithSpan.
+	//
+	// SpanFromContext is used by elasticapm.SpanFromContext. It is a
+	// variable to allow other packages, such as apmot, to replace it
+	// at package init time.
+	SpanFromContext = DefaultSpanFromContext
+
+	// TransactionFromContext returns a transaction included in the context
+	// using ContextWithTransaction.
+	//
+	// TransactionFromContext is used by elasticapm.TransactionFromContext.
+	// It is a variable to allow other packages, such as apmot, to replace
+	// it at package init time.
+	TransactionFromContext = DefaultTransactionFromContext
+)
+
+type spanKey struct{}
+type transactionKey struct{}
+
+// DefaultContextWithSpan is the default value for ContextWithSpan.
+func DefaultContextWithSpan(ctx context.Context, span interface{}) context.Context {
+	return context.WithValue(ctx, spanKey{}, span)
+}
+
+// DefaultContextWithTransaction is the default value for ContextWithTransaction.
+func DefaultContextWithTransaction(ctx context.Context, tx interface{}) context.Context {
+	return context.WithValue(ctx, transactionKey{}, tx)
+}
+
+// DefaultSpanFromContext is the default value for SpanFromContext.
+func DefaultSpanFromContext(ctx context.Context) interface{} {
+	return ctx.Value(spanKey{})
+}
+
+// DefaultTransactionFromContext is the default value for TransactionFromContext.
+func DefaultTransactionFromContext(ctx context.Context) interface{} {
+	return ctx.Value(transactionKey{})
+}

--- a/module/apmot/noop.go
+++ b/module/apmot/noop.go
@@ -1,0 +1,33 @@
+package apmot
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+type unsupportedSpanMethods struct{}
+
+// BaggageItem returns the empty string; we do not support baggage.
+func (unsupportedSpanMethods) BaggageItem(key string) string {
+	return ""
+}
+
+func (unsupportedSpanMethods) LogKV(keyValues ...interface{}) {
+	// No-op.
+}
+
+func (unsupportedSpanMethods) LogFields(fields ...log.Field) {
+	// No-op.
+}
+
+func (unsupportedSpanMethods) LogEvent(event string) {
+	// No-op.
+}
+
+func (unsupportedSpanMethods) LogEventWithPayload(event string, payload interface{}) {
+	// No-op.
+}
+
+func (unsupportedSpanMethods) Log(ld opentracing.LogData) {
+	// No-op.
+}

--- a/module/apmot/span.go
+++ b/module/apmot/span.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/module/apmhttp"
@@ -16,11 +15,18 @@ import (
 // otSpan wraps elasticapm objects to implement the opentracing.Span interface.
 type otSpan struct {
 	tracer *otTracer
+	unsupportedSpanMethods
 
 	mu   sync.Mutex
 	span *elasticapm.Span
 	tags opentracing.Tags
 	ctx  spanContext
+}
+
+// Span returns s.span, the underlying elasticapm.Span. This is used to satisfy
+// SpanFromContext.
+func (s *otSpan) Span() *elasticapm.Span {
+	return s.span
 }
 
 // SetOperationName sets or changes the operation name.
@@ -94,31 +100,6 @@ func (s *otSpan) Context() opentracing.SpanContext {
 func (s *otSpan) SetBaggageItem(key, val string) opentracing.Span {
 	// We do not support baggage.
 	return s
-}
-
-// BaggageItem returns the empty string; we do not support baggage.
-func (s *otSpan) BaggageItem(key string) string {
-	return ""
-}
-
-func (*otSpan) LogKV(keyValues ...interface{}) {
-	// No-op.
-}
-
-func (*otSpan) LogFields(fields ...log.Field) {
-	// No-op.
-}
-
-func (*otSpan) LogEvent(event string) {
-	// No-op.
-}
-
-func (*otSpan) LogEventWithPayload(event string, payload interface{}) {
-	// No-op.
-}
-
-func (*otSpan) Log(ld opentracing.LogData) {
-	// No-op.
 }
 
 func (s *otSpan) setSpanContext() {

--- a/module/apmot/wrapper.go
+++ b/module/apmot/wrapper.go
@@ -1,0 +1,187 @@
+package apmot
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/internal/apmcontext"
+)
+
+func init() {
+	// We override the apmcontext functions so that transactions
+	// and spans started with the native API are wrapped and made
+	// available as OpenTracing spans.
+	apmcontext.ContextWithSpan = contextWithSpan
+	apmcontext.ContextWithTransaction = contextWithTransaction
+	apmcontext.SpanFromContext = spanFromContext
+	apmcontext.TransactionFromContext = transactionFromContext
+}
+
+func contextWithSpan(ctx context.Context, apmSpan interface{}) context.Context {
+	tx, _ := transactionFromContext(ctx).(*elasticapm.Transaction)
+	return opentracing.ContextWithSpan(ctx, apmSpanWrapper{
+		spanContext: apmSpanWrapperContext{
+			span:        apmSpan.(*elasticapm.Span),
+			transaction: tx,
+		},
+	})
+}
+
+func contextWithTransaction(ctx context.Context, apmTransaction interface{}) context.Context {
+	return opentracing.ContextWithSpan(ctx, apmTransactionWrapper{
+		spanContext: apmTransactionWrapperContext{
+			transaction: apmTransaction.(*elasticapm.Transaction),
+		},
+	})
+}
+
+func spanFromContext(ctx context.Context) interface{} {
+	otSpan, _ := opentracing.SpanFromContext(ctx).(interface {
+		Span() *elasticapm.Span
+	})
+	if otSpan == nil {
+		return nil
+	}
+	return otSpan.Span()
+}
+
+func transactionFromContext(ctx context.Context) interface{} {
+	otSpan := opentracing.SpanFromContext(ctx)
+	if otSpan == nil {
+		return nil
+	}
+	if apmSpanContext, ok := otSpan.Context().(interface {
+		Transaction() *elasticapm.Transaction
+	}); ok {
+		return apmSpanContext.Transaction()
+	}
+	return nil
+}
+
+// apmSpanWrapperContext is an opentracing.SpanContext that wraps
+// an elasticapm.Span and elasticapm.Transaction.
+type apmSpanWrapperContext struct {
+	span        *elasticapm.Span
+	transaction *elasticapm.Transaction
+}
+
+// TraceContext returns ctx.span.TraceContext(). This is used to set the
+// parent trace context for spans created through the OpenTracing API.
+func (ctx apmSpanWrapperContext) TraceContext() elasticapm.TraceContext {
+	return ctx.span.TraceContext()
+}
+
+// Transaction returns ctx.transaction. This is used to obtain the transaction
+// to use for creating spans through the OpenTracing API.
+func (ctx apmSpanWrapperContext) Transaction() *elasticapm.Transaction {
+	return ctx.transaction
+}
+
+// ForeachBaggageItem is a no-op; we do not support baggage propagation.
+func (apmSpanWrapperContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+// apmSpanWrapper is an opentracing.Span that wraps an apmSpanWrapperContext.
+type apmSpanWrapper struct {
+	apmBaseWrapper
+	spanContext apmSpanWrapperContext
+}
+
+// Span returns s.spanContext.span. This is used by spanFromContext.
+func (s apmSpanWrapper) Span() *elasticapm.Span {
+	return s.spanContext.span
+}
+
+// SetOperationName sets or changes the operation name.
+func (s apmSpanWrapper) SetOperationName(operationName string) opentracing.Span {
+	return s
+}
+
+// SetTag adds or changes a tag.
+func (s apmSpanWrapper) SetTag(key string, value interface{}) opentracing.Span {
+	return s
+}
+
+// Context returns the span's current context.
+//
+// It is valid to call Context after calling Finish or FinishWithOptions.
+// The resulting context is also valid after the span is finished.
+func (s apmSpanWrapper) Context() opentracing.SpanContext {
+	return s.spanContext
+}
+
+// SetBaggageItem is a no-op; we do not support baggage.
+func (s apmSpanWrapper) SetBaggageItem(key, val string) opentracing.Span {
+	// We do not support baggage.
+	return s
+}
+
+// apmTransactionWrapperContext is an opentracing.SpanContext that wraps
+// an elasticapm.Transaction.
+type apmTransactionWrapperContext struct {
+	transaction *elasticapm.Transaction
+}
+
+// TraceContext returns ctx.transaction.TraceContext(). This is used to set the
+// parent trace context for spans created through the OpenTracing API.
+func (ctx apmTransactionWrapperContext) TraceContext() elasticapm.TraceContext {
+	return ctx.transaction.TraceContext()
+}
+
+// Transaction returns ctx.transaction. This is used to obtain the transaction
+// to use for creating spans through the OpenTracing API.
+func (ctx apmTransactionWrapperContext) Transaction() *elasticapm.Transaction {
+	return ctx.transaction
+}
+
+// ForeachBaggageItem is a no-op; we do not support baggage propagation.
+func (apmTransactionWrapperContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+// apmTransactionWrapper is an opentracing.Span that wraps an apmTransactionWrapperContext.
+type apmTransactionWrapper struct {
+	apmBaseWrapper
+	spanContext apmTransactionWrapperContext
+}
+
+// SetOperationName sets or changes the operation name.
+func (s apmTransactionWrapper) SetOperationName(operationName string) opentracing.Span {
+	return s
+}
+
+// SetTag adds or changes a tag.
+func (s apmTransactionWrapper) SetTag(key string, value interface{}) opentracing.Span {
+	return s
+}
+
+// Context returns the span's current context.
+//
+// It is valid to call Context after calling Finish or FinishWithOptions.
+// The resulting context is also valid after the span is finished.
+func (s apmTransactionWrapper) Context() opentracing.SpanContext {
+	return s.spanContext
+}
+
+// SetBaggageItem is a no-op; we do not support baggage.
+func (s apmTransactionWrapper) SetBaggageItem(key, val string) opentracing.Span {
+	// We do not support baggage.
+	return s
+}
+
+type apmBaseWrapper struct {
+	unsupportedSpanMethods
+}
+
+// Tracer returns the Tracer that created this span.
+func (apmBaseWrapper) Tracer() opentracing.Tracer {
+	return opentracing.NoopTracer{}
+}
+
+// Finish ends the span; this (or FinishWithOptions) must be the last method
+// call on the span, except for calls to Context which may be called at any
+// time.
+func (apmBaseWrapper) Finish() {}
+
+// FinishWithOptions is like Finish, but provides explicit control over the
+// end timestamp and log data.
+func (apmBaseWrapper) FinishWithOptions(opentracing.FinishOptions) {}


### PR DESCRIPTION
Introduce an internal package which is used
instead of using context.WithValue/context.Value
directly. By default those functions are used,
but when apmot is imported, it overrides their
use with the opentracing context functions,
wrapping all transactions and spans such that
they implement the opentracing.Span API.