### PR TITLE
Implement currentProcessTitle for non-Linux

### DIFF
--- a/span.go
+++ b/span.go
@@ -55,11 +55,6 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 	}
 	span := tx.tracer.startSpan(name, spanType, transactionID, opts)
 	binary.LittleEndian.PutUint64(span.traceContext.Span[:], tx.rand.Uint64())
-	// TODO(axw) profile whether it's worthwhile threading and
-	// storing spanFramesMinDuration through to the transaction
-	// and span, or if we can instead unconditionally capture
-	// the stack trace, and make the rendering in the model
-	// writer conditional.
 	span.stackFramesMinDuration = tx.spanFramesMinDuration
 	span.transactionTimestamp = tx.timestamp
 	tx.spansCreated++
@@ -90,11 +85,6 @@ func (t *Tracer) StartSpan(name, spanType string, transactionID SpanID, transact
 	span := t.startSpan(name, spanType, transactionID, opts)
 	span.traceContext.Span = spanID
 	span.transactionTimestamp = transactionTimestamp
-	// TODO(axw) profile whether it's worthwhile threading and
-	// storing spanFramesMinDuration through to the transaction
-	// and span, or if we can instead unconditionally capture
-	// the stack trace, and make the rendering in the model
-	// writer conditional.
 	t.spanFramesMinDurationMu.RLock()
 	span.stackFramesMinDuration = t.spanFramesMinDuration
 	t.spanFramesMinDurationMu.RUnlock()

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package elasticapm
 import (
 	"math/rand"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -38,8 +39,8 @@ func init() {
 func getCurrentProcess() model.Process {
 	ppid := os.Getppid()
 	title, err := currentProcessTitle()
-	if err != nil {
-		title = os.Args[0]
+	if err != nil || title == "" {
+		title = filepath.Base(os.Args[0])
 	}
 	return model.Process{
 		Pid:   os.Getpid(),

--- a/utils_linux_test.go
+++ b/utils_linux_test.go
@@ -1,0 +1,34 @@
+package elasticapm
+
+import (
+	"syscall"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentProcessTitle(t *testing.T) {
+	origProcessTitle, err := currentProcessTitle()
+	assert.NoError(t, err)
+
+	setProcessTitle := func(title string) {
+		var buf [16]byte
+		copy(buf[:], title)
+		if _, _, errno := syscall.RawSyscall6(
+			syscall.SYS_PRCTL, syscall.PR_SET_NAME,
+			uintptr(unsafe.Pointer(&buf[0])),
+			0, 0, 0, 0,
+		); errno != 0 {
+			t.Fatal(errno)
+		}
+	}
+
+	const desiredTitle = "foo [bar]"
+	setProcessTitle(desiredTitle)
+	defer setProcessTitle(origProcessTitle)
+
+	processTitle, err := currentProcessTitle()
+	assert.NoError(t, err)
+	assert.Equal(t, desiredTitle, processTitle)
+}

--- a/utils_other.go
+++ b/utils_other.go
@@ -2,7 +2,20 @@
 
 package elasticapm
 
+import (
+	"github.com/pkg/errors"
+
+	"github.com/elastic/go-sysinfo"
+)
+
 func currentProcessTitle() (string, error) {
-	// TODO(axw)
-	return "", nil
+	proc, err := sysinfo.Self()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get process info")
+	}
+	info, err := proc.Info()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get process info")
+	}
+	return info.Name, nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,11 +2,27 @@ package elasticapm
 
 import (
 	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGetCurrentProcess(t *testing.T) {
+	process := getCurrentProcess()
+	expected := filepath.Base(os.Args[0])
+
+	// On Linux, the process title can be at most
+	// 16 bytes, including the null terminator.
+	if runtime.GOOS == "linux" && len(expected) >= 16 {
+		expected = expected[:15]
+	}
+
+	assert.Equal(t, expected, process.Title)
+}
 
 func TestGracePeriod(t *testing.T) {
 	var p time.Duration = -1


### PR DESCRIPTION
Use go-sysinfo on non-Linux systems. Could use it on Linux too, but that would incur more overhead for the usual case.

Closes #254 