### PR TITLE
module/apmredigo: introduce redigo instrumentation

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -352,6 +352,46 @@ func main() {
 }
 ----
 
+[[builtin-modules-apmredigo]]
+===== module/apmredigo
+Package apmredigo provides a means of instrumenting https://github.com/gomodule/redigo[Redigo]
+so that Redis commands are reported as spans within the current transaction.
+
+To report Redis commands, you can use the top-level `Do` or `DoWithTimeout` functions.
+These functions have the same signature as the `redis.Conn` equivalents apart from an
+initial `context.Context` parameter. If the context passed in contains a sampled
+transaction, a span will be reported for the Redis command.
+
+Another top-level function, `Wrap`, is provided to wrap a `redis.Conn` such that its
+`Do` and `DoWithTimeout` methods call the above mentioned functions. Initially, the
+wrapped connection will be associated with the background context; its `WithContext`
+method may be used to obtain a shallow copy with another context. For example, in an
+HTTP middleware you might bind a connection to the request context, which would
+associate spans with the request's APM transaction.
+
+[source,go]
+----
+import (
+	"net/http"
+
+	"github.com/gomodule/redigo/redis"
+
+	"github.com/elastic/apm-agent-go/module/apmredigo"
+)
+
+var redisPool *redis.Pool // initialized at program startup
+
+func handleRequest(w http.ResponseWriter, req *http.Request) {
+	// Wrap and bind redis.Conn to request context. If the HTTP
+	// server is instrumented with Elastic APM (e.g. with apmhttp),
+	// Redis commands will be reported as spans within the request's
+	// transaction.
+	conn := apmredigo.Wrap(redisPool.Get()).WithContext(req.Context())
+	defer conn.Close()
+	...
+}
+----
+
 [[custom-instrumentation]]
 ==== Custom instrumentation
 

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -118,6 +118,16 @@ See <<builtin-modules-apmgocql, module/apmgocql>> for more information
 about GoCQL instrumentation.
 
 [float]
+==== Redis (gomodule/redigo)
+
+We support https://github.com/gomodule/redigo[Redigo],
+https://github.com/gomodule/redigo/tree/v2.0.0[v2.0.0] and greater.
+We provide helper functions for reporting Redis commands as spans.
+
+See <<builtin-modules-apmredigo, module/apmredigo>> for more information
+about Redigo instrumentation.
+
+[float]
 [[supported-tech-rpc]]
 === RPC Frameworks
 

--- a/module/apmredigo/conn.go
+++ b/module/apmredigo/conn.go
@@ -1,0 +1,93 @@
+package apmredigo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+
+	"github.com/elastic/apm-agent-go"
+)
+
+// Conn is the interface returned by ContextConn.
+//
+// Conn's Do method reports spans using the bound context.
+type Conn interface {
+	redis.Conn
+
+	// WithContext returns a shallow copy of the connection with
+	// its context changed to ctx.
+	//
+	// To report commands as spans, ctx must contain a transaction or span.
+	WithContext(ctx context.Context) Conn
+}
+
+// Wrap wraps conn such that its Do method calls apmredigo.Do with
+// context.Background(). The context can be changed using Conn.WithContext.
+//
+// If conn implements redis.ConnWithTimeout, then the DoWithTimeout method
+// will similarly call apmredigo.DoWithTimeout.
+//
+// Send and Receive calls are not currently captured.
+func Wrap(conn redis.Conn) Conn {
+	ctx := context.Background()
+	if cwt, ok := conn.(redis.ConnWithTimeout); ok {
+		return contextConnWithTimeout{ConnWithTimeout: cwt, ctx: ctx}
+	}
+	return contextConn{Conn: conn, ctx: ctx}
+}
+
+type contextConnWithTimeout struct {
+	redis.ConnWithTimeout
+	ctx context.Context
+}
+
+func (c contextConnWithTimeout) WithContext(ctx context.Context) Conn {
+	c.ctx = ctx
+	return c
+}
+
+func (c contextConnWithTimeout) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+	return Do(c.ctx, c.ConnWithTimeout, commandName, args...)
+}
+
+func (c contextConnWithTimeout) DoWithTimeout(timeout time.Duration, commandName string, args ...interface{}) (reply interface{}, err error) {
+	return DoWithTimeout(c.ctx, c.ConnWithTimeout, timeout, commandName, args...)
+}
+
+type contextConn struct {
+	redis.Conn
+	ctx context.Context
+}
+
+func (c contextConn) WithContext(ctx context.Context) Conn {
+	c.ctx = ctx
+	return c
+}
+
+func (c contextConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+	return Do(c.ctx, c.Conn, commandName, args...)
+}
+
+// Do calls conn.Do(commandName, args...), and also reports the operation as a span to Elastic APM.
+func Do(ctx context.Context, conn redis.Conn, commandName string, args ...interface{}) (interface{}, error) {
+	spanName := strings.ToUpper(commandName)
+	if spanName == "" {
+		spanName = "(flush pipeline)"
+	}
+	span, _ := elasticapm.StartSpan(ctx, spanName, "cache.redis")
+	defer span.End()
+	return conn.Do(commandName, args...)
+}
+
+// DoWithTimeout calls redis.DoWithTimeout(conn, timeout, commandName, args...), and also reports the operation as a span to Elastic APM.
+func DoWithTimeout(ctx context.Context, conn redis.Conn, timeout time.Duration, commandName string, args ...interface{}) (interface{}, error) {
+	spanName := strings.ToUpper(commandName)
+	if spanName == "" {
+		spanName = "(flush pipeline)"
+	}
+	span, _ := elasticapm.StartSpan(ctx, spanName, "cache.redis")
+	defer span.End()
+	return redis.DoWithTimeout(conn, timeout, commandName, args...)
+}

--- a/module/apmredigo/conn_test.go
+++ b/module/apmredigo/conn_test.go
@@ -1,0 +1,107 @@
+package apmredigo_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go"
+	"github.com/elastic/apm-agent-go/apmtest"
+	"github.com/elastic/apm-agent-go/module/apmredigo"
+)
+
+func TestWrap(t *testing.T) {
+	var conn mockConn
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		conn := apmredigo.Wrap(conn).WithContext(ctx)
+		conn.Do("PING", "hello, world!")
+	})
+	require.Len(t, spans, 1)
+	assert.Equal(t, "PING", spans[0].Name)
+	assert.Equal(t, "cache.redis", spans[0].Type)
+}
+
+func TestWithContext(t *testing.T) {
+	ping := func(ctx context.Context, conn apmredigo.Conn) {
+		span, ctx := elasticapm.StartSpan(ctx, "ping", "custom")
+		defer span.End()
+
+		// bind conn to the ctx containing the span above
+		conn = conn.WithContext(ctx)
+		conn.Do("PING", "hello, world!")
+	}
+
+	var conn mockConn
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		conn := apmredigo.Wrap(conn)
+		ping(ctx, conn)
+	})
+	require.Len(t, spans, 2)
+	assert.Equal(t, "PING", spans[0].Name)
+	assert.Equal(t, "ping", spans[1].Name)
+	assert.Equal(t, spans[1].ID, spans[0].ParentID)
+}
+
+func TestConnWithTimeout(t *testing.T) {
+	var conn mockConnWithTimeout
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		conn := apmredigo.Wrap(conn).WithContext(ctx)
+		redis.DoWithTimeout(conn, time.Second, "PING", "hello, world!")
+	})
+	require.Len(t, spans, 1)
+	assert.Equal(t, "PING", spans[0].Name)
+	assert.Equal(t, "cache.redis", spans[0].Type)
+}
+
+func TestWrapPipeline(t *testing.T) {
+	var conn mockConnWithTimeout
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		conn := apmredigo.Wrap(conn).WithContext(ctx)
+		conn.Do("")
+		redis.DoWithTimeout(conn, time.Second, "")
+	})
+	require.Len(t, spans, 2)
+	assert.Equal(t, "(flush pipeline)", spans[0].Name)
+	assert.Equal(t, "(flush pipeline)", spans[1].Name)
+}
+
+type mockConnWithTimeout struct{ mockConn }
+
+func (mockConnWithTimeout) DoWithTimeout(timeout time.Duration, commandName string, args ...interface{}) (reply interface{}, err error) {
+	return []byte("Done"), errors.New("DoWithTimeout failed")
+}
+
+func (mockConnWithTimeout) ReceiveWithTimeout(timeout time.Duration) (reply interface{}, err error) {
+	return []byte("REceived"), errors.New("ReceiveWithTimeout failed")
+}
+
+type mockConn struct{}
+
+func (mockConn) Close() error {
+	panic("Close not implemented")
+}
+
+func (mockConn) Err() error {
+	panic("Err not implemented")
+}
+
+func (mockConn) Flush() error {
+	panic("Flush not implemented")
+}
+
+func (mockConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+	return []byte("Done"), errors.New("Do failed")
+}
+
+func (mockConn) Send(commandName string, args ...interface{}) error {
+	return errors.New("Send failed")
+}
+
+func (mockConn) Receive() (reply interface{}, err error) {
+	return []byte("Received"), errors.New("Receive failed")
+}

--- a/module/apmredigo/doc.go
+++ b/module/apmredigo/doc.go
@@ -1,0 +1,2 @@
+// Package apmredigo provides helpers for tracing github.com/gomodule/redigo/redis client operations as spans.
+package apmredigo

--- a/module/apmredigo/integration_test.go
+++ b/module/apmredigo/integration_test.go
@@ -1,0 +1,144 @@
+package apmredigo_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-agent-go/apmtest"
+	"github.com/elastic/apm-agent-go/module/apmhttp"
+	"github.com/elastic/apm-agent-go/module/apmredigo"
+	"github.com/elastic/apm-agent-go/transport/transporttest"
+)
+
+func TestRequestContext(t *testing.T) {
+	c := dialRedis(t)
+	cleanRedis(t, c)
+	c.Close()
+
+	pool := &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			return dialRedis(t), nil
+		},
+	}
+	defer pool.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		// When getting a redis.Conn from a pool, bind it to the
+		// request context. This will ensure spans are reported.
+		conn := apmredigo.Wrap(pool.Get()).WithContext(req.Context())
+		defer conn.Close()
+
+		value, err := redis.Bytes(conn.Do("GET", "content"))
+		if err == nil {
+			w.Write(append([]byte("(cached) "), value...))
+			return
+		}
+
+		value = []byte("Lorem ipsum dolor sit amet")
+		if _, err := conn.Do("SET", "content", value); err != nil {
+			require.NoError(t, err)
+		}
+		w.Write(value)
+	})
+
+	tracer, recorder := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+	handler := apmhttp.Wrap(mux, apmhttp.WithTracer(tracer))
+	for i := 0; i < 2; i++ {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "http://server.testing/", nil)
+		handler.ServeHTTP(w, req)
+	}
+	tracer.Flush(nil)
+
+	payloads := recorder.Payloads()
+	assert.Len(t, payloads.Transactions, 2)
+	assert.Len(t, payloads.Spans, 3)
+
+	assert.Equal(t, "GET", payloads.Spans[0].Name)
+	assert.Equal(t, "SET", payloads.Spans[1].Name)
+	assert.Equal(t, "GET", payloads.Spans[2].Name)
+}
+
+func TestPipelineSendReceive(t *testing.T) {
+	c := dialRedis(t)
+	defer c.Close()
+	cleanRedis(t, c)
+
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		c := apmredigo.Wrap(c).WithContext(ctx)
+
+		err := c.Send("SET", "foo", "bar")
+		require.NoError(t, err)
+
+		err = c.Send("GET", "foo")
+		require.NoError(t, err)
+
+		err = c.Flush()
+		require.NoError(t, err)
+
+		setReply, err := c.Receive() // reply from SET
+		require.NoError(t, err)
+		_ = setReply
+
+		getReply, err := c.Receive() // reply from GET
+		require.NoError(t, err)
+		_ = getReply
+	})
+	// Send and Receive calls are not currently captured.
+	assert.Len(t, spans, 0)
+}
+
+func TestPipelinedTransaction(t *testing.T) {
+	c := dialRedis(t)
+	defer c.Close()
+	cleanRedis(t, c)
+
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		c := apmredigo.Wrap(c).WithContext(ctx)
+		c.Send("MULTI")
+		c.Send("INCR", "foo")
+		c.Send("INCR", "bar")
+		c.Send("INCR", "bar")
+		values, err := redis.Values(c.Do("EXEC"))
+		assert.NoError(t, err)
+		assert.Equal(t, []interface{}{int64(1), int64(1), int64(2)}, values)
+	})
+	assert.Len(t, spans, 1)
+	assert.Equal(t, "EXEC", spans[0].Name)
+}
+
+func dialRedis(t *testing.T) redis.Conn {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		t.Skipf("REDIS_URL not specified")
+	}
+
+	closeConn := true
+	conn, err := redis.DialURL(redisURL)
+	require.NoError(t, err)
+	defer func() {
+		if closeConn {
+			conn.Close()
+		}
+	}()
+
+	_, err = conn.Do("SELECT", "4")
+	require.NoError(t, err)
+
+	closeConn = false
+	return conn
+}
+
+func cleanRedis(t *testing.T, conn redis.Conn) {
+	_, err := conn.Do("FLUSHDB")
+	require.NoError(t, err)
+}

--- a/scripts/Dockerfile-testing
+++ b/scripts/Dockerfile-testing
@@ -6,6 +6,7 @@ RUN go get -v github.com/aws/aws-lambda-go/lambdacontext
 RUN go get -v github.com/gin-gonic/gin
 RUN go get -v github.com/go-sql-driver/mysql
 RUN go get -v github.com/gocql/gocql
+RUN go get -v github.com/gomodule/redigo/redis
 RUN go get -v github.com/google/go-cmp/cmp
 RUN go get -v github.com/gorilla/mux
 RUN go get -v github.com/grpc-ecosystem/go-grpc-middleware

--- a/scripts/docker-compose-testing.yml
+++ b/scripts/docker-compose-testing.yml
@@ -14,10 +14,12 @@ services:
       CASSANDRA_HOST: cassandra
       MYSQL_HOST: mysql
       PGHOST: postgres
+      REDIS_URL: redis://redis
     depends_on:
       - cassandra
       - mysql
       - postgres
+      - redis
 
   mysql:
     image: mysql:latest
@@ -42,6 +44,9 @@ services:
     environment:
       MAX_HEAP_SIZE: "1G"
       HEAP_NEWSIZE: 400m
+
+  redis:
+    image: redis:latest
 
 volumes:
   mysqldata:


### PR DESCRIPTION
We introduce module/apmredigo, which provides
top-level function for calling redis.Conn.Do
with a context, a la ctxhttp.Do. apmredigo also
provides a function (ContextConn) for binding a
redis.Conn to a given context, diverting Do calls
to the aforementioned Do-with-context function.

Send and Receive are not instrumented. For now,
spans should be created for the higher-level
operations in which they are used (pub/sub,
transactions, etc.)

Closes #35 