### PR TITLE
[v2] Update timestamps to usec since epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  - Truncate all strings to a maximum of 10000 chars (#244)
  - Add leading slash to URLs in transaction/span context (#250)
  - Add `Transaction.Context` method for setting framework (#252)
+ - Timestamps are now reported as usec since epoch, spans no longer use "start" offset (#257)
 
 ## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
 

--- a/internal/apmschema/jsonschema/errors/common_error.json
+++ b/internal/apmschema/jsonschema/errors/common_error.json
@@ -1,5 +1,5 @@
 {
-    "$id": "docs/spec/errors/error.json",
+    "$id": "docs/spec/errors/common_error.json",
     "type": "object",
     "description": "Data captured by an agent representing an event occurring in a monitored service",
     "properties": {
@@ -86,12 +86,6 @@
                 }
             },
             "required": ["message"]
-        },
-        "timestamp": {
-            "type": ["string","null"],
-            "format": "date-time",
-            "pattern": "Z$",
-            "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },
     "anyOf": [

--- a/internal/apmschema/jsonschema/errors/v2_error.json
+++ b/internal/apmschema/jsonschema/errors/v2_error.json
@@ -5,29 +5,39 @@
     "allOf": [
 
         { "$ref": "common_error.json"  }, 
+        { "$ref": "../timestamp_epoch.json" },
         {  
             "properties": {
                 "id": {
-                    "type": ["string", "null"],
-                    "description": "Hex encoded 64 random bits ID of the error.",
+                    "type": ["string"],
+                    "description": "Hex encoded 128 random bits ID of the error.",
                     "maxLength": 1024
                 },
                 "trace_id": {
-                    "description": "Hex encoded 128 random bits ID of the correlated trace.", 
+                    "description": "Hex encoded 128 random bits ID of the correlated trace. Must be present if transaction_id and parent_id are set.", 
                     "type": ["string", "null"],
                     "maxLength": 1024
                 },
                 "transaction_id": {
                     "type": ["string", "null"],
-                    "description": "Hex encoded 64 random bits ID of the correlated transaction.",
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction. Must be present if trace_id and parent_id are set.",
                     "maxLength": 1024
                 },
                 "parent_id": {
-                    "description": "Hex encoded 64 random bits ID of the parent transaction or span.", 
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Must be present if trace_id and transaction_id are set.", 
                     "type": ["string", "null"],
                     "maxLength": 1024
                 }
-            }
+            },
+            "allOf": [
+                { "required": ["id"] },
+                { "if": {"required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}},
+                  "then": { "required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}} },
+                { "if": {"required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}},
+                  "then": { "required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}} },
+                { "if": {"required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}},
+                  "then": { "required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}} }
+            ]
         }
     ]
 }

--- a/internal/apmschema/jsonschema/metadata.json
+++ b/internal/apmschema/jsonschema/metadata.json
@@ -1,6 +1,6 @@
 {
     "$id": "doc/spec/metadata.json",
-    "title": "Context",
+    "title": "Metadata",
     "description": "Metadata concerning the other objects in the stream.",
     "type": ["object"],
     "properties": {

--- a/internal/apmschema/jsonschema/metricsets/common_metricset.json
+++ b/internal/apmschema/jsonschema/metricsets/common_metricset.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "docs/spec/metrics/metricset.json",
+    "$id": "docs/spec/metricsets/common_metricset.json",
     "type": "object",
     "description": "Metric data captured by an APM agent",
     "properties": {
@@ -24,13 +24,7 @@
                 }
             },
             "additionalProperties": false
-        },
-        "timestamp": {
-            "type": "string",
-            "format": "date-time",
-            "pattern": "Z$",
-            "description": "Recorded time of the metric, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },
-    "required": ["samples", "timestamp"]
+    "required": ["samples"]
 }

--- a/internal/apmschema/jsonschema/metricsets/sample.json
+++ b/internal/apmschema/jsonschema/metricsets/sample.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "docs/spec/metrics/sample.json",
+    "$id": "docs/spec/metricsets/sample.json",
     "type": ["object", "null"],
     "description": "A single metric sample.",
     "properties": {

--- a/internal/apmschema/jsonschema/metricsets/v2_metricset.json
+++ b/internal/apmschema/jsonschema/metricsets/v2_metricset.json
@@ -1,0 +1,11 @@
+{
+    "$id": "docs/spec/metricsets/v2_metricset.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "allOf": [
+
+        { "$ref": "common_metricset.json"  }, 
+        { "$ref": "../timestamp_epoch.json"},
+        {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}}
+    ]
+}

--- a/internal/apmschema/jsonschema/spans/common_span.json
+++ b/internal/apmschema/jsonschema/spans/common_span.json
@@ -60,15 +60,11 @@
             },
             "minItems": 0
         },
-        "start": {
-            "type": "number",
-            "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
-        },
         "type": {
             "type": "string",
             "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
             "maxLength": 1024
         }
     },
-    "required": ["duration", "name", "start", "type"]
+    "required": ["duration", "name", "type"]
 }

--- a/internal/apmschema/jsonschema/spans/v2_span.json
+++ b/internal/apmschema/jsonschema/spans/v2_span.json
@@ -3,7 +3,8 @@
     "type": "object",
     "$ref": "common_span.json",
     "allOf": [
-        { "$ref": "common_span.json"  }, 
+        { "$ref": "common_span.json"  },
+        { "$ref": "../timestamp_epoch.json" },
         {  
             "properties": {
                 "id": {
@@ -18,22 +19,25 @@
                 },
                 "trace_id": {
                     "description": "Hex encoded 128 random bits ID of the correlated trace.", 
-                    "type": ["string", "null"],
+                    "type": "string",
                     "maxLength": 1024
                 },
                 "parent_id": {
                     "description": "Hex encoded 64 random bits ID of the parent transaction or span.", 
-                    "type": ["string", "null"],
+                    "type": "string",
                     "maxLength": 1024
                 },
-                "timestamp": {
-                    "description": "Recorded time of the span, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ",
-                    "type": ["string", "null"],
-                    "pattern": "Z$",
-                    "format": "date-time"
+                "start": {
+                    "type": ["number", "null"],
+                    "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
                 }
             },
-            "required": ["id", "transaction_id", "trace_id"]
+            "required": ["id", "transaction_id", "trace_id", "parent_id"]
+        },
+        { "anyOf":[
+                {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}},
+                {"required": ["start"], "properties": {"start": { "type": "number" }}}
+            ]
         }
     ]
 }

--- a/internal/apmschema/jsonschema/timestamp_epoch.json
+++ b/internal/apmschema/jsonschema/timestamp_epoch.json
@@ -1,0 +1,12 @@
+{
+    "$id": "doc/spec/timestamp_epoch.json",
+    "title": "Timestamp Epoch",
+    "description": "Object with 'timestamp' property.",
+    "type": ["object"],
+    "properties": {  
+        "timestamp": {
+            "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
+            "type": ["integer", "null"]
+        }
+    }
+}

--- a/internal/apmschema/jsonschema/transactions/common_transaction.json
+++ b/internal/apmschema/jsonschema/transactions/common_transaction.json
@@ -20,12 +20,6 @@
             "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
             "maxLength": 1024
         },
-        "timestamp": {
-            "type": ["string", "null"],
-            "pattern": "Z$",
-            "format": "date-time",
-            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
-        },
         "type": {
             "type": "string",
             "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",

--- a/internal/apmschema/jsonschema/transactions/v2_transaction.json
+++ b/internal/apmschema/jsonschema/transactions/v2_transaction.json
@@ -3,7 +3,8 @@
     "type": "object",
     "description": "Data captured by an agent representing an event occurring in a monitored service",
     "allOf": [
-        { "$ref": "common_transaction.json"  }, 
+        { "$ref": "common_transaction.json"  },
+        { "$ref": "../timestamp_epoch.json" },
         {  
             "properties": {
                 "id": {
@@ -13,11 +14,11 @@
                 },
                 "trace_id": {
                     "description": "Hex encoded 128 random bits ID of the correlated trace.", 
-                    "type": ["string", "null"],
+                    "type": "string",
                     "maxLength": 1024
                 },
                 "parent_id": {
-                    "description": "Hex encoded 64 random bits ID of the parent transaction or span.", 
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Only root transactions of a trace do not have a parent_id, otherwise it needs to be set.", 
                     "type": ["string", "null"],
                     "maxLength": 1024
                 },
@@ -38,7 +39,7 @@
                     "required": ["started"]
                 }
             },
-            "required": ["id", "trace_id","span_count"]
+            "required": ["id", "trace_id", "span_count"]
         }
     ]
 }

--- a/internal/apmschema/schema.go
+++ b/internal/apmschema/schema.go
@@ -43,7 +43,7 @@ func init() {
 	}
 	compile("errors/v2_error.json", &Error)
 	compile("metadata.json", &Metadata)
-	compile("metrics/metricset.json", &MetricSet)
+	compile("metricsets/v2_metricset.json", &MetricSet)
 	compile("spans/v2_span.json", &Span)
 	compile("transactions/v2_transaction.json", &Transaction)
 }

--- a/internal/apmschema/update.sh
+++ b/internal/apmschema/update.sh
@@ -14,8 +14,9 @@ FILES=( \
     "transactions/mark.json" \
     "transactions/common_transaction.json" \
     "transactions/v2_transaction.json" \
-    "metrics/metricset.json" \
-    "metrics/sample.json" \
+    "metricsets/common_metricset.json" \
+    "metricsets/v2_metricset.json" \
+    "metricsets/sample.json" \
     "context.json" \
     "metadata.json" \
     "process.json" \
@@ -24,10 +25,11 @@ FILES=( \
     "stacktrace_frame.json" \
     "system.json" \
     "tags.json" \
+    "timestamp_epoch.json" \
     "user.json" \
 )
 
-mkdir -p jsonschema/errors jsonschema/transactions jsonschema/sourcemaps jsonschema/spans jsonschema/metrics
+mkdir -p jsonschema/errors jsonschema/transactions jsonschema/sourcemaps jsonschema/spans jsonschema/metricsets
 
 for i in "${FILES[@]}"; do
   o=jsonschema/$i

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -16,29 +16,18 @@ import (
 
 //go:generate go run ../internal/fastjson/generate.go -f -o marshal_fastjson.go .
 
-const (
-	// YYYY-MM-DDTHH:mm:ss.sssZ
-	dateTimeFormat = "2006-01-02T15:04:05.999Z"
-)
-
 // MarshalFastJSON writes the JSON representation of t to w.
 func (t Time) MarshalFastJSON(w *fastjson.Writer) {
-	w.RawByte('"')
-	w.Time(time.Time(t), dateTimeFormat)
-	w.RawByte('"')
+	w.Int64(time.Time(t).UnixNano() / int64(time.Microsecond))
 }
 
 // UnmarshalJSON unmarshals the JSON data into t.
 func (t *Time) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
+	var usec int64
+	if err := json.Unmarshal(data, &usec); err != nil {
 		return err
 	}
-	time, err := time.Parse(dateTimeFormat, s)
-	if err != nil {
-		return err
-	}
-	*t = Time(time)
+	*t = Time(time.Unix(usec/1000000, (usec%1000000)*1000).UTC())
 	return nil
 }
 

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -234,8 +234,6 @@ func (v *Span) MarshalFastJSON(w *fastjson.Writer) {
 	v.ID.MarshalFastJSON(w)
 	w.RawString(",\"name\":")
 	w.String(v.Name)
-	w.RawString(",\"start\":")
-	w.Float64(v.Start)
 	w.RawString(",\"timestamp\":")
 	v.Timestamp.MarshalFastJSON(w)
 	w.RawString(",\"trace_id\":")

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -29,7 +29,7 @@ func TestMarshalTransaction(t *testing.T) {
 		"parent_id": "0001020304050607",
 		"name":      "GET /foo/bar",
 		"type":      "request",
-		"timestamp": "1970-01-01T00:02:03Z",
+		"timestamp": float64(123000000),
 		"duration":  123.456,
 		"result":    "418",
 		"context": map[string]interface{}{
@@ -104,7 +104,7 @@ func TestMarshalSpan(t *testing.T) {
 		"parent_id":      "0001020304050607",
 		"transaction_id": "0001020304050607",
 		"name":           "SELECT FROM bar",
-		"timestamp":      "1970-01-01T00:02:03Z",
+		"timestamp":      float64(123000000),
 		"duration":       float64(3),
 		"type":           "db.postgresql.query",
 		"context": map[string]interface{}{
@@ -131,7 +131,7 @@ func TestMarshalSpan(t *testing.T) {
 		"id":             "0001020304050607",
 		"transaction_id": "0001020304050607",
 		"name":           "GET testing.invalid:8000",
-		"timestamp":      "1970-01-01T00:02:03Z",
+		"timestamp":      float64(123000000),
 		"duration":       float64(4),
 		"type":           "ext.http",
 		"context": map[string]interface{}{
@@ -150,7 +150,7 @@ func TestMarshalMetrics(t *testing.T) {
 
 	decoded := mustUnmarshalJSON(w)
 	expect := map[string]interface{}{
-		"timestamp": "1970-01-01T00:02:03Z",
+		"timestamp": float64(123000000),
 		"labels": map[string]interface{}{
 			"foo": "bar",
 		},
@@ -175,7 +175,7 @@ func TestMarshalError(t *testing.T) {
 	// The primary error ID is required, all other IDs are optional
 	var w fastjson.Writer
 	e.MarshalFastJSON(&w)
-	assert.Equal(t, `{"id":"00000000000000000000000000000000","timestamp":"1970-01-01T00:02:03Z"}`, string(w.Bytes()))
+	assert.Equal(t, `{"id":"00000000000000000000000000000000","timestamp":123000000}`, string(w.Bytes()))
 
 	e.ID = model.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	e.TransactionID = model.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
@@ -184,7 +184,7 @@ func TestMarshalError(t *testing.T) {
 	w.Reset()
 	e.MarshalFastJSON(&w)
 	assert.Equal(t,
-		`{"id":"000102030405060708090a0b0c0d0e0f","timestamp":"1970-01-01T00:02:03Z","parent_id":"0102030405060708","trace_id":"0102030405060708090a0b0c0d0e0f10","transaction_id":"0102030405060708"}`,
+		`{"id":"000102030405060708090a0b0c0d0e0f","timestamp":123000000,"parent_id":"0102030405060708","trace_id":"0102030405060708090a0b0c0d0e0f10","transaction_id":"0102030405060708"}`,
 		string(w.Bytes()),
 	)
 }

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -103,7 +103,6 @@ func TestMarshalSpan(t *testing.T) {
 		"id":             "0001020304050607",
 		"parent_id":      "0001020304050607",
 		"transaction_id": "0001020304050607",
-		"start":          float64(123),
 		"name":           "SELECT FROM bar",
 		"timestamp":      "1970-01-01T00:02:03Z",
 		"duration":       float64(3),
@@ -133,7 +132,6 @@ func TestMarshalSpan(t *testing.T) {
 		"transaction_id": "0001020304050607",
 		"name":           "GET testing.invalid:8000",
 		"timestamp":      "1970-01-01T00:02:03Z",
-		"start":          float64(123),
 		"duration":       float64(4),
 		"type":           "ext.http",
 		"context": map[string]interface{}{
@@ -567,7 +565,6 @@ func fakeSpan() model.Span {
 		TransactionID: model.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
 		TraceID:       model.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 		Timestamp:     model.Time(time.Unix(123, 0).UTC()),
-		Start:         123,
 		Duration:      3,
 		Type:          "db.postgresql.query",
 		Context:       fakeDatabaseSpanContext(),

--- a/model/model.go
+++ b/model/model.go
@@ -162,10 +162,6 @@ type Span struct {
 	// Timestamp holds the time at which the span's transaction started.
 	Timestamp Time `json:"timestamp"`
 
-	// Start is the start time of the span, in milliseconds relative to
-	// the containing transaction's timestamp.
-	Start float64 `json:"start"`
-
 	// Duration holds the duration of the span, in milliseconds.
 	Duration float64 `json:"duration"`
 

--- a/model/model.go
+++ b/model/model.go
@@ -501,7 +501,7 @@ type ResponseHeaders struct {
 	ContentType string `json:"content-type,omitempty"`
 }
 
-// Time is a timestamp, formatted as "YYYY-MM-DDTHH:mm:ss.sssZ".
+// Time is a timestamp, formatted as a number of microseconds since January 1, 1970 UTC.
 type Time time.Time
 
 // TraceID holds a 128-bit trace ID.

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -105,8 +105,7 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span) {
 
 	out.Name = truncateKeyword(span.Name)
 	out.Type = truncateKeyword(span.Type)
-	out.Timestamp = model.Time(span.transactionTimestamp.UTC())
-	out.Start = span.timestamp.Sub(span.transactionTimestamp).Seconds() * 1000
+	out.Timestamp = model.Time(span.timestamp.UTC())
 	out.Duration = span.Duration.Seconds() * 1000
 	out.Context = span.Context.build()
 

--- a/module/apmot/tracer.go
+++ b/module/apmot/tracer.go
@@ -69,7 +69,6 @@ func (t *otTracer) StartSpanWithOptions(name string, opts opentracing.StartSpanO
 			} else {
 				otSpan.span = t.tracer.StartSpan(name, "",
 					parentCtx.transactionID,
-					parentCtx.txSpanContext.startTime,
 					opts,
 				)
 			}

--- a/span_test.go
+++ b/span_test.go
@@ -39,7 +39,7 @@ func TestTracerStartSpan(t *testing.T) {
 	// Even if the transaction and parent span have been ended,
 	// it is possible to report a span with their IDs.
 	tracer.StartSpan("name", "type",
-		txTraceContext.Span, txTimestamp,
+		txTraceContext.Span,
 		elasticapm.SpanOptions{
 			Parent: span0TraceContext,
 			Start:  txTimestamp.Add(time.Second),
@@ -59,10 +59,7 @@ func TestTracerStartSpan(t *testing.T) {
 	}
 	assert.NotZero(t, payloads.Spans[1].ID)
 
-	// NOTE(axw) the timestamp of the span is set to the same as the
-	// transaction. The span's "start" is relative to that timestamp.
-	assert.Equal(t, payloads.Transactions[0].Timestamp, payloads.Spans[1].Timestamp)
-	assert.Equal(t, float64(1000), payloads.Spans[1].Start)
+	assert.Equal(t, time.Time(payloads.Transactions[0].Timestamp).Add(time.Second), time.Time(payloads.Spans[1].Timestamp))
 
 	// The span created after the transaction (obviously?)
 	// doesn't get included in the transaction's span count.


### PR DESCRIPTION
Spans are now reported with timestamps rather than offsets relative to the transaction start time. The timestamp is still calculated based on the transaction timestamp using the monotonic clock. All timestamps are now reported as microseconds since the Unix epoch.

Closes #240 