### PR TITLE
 Drop Context.SetHTTPResponse{HeadersSent,Finished}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
  - Require units for duration configuration (#211)
  - Add support for multiple server URLs with failover (#233)
  - Add support for mixing OpenTracing spans with native transactions/spans (#235)
+ - Drop SetHTTPResponseHeadersSent and SetHTTPResponseFinished methods from Context (#238)
+ - Stop setting custom context (gin.handler) in apmgin (#238)
+ - Set response context in errors reported by web modules (#238)
 
 ## [v0.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.0)
 

--- a/context.go
+++ b/context.go
@@ -161,18 +161,6 @@ func (c *Context) SetHTTPResponseHeaders(h http.Header) {
 	}
 }
 
-// SetHTTPResponseHeadersSent records whether or not response were sent.
-func (c *Context) SetHTTPResponseHeadersSent(headersSent bool) {
-	c.response.HeadersSent = &headersSent
-	c.model.Response = &c.response
-}
-
-// SetHTTPResponseFinished records whether or not the response was finished.
-func (c *Context) SetHTTPResponseFinished(finished bool) {
-	c.response.Finished = &finished
-	c.model.Response = &c.response
-}
-
 // SetHTTPStatusCode records the HTTP response status code.
 func (c *Context) SetHTTPStatusCode(statusCode int) {
 	c.response.StatusCode = statusCode

--- a/module/apmgin/middleware_test.go
+++ b/module/apmgin/middleware_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/apm-agent-go/model"
 	"github.com/elastic/apm-agent-go/module/apmgin"
@@ -22,15 +24,15 @@ func TestMiddleware(t *testing.T) {
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
-	r := gin.New()
-	r.Use(apmgin.Middleware(r, apmgin.WithTracer(tracer)))
-	r.GET("/hello/:name", handleHello)
+	e := gin.New()
+	e.Use(apmgin.Middleware(e, apmgin.WithTracer(tracer)))
+	e.GET("/hello/:name", handleHello)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "http://server.testing/hello/isbel", nil)
 	req.Header.Set("User-Agent", "apmgin_test")
 	req.RemoteAddr = "client.testing:1234"
-	r.ServeHTTP(w, req)
+	e.ServeHTTP(w, req)
 	tracer.Flush(nil)
 
 	payloads := transport.Payloads()
@@ -39,14 +41,7 @@ func TestMiddleware(t *testing.T) {
 	assert.Equal(t, "request", transaction.Type)
 	assert.Equal(t, "HTTP 2xx", transaction.Result)
 
-	true_ := true
 	assert.Equal(t, &model.Context{
-		Custom: model.IfaceMap{{
-			Key: "gin",
-			Value: map[string]interface{}{
-				"handler": "github.com/elastic/apm-agent-go/module/apmgin_test.handleHello",
-			},
-		}},
 		Request: &model.Request{
 			Socket: &model.RequestSocket{
 				RemoteAddress: "client.testing",
@@ -64,12 +59,86 @@ func TestMiddleware(t *testing.T) {
 			HTTPVersion: "1.1",
 		},
 		Response: &model.Response{
-			StatusCode:  200,
-			Finished:    &true_,
-			HeadersSent: &true_,
+			StatusCode: 200,
 			Headers: &model.ResponseHeaders{
 				ContentType: "text/plain; charset=utf-8",
 			},
 		},
 	}, transaction.Context)
+}
+
+func TestMiddlewarePanic(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	e := gin.New()
+	e.Use(apmgin.Middleware(e, apmgin.WithTracer(tracer)))
+	e.GET("/panic", handlePanic)
+
+	w := doRequest(e, "GET", "http://server.testing/panic")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	tracer.Flush(nil)
+	assertError(t, transport.Payloads(), "handlePanic", "boom", false)
+}
+
+func TestMiddlewarePanicHeadersSent(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	e := gin.New()
+	e.Use(apmgin.Middleware(e, apmgin.WithTracer(tracer)))
+	e.GET("/panic", handlePanicAfterHeaders)
+
+	w := doRequest(e, "GET", "http://server.testing/panic")
+	assert.Equal(t, http.StatusOK, w.Code)
+	tracer.Flush(nil)
+	assertError(t, transport.Payloads(), "handlePanicAfterHeaders", "boom", false)
+}
+
+func TestMiddlewareError(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	e := gin.New()
+	e.Use(apmgin.Middleware(e, apmgin.WithTracer(tracer)))
+	e.GET("/error", handleError)
+
+	w := doRequest(e, "GET", "http://server.testing/error")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	tracer.Flush(nil)
+	assertError(t, transport.Payloads(), "handleError", "wot", true)
+}
+
+func assertError(t *testing.T, payloads transporttest.Payloads, culprit, message string, handled bool) model.Error {
+	error0 := payloads.Errors[0]
+
+	require.NotNil(t, error0.Context)
+	require.NotNil(t, error0.Exception)
+	assert.NotEmpty(t, error0.TransactionID)
+	assert.Equal(t, culprit, error0.Culprit)
+	assert.Equal(t, message, error0.Exception.Message)
+	assert.Equal(t, handled, error0.Exception.Handled)
+	return error0
+}
+
+func handlePanic(c *gin.Context) {
+	panic("boom")
+}
+
+func handlePanicAfterHeaders(c *gin.Context) {
+	c.String(200, "")
+	panic("boom")
+}
+
+func handleError(c *gin.Context) {
+	c.AbortWithError(500, errors.New("wot"))
+}
+
+func doRequest(e *gin.Engine, method, url string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(method, url, nil)
+	req.Header.Set("User-Agent", "apmecho_test")
+	req.RemoteAddr = "client.testing:1234"
+	e.ServeHTTP(w, req)
+	return w
 }

--- a/module/apmgorilla/middleware_test.go
+++ b/module/apmgorilla/middleware_test.go
@@ -34,7 +34,6 @@ func TestMuxMiddleware(t *testing.T) {
 	assert.Equal(t, "request", transaction.Type)
 	assert.Equal(t, "HTTP 2xx", transaction.Result)
 
-	true_ := true
 	assert.Equal(t, &model.Context{
 		Request: &model.Request{
 			Socket: &model.RequestSocket{
@@ -51,9 +50,7 @@ func TestMuxMiddleware(t *testing.T) {
 			HTTPVersion: "1.1",
 		},
 		Response: &model.Response{
-			StatusCode:  200,
-			Finished:    &true_,
-			HeadersSent: &true_,
+			StatusCode: 200,
 			Headers: &model.ResponseHeaders{
 				ContentType: "text/plain; charset=utf-8",
 			},

--- a/module/apmhttp/handler_test.go
+++ b/module/apmhttp/handler_test.go
@@ -45,7 +45,6 @@ func TestHandler(t *testing.T) {
 	assert.Equal(t, "request", transaction.Type)
 	assert.Equal(t, "HTTP 4xx", transaction.Result)
 
-	true_ := true
 	assert.Equal(t, &model.Context{
 		Request: &model.Request{
 			Socket: &model.RequestSocket{
@@ -65,7 +64,6 @@ func TestHandler(t *testing.T) {
 		},
 		Response: &model.Response{
 			StatusCode: 418,
-			Finished:   &true_,
 		},
 	}, transaction.Context)
 }
@@ -104,7 +102,6 @@ func TestHandlerHTTP2(t *testing.T) {
 	payloads := transport.Payloads()
 	transaction := payloads.Transactions[0]
 
-	true_ := true
 	assert.Equal(t, &model.Context{
 		Request: &model.Request{
 			Socket: &model.RequestSocket{
@@ -126,7 +123,6 @@ func TestHandlerHTTP2(t *testing.T) {
 		},
 		Response: &model.Response{
 			StatusCode: 418,
-			Finished:   &true_,
 		},
 	}, transaction.Context)
 }
@@ -230,9 +226,7 @@ func TestHandlerRecovery(t *testing.T) {
 	assert.Equal(t, "panicHandler", error0.Culprit)
 	assert.Equal(t, "foo", error0.Exception.Message)
 
-	true_ := true
 	assert.Equal(t, &model.Response{
-		Finished:   &true_,
 		StatusCode: 418,
 	}, transaction.Context.Response)
 }

--- a/module/apmhttp/recovery.go
+++ b/module/apmhttp/recovery.go
@@ -10,6 +10,7 @@ import (
 type RecoveryFunc func(
 	w http.ResponseWriter,
 	req *http.Request,
+	resp *Response,
 	body *elasticapm.BodyCapturer,
 	tx *elasticapm.Transaction,
 	recovered interface{},
@@ -27,14 +28,14 @@ func NewTraceRecovery(t *elasticapm.Tracer) RecoveryFunc {
 	return func(
 		w http.ResponseWriter,
 		req *http.Request,
+		resp *Response,
 		body *elasticapm.BodyCapturer,
 		tx *elasticapm.Transaction,
 		recovered interface{},
 	) {
 		e := t.Recovered(recovered)
 		e.SetTransaction(tx)
-		e.Context.SetHTTPRequest(req)
-		e.Context.SetHTTPRequestBody(body)
+		setContext(&e.Context, req, resp, body)
 		e.Send()
 	}
 }

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -37,18 +37,15 @@ func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 		tx, req := apmhttp.StartTransaction(opts.tracer, req.Method+" "+route, req)
 		defer tx.End()
 
-		finished := false
 		body := opts.tracer.CaptureHTTPRequestBody(req)
 		w, resp := apmhttp.WrapResponseWriter(w)
 		defer func() {
 			if v := recover(); v != nil {
-				opts.recovery(w, req, body, tx, v)
-				finished = true
+				opts.recovery(w, req, resp, body, tx, v)
 			}
-			apmhttp.SetTransactionContext(tx, req, resp, body, finished)
+			apmhttp.SetTransactionContext(tx, req, resp, body)
 		}()
 		h(w, req, p)
-		finished = true
 	}
 }
 

--- a/module/apmhttprouter/handler_test.go
+++ b/module/apmhttprouter/handler_test.go
@@ -44,7 +44,6 @@ func TestWrap(t *testing.T) {
 	assert.Equal(t, "request", transaction.Type)
 	assert.Equal(t, "HTTP 4xx", transaction.Result)
 
-	true_ := true
 	assert.Equal(t, &model.Context{
 		Request: &model.Request{
 			Socket: &model.RequestSocket{
@@ -64,7 +63,6 @@ func TestWrap(t *testing.T) {
 		},
 		Response: &model.Response{
 			StatusCode: 418,
-			Finished:   &true_,
 		},
 	}, transaction.Context)
 }
@@ -94,9 +92,7 @@ func TestRecovery(t *testing.T) {
 	assert.Equal(t, "panicHandler", error0.Culprit)
 	assert.Equal(t, "foo", error0.Exception.Message)
 
-	true_ := true
 	assert.Equal(t, &model.Response{
-		Finished:   &true_,
 		StatusCode: 418,
 	}, transaction.Context.Response)
 }


### PR DESCRIPTION
We no longer set context.response.headers_sent or finished.
These may make sense for other languages/runtimes, but not for
Go, where a response is either guaranteed, or lack of response
cannot be observed.

Also:
 - set other response context on transactions and errors consistently
 - stop setting custom context in apmgin

Closes #208 