### PR TITLE
[v2] Truncate non keywords

### DIFF
--- a/capturebody.go
+++ b/capturebody.go
@@ -84,7 +84,9 @@ func (bc *BodyCapturer) setContext(out *model.RequestBody) bool {
 		postForm := make(url.Values, len(bc.request.PostForm))
 		for k, v := range bc.request.PostForm {
 			vcopy := make([]string, len(v))
-			copy(vcopy, v)
+			for i := range vcopy {
+				vcopy[i] = truncateText(v[i])
+			}
 			postForm[k] = vcopy
 		}
 		out.Form = postForm
@@ -98,6 +100,6 @@ func (bc *BodyCapturer) setContext(out *model.RequestBody) bool {
 		// TODO(axw) log error?
 		return false
 	}
-	out.Raw = string(all)
+	out.Raw = truncateText(string(all))
 	return true
 }

--- a/context.go
+++ b/context.go
@@ -67,7 +67,7 @@ func (c *Context) SetTag(key, value string) {
 	if !validTagKey(key) {
 		return
 	}
-	value = truncateString(value)
+	value = truncateKeyword(value)
 	if c.model.Tags == nil {
 		c.model.Tags = map[string]string{key: value}
 	} else {
@@ -108,7 +108,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 	c.request = model.Request{
 		Body:        c.request.Body,
 		URL:         apmhttputil.RequestURL(req, forwarded),
-		Method:      truncateString(req.Method),
+		Method:      truncateKeyword(req.Method),
 		HTTPVersion: httpVersion,
 		Cookies:     req.Cookies(),
 	}
@@ -116,7 +116,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 
 	c.requestHeaders = model.RequestHeaders{
 		ContentType: req.Header.Get("Content-Type"),
-		Cookie:      strings.Join(req.Header["Cookie"], ";"),
+		Cookie:      truncateText(strings.Join(req.Header["Cookie"], ";")),
 		UserAgent:   req.UserAgent(),
 	}
 	if c.requestHeaders != (model.RequestHeaders{}) {
@@ -135,7 +135,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 	if !ok && req.URL.User != nil {
 		username = req.URL.User.Username()
 	}
-	c.user.Username = truncateString(username)
+	c.user.Username = truncateKeyword(username)
 	if c.user.Username != "" {
 		c.model.User = &c.user
 	}
@@ -169,7 +169,7 @@ func (c *Context) SetHTTPStatusCode(statusCode int) {
 
 // SetUserID sets the ID of the authenticated user.
 func (c *Context) SetUserID(id string) {
-	c.user.ID = truncateString(id)
+	c.user.ID = truncateKeyword(id)
 	if c.user.ID != "" {
 		c.model.User = &c.user
 	}
@@ -177,7 +177,7 @@ func (c *Context) SetUserID(id string) {
 
 // SetUserEmail sets the email for the authenticated user.
 func (c *Context) SetUserEmail(email string) {
-	c.user.Email = truncateString(email)
+	c.user.Email = truncateKeyword(email)
 	if c.user.Email != "" {
 		c.model.User = &c.user
 	}
@@ -185,7 +185,7 @@ func (c *Context) SetUserEmail(email string) {
 
 // SetUsername sets the username of the authenticated user.
 func (c *Context) SetUsername(username string) {
-	c.user.Username = truncateString(username)
+	c.user.Username = truncateKeyword(username)
 	if c.user.Username != "" {
 		c.model.User = &c.user
 	}

--- a/error.go
+++ b/error.go
@@ -65,7 +65,7 @@ func (t *Tracer) NewError(err error) *Error {
 	}
 	e := t.newError()
 	rand.Read(e.ID[:]) // ignore error, can't do anything about it
-	e.model.Exception.Message = err.Error()
+	e.model.Exception.Message = truncateText(err.Error())
 	if e.model.Exception.Message == "" {
 		e.model.Exception.Message = "[EMPTY]"
 	}
@@ -86,10 +86,10 @@ func (t *Tracer) NewError(err error) *Error {
 func (t *Tracer) NewErrorLog(r ErrorLogRecord) *Error {
 	e := t.newError()
 	e.model.Log = model.Log{
-		Message:      r.Message,
-		Level:        truncateString(r.Level),
-		LoggerName:   truncateString(r.LoggerName),
-		ParamMessage: truncateString(r.MessageFormat),
+		Message:      truncateText(r.Message),
+		Level:        truncateKeyword(r.Level),
+		LoggerName:   truncateKeyword(r.LoggerName),
+		ParamMessage: truncateKeyword(r.MessageFormat),
 	}
 	if e.model.Log.Message == "" {
 		e.model.Log.Message = "[EMPTY]"
@@ -301,8 +301,8 @@ func initException(e *model.Exception, err error) {
 	if errTimeout(err) {
 		setAttr("timeout", true)
 	}
-	e.Code.String = truncateString(e.Code.String)
-	e.Type = truncateString(e.Type)
+	e.Code.String = truncateKeyword(e.Code.String)
+	e.Type = truncateKeyword(e.Type)
 }
 
 func initStacktrace(e *Error, err error) {

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -78,9 +78,9 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 	out.TraceID = model.TraceID(tx.traceContext.Trace)
 	out.ParentID = model.SpanID(tx.parentSpan)
 
-	out.Name = truncateString(tx.Name)
-	out.Type = truncateString(tx.Type)
-	out.Result = truncateString(tx.Result)
+	out.Name = truncateKeyword(tx.Name)
+	out.Type = truncateKeyword(tx.Type)
+	out.Result = truncateKeyword(tx.Result)
 	out.Timestamp = model.Time(tx.timestamp.UTC())
 	out.Duration = tx.Duration.Seconds() * 1000
 	out.SpanCount.Started = tx.spansCreated
@@ -103,8 +103,8 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span) {
 	out.ParentID = model.SpanID(span.parentID)
 	out.TransactionID = model.SpanID(span.transactionID)
 
-	out.Name = truncateString(span.Name)
-	out.Type = truncateString(span.Type)
+	out.Name = truncateKeyword(span.Name)
+	out.Type = truncateKeyword(span.Type)
 	out.Timestamp = model.Time(span.transactionTimestamp.UTC())
 	out.Start = span.timestamp.Sub(span.transactionTimestamp).Seconds() * 1000
 	out.Duration = span.Duration.Seconds() * 1000

--- a/spancontext.go
+++ b/spancontext.go
@@ -51,7 +51,7 @@ func (c *SpanContext) SetTag(key, value string) {
 	if !validTagKey(key) {
 		return
 	}
-	value = truncateString(value)
+	value = truncateKeyword(value)
 	if c.model.Tags == nil {
 		c.model.Tags = map[string]string{key: value}
 	} else {
@@ -61,7 +61,12 @@ func (c *SpanContext) SetTag(key, value string) {
 
 // SetDatabase sets the span context for database-related operations.
 func (c *SpanContext) SetDatabase(db DatabaseSpanContext) {
-	c.database = model.DatabaseSpanContext(db)
+	c.database = model.DatabaseSpanContext{
+		Instance:  truncateKeyword(db.Instance),
+		Statement: truncateText(db.Statement),
+		Type:      truncateKeyword(db.Type),
+		User:      truncateKeyword(db.User),
+	}
 	c.model.Database = &c.database
 }
 

--- a/utils.go
+++ b/utils.go
@@ -44,16 +44,16 @@ func getCurrentProcess() model.Process {
 	return model.Process{
 		Pid:   os.Getpid(),
 		Ppid:  &ppid,
-		Title: truncateString(title),
+		Title: truncateKeyword(title),
 		Argv:  os.Args,
 	}
 }
 
 func makeService(name, version, environment string) model.Service {
 	return model.Service{
-		Name:        truncateString(name),
-		Version:     truncateString(version),
-		Environment: truncateString(environment),
+		Name:        truncateKeyword(name),
+		Version:     truncateKeyword(version),
+		Environment: truncateKeyword(environment),
 		Agent:       goAgent,
 		Language:    &goLanguage,
 		Runtime:     &goRuntime,
@@ -71,7 +71,7 @@ func getLocalSystem() model.System {
 			system.Hostname = hostname
 		}
 	}
-	system.Hostname = truncateString(system.Hostname)
+	system.Hostname = truncateKeyword(system.Hostname)
 	return system
 }
 
@@ -94,9 +94,18 @@ func sanitizeServiceName(name string) string {
 	return serviceNameInvalidRegexp.ReplaceAllString(name, "_")
 }
 
-func truncateString(s string) string {
-	// At the time of writing, all length limits are 1024.
+func truncateKeyword(s string) string {
+	// At the time of writing, all keyword length
+	// limits are 1024, enforced by JSON Schema.
 	return apmstrings.Truncate(s, 1024)
+}
+
+func truncateText(s string) string {
+	// Non-keyword string fields should be limited
+	// to 10000 characters/runes. This is not
+	// currently enforced by JSON Schema, as we
+	// may want to make it configurable.
+	return apmstrings.Truncate(s, 10000)
 }
 
 func nextGracePeriod(p time.Duration) time.Duration {


### PR DESCRIPTION
All strings we craft and transmit to the server are now truncated to either 1024 runes (for keywords) or 10000 runes (for non-keywords). This does not cover "custom" context, since that is opaque to the agent code, but it does cover tags.

Closes #187 