### PR TITLE
ELASTIC_APM_SANITIZE_FIELD_NAMES and ELASTIC_APM_IGNORE_URLS now use wildcard matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  - Add leading slash to URLs in transaction/span context (#250)
  - Add `Transaction.Context` method for setting framework (#252)
  - Timestamps are now reported as usec since epoch, spans no longer use "start" offset (#257)
+ - `ELASTIC_APM_SANITIZE_FIELD_NAMES` and `ELASTIC_APM_IGNORE_URLS` now use wildcard matching (#260)
 
 ## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -167,16 +167,15 @@ any data to the Elastic APM server, and instrumentation overhead is minimized.
 [options="header"]
 |============
 | Environment               | Default | Example
-| `ELASTIC_APM_IGNORE_URLS` |         | `/heartbeat\|/_internal/.*`
+| `ELASTIC_APM_IGNORE_URLS` |         | `/heartbeat*, *.jpg`
 |============
 
-A regular expression matching the request line of HTTP requests for which
-transactions should not be reported.
+A list of patterns to match HTTP requests to ignore. An incoming HTTP request
+whose request line matches any of the patterns will not be reported as a transaction.
 
-The pattern specified in `ELASTIC_APM_IGNORE_URLS` is treated
-case-insensitively by default. To override this behavior and match case-sensitively,
-wrap the value like `(?-i:<value>)`. For a full definition of Go's regular
-expression syntax, see https://golang.org/pkg/regexp/syntax/.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default.
+Prefixing a pattern with `(?-i)` makes the matching case sensitive.
 
 [float]
 [[config-sanitize-field-names]]
@@ -184,16 +183,15 @@ expression syntax, see https://golang.org/pkg/regexp/syntax/.
 
 [options="header"]
 |============
-| Environment                        | Default                                                                            | Example
-| `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `password\|passwd\|pwd\|secret\|.*key\|.*token\|.*session.*\|.*credit.*\|.*card.*` | `sekrits`
+| Environment                        | Default                                                                     | Example
+| `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*` | `sekrits`
 |============
 
-A regular expression matching the names of HTTP cookies and POST form fields to redact.
+A list of patterns to match the names of HTTP cookies and POST form fields to refact.
 
-The pattern specified in `ELASTIC_APM_SANITIZE_FIELD_NAMES` is treated
-case-insensitively by default. To override this behavior and match case-sensitively,
-wrap the value like `(?-i:<value>)`. For a full definition of Go's regular
-expression syntax, see https://golang.org/pkg/regexp/syntax/.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default.
+Prefixing a pattern with `(?-i)` makes the matching case sensitive.
 
 [float]
 [[config-capture-body]]

--- a/env_test.go
+++ b/env_test.go
@@ -142,14 +142,6 @@ func testTracerTransactionRateEnv(t *testing.T, envValue string, ratio float64) 
 	assert.InDelta(t, N*ratio, sampled, N*0.02) // allow 2% error
 }
 
-func TestTracerSanitizeFieldNamesEnvInvalid(t *testing.T) {
-	os.Setenv("ELASTIC_APM_SANITIZE_FIELD_NAMES", "oy(")
-	defer os.Unsetenv("ELASTIC_APM_SANITIZE_FIELD_NAMES")
-
-	_, err := elasticapm.NewTracer("tracer_testing", "")
-	assert.EqualError(t, err, "invalid ELASTIC_APM_SANITIZE_FIELD_NAMES value: error parsing regexp: missing closing ): `oy(`")
-}
-
 func TestTracerSanitizeFieldNamesEnv(t *testing.T) {
 	testTracerSanitizeFieldNamesEnv(t, "secRet", "[REDACTED]")
 	testTracerSanitizeFieldNamesEnv(t, "nada", "top")

--- a/internal/apmconfig/env.go
+++ b/internal/apmconfig/env.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-agent-go/internal/wildcard"
 )
 
 // ParseDurationEnv gets the value of the environment variable envKey
@@ -62,4 +64,15 @@ func ParseListEnv(envKey, sep string, defaultValue []string) []string {
 		return defaultValue
 	}
 	return ParseList(value, sep)
+}
+
+// ParseWildcardPatternsEnv gets the value of the environment variable envKey
+// and, if set, parses it as a list of wildcard patterns. If the environment
+// variable is unset, defaultValue is returned.
+func ParseWildcardPatternsEnv(envKey string, defaultValue wildcard.Matchers) wildcard.Matchers {
+	value := os.Getenv(envKey)
+	if value == "" {
+		return defaultValue
+	}
+	return ParseWildcardPatterns(value)
 }

--- a/internal/apmconfig/env.go
+++ b/internal/apmconfig/env.go
@@ -52,3 +52,14 @@ func ParseBoolEnv(envKey string, defaultValue bool) (bool, error) {
 	}
 	return b, nil
 }
+
+// ParseListEnv gets the value of the environment variable envKey
+// and, if set, parses it as a list separated by sep. If the environment
+// variable is unset, defaultValue is returned.
+func ParseListEnv(envKey, sep string, defaultValue []string) []string {
+	value := os.Getenv(envKey)
+	if value == "" {
+		return defaultValue
+	}
+	return ParseList(value, sep)
+}

--- a/internal/apmconfig/list.go
+++ b/internal/apmconfig/list.go
@@ -1,0 +1,17 @@
+package apmconfig
+
+import "strings"
+
+// ParseList parses s as a list of strings, separated by sep,
+// and with whitespace trimmed from the list items, omitting
+// empty items.
+func ParseList(s, sep string) []string {
+	var list []string
+	for _, item := range strings.Split(s, sep) {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			list = append(list, item)
+		}
+	}
+	return list
+}

--- a/internal/apmconfig/wildcards.go
+++ b/internal/apmconfig/wildcards.go
@@ -1,0 +1,45 @@
+package apmconfig
+
+import (
+	"strings"
+
+	"github.com/elastic/apm-agent-go/internal/wildcard"
+)
+
+// ParseWildcardPatterns parses s as a comma-separated list of wildcard patterns,
+// and returns wildcard.Matchers for each.
+//
+// Patterns support the "*" wildcard, which will match zero or more characters.
+// A prefix of (?-i) treats the pattern case-sensitively, while a prefix of (?i)
+// treats the pattern case-insensitively (the default). All other characters in
+// the pattern are matched exactly.
+func ParseWildcardPatterns(s string) wildcard.Matchers {
+	patterns := ParseList(s, ",")
+	matchers := make(wildcard.Matchers, len(patterns))
+	for i, p := range patterns {
+		matchers[i] = ParseWildcardPattern(p)
+	}
+	return matchers
+}
+
+// ParseWildcardPattern parses p as a wildcard pattern, returning a wildcard.Matcher.
+//
+// Patterns support the "*" wildcard, which will match zero or more characters.
+// A prefix of (?-i) treats the pattern case-sensitively, while a prefix of (?i)
+// treats the pattern case-insensitively (the default). All other characters in
+// the pattern are matched exactly.
+func ParseWildcardPattern(p string) *wildcard.Matcher {
+	const (
+		caseSensitivePrefix   = "(?-i)"
+		caseInsensitivePrefix = "(?i)"
+	)
+	caseSensitive := wildcard.CaseInsensitive
+	switch {
+	case strings.HasPrefix(p, caseSensitivePrefix):
+		caseSensitive = wildcard.CaseSensitive
+		p = p[len(caseSensitivePrefix):]
+	case strings.HasPrefix(p, caseInsensitivePrefix):
+		p = p[len(caseInsensitivePrefix):]
+	}
+	return wildcard.NewMatcher(p, caseSensitive)
+}

--- a/internal/wildcard/doc.go
+++ b/internal/wildcard/doc.go
@@ -1,0 +1,2 @@
+// Package wildcard provides a fast, zero-allocation wildcard matcher.
+package wildcard

--- a/internal/wildcard/matcher.go
+++ b/internal/wildcard/matcher.go
@@ -1,0 +1,125 @@
+package wildcard
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// CaseSensitivity controls the case sensitivity of matching.
+type CaseSensitivity bool
+
+// CaseSensitivity values.
+const (
+	CaseSensitive   CaseSensitivity = true
+	CaseInsensitive CaseSensitivity = false
+)
+
+// NewMatcher constructs a new wildcard matcher for the given pattern.
+//
+// If p is the empty string, it will match only the empty string.
+// If p is not a valid UTF-8 string, matching behaviour is undefined.
+func NewMatcher(p string, caseSensitive CaseSensitivity) *Matcher {
+	parts := strings.Split(p, "*")
+	m := &Matcher{
+		wildcardBegin: strings.HasPrefix(p, "*"),
+		wildcardEnd:   strings.HasSuffix(p, "*"),
+		caseSensitive: caseSensitive,
+	}
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if !m.caseSensitive {
+			part = strings.ToLower(part)
+		}
+		m.parts = append(m.parts, part)
+	}
+	return m
+}
+
+// Matcher matches strings against a wildcard pattern with configurable case sensitivity.
+type Matcher struct {
+	parts         []string
+	wildcardBegin bool
+	wildcardEnd   bool
+	caseSensitive CaseSensitivity
+}
+
+// Match reports whether s matches m's wildcard pattern.
+func (m *Matcher) Match(s string) bool {
+	if len(m.parts) == 0 && !m.wildcardBegin && !m.wildcardEnd {
+		return s == ""
+	}
+	if len(m.parts) == 1 && !m.wildcardBegin && !m.wildcardEnd {
+		if m.caseSensitive {
+			return s == m.parts[0]
+		}
+		return len(s) == len(m.parts[0]) && hasPrefixLower(s, m.parts[0]) == 0
+	}
+	parts := m.parts
+	if !m.wildcardEnd && len(parts) > 0 {
+		part := parts[len(parts)-1]
+		if m.caseSensitive {
+			if !strings.HasSuffix(s, part) {
+				return false
+			}
+		} else {
+			if len(s) < len(part) {
+				return false
+			}
+			if hasPrefixLower(s[len(s)-len(part):], part) != 0 {
+				return false
+			}
+		}
+		parts = parts[:len(parts)-1]
+	}
+	for i, part := range parts {
+		j := -1
+		if m.caseSensitive {
+			if i > 0 || m.wildcardBegin {
+				j = strings.Index(s, part)
+			} else {
+				if !strings.HasPrefix(s, part) {
+					return false
+				}
+				j = 0
+			}
+		} else {
+			off := 0
+			for j == -1 && len(s)-off >= len(part) {
+				skip := hasPrefixLower(s[off:], part)
+				if skip == 0 {
+					j = off
+				} else {
+					if i == 0 && !m.wildcardBegin {
+						return false
+					}
+					off += skip
+				}
+			}
+		}
+		if j == -1 {
+			return false
+		}
+		s = s[j+len(part):]
+	}
+	return true
+}
+
+// hasPrefixLower reports whether or not s begins with prefixLower,
+// returning 0 if it does, and the number of bytes representing the
+// first rune in s otherwise.
+func hasPrefixLower(s, prefixLower string) (skip int) {
+	var firstSize int
+	for i, r := range prefixLower {
+		r2, size := utf8.DecodeRuneInString(s[i:])
+		if firstSize == 0 {
+			firstSize = size
+		}
+		if r2 != r && r2 != unicode.ToUpper(r) {
+			return firstSize
+		}
+	}
+	return 0
+}

--- a/internal/wildcard/matcher_test.go
+++ b/internal/wildcard/matcher_test.go
@@ -1,0 +1,156 @@
+package wildcard
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWildcardStartsWith(t *testing.T) {
+	mS := NewMatcher("foo*", CaseSensitive)
+	mI := NewMatcher("foo*", CaseInsensitive)
+	for _, m := range []*Matcher{mS, mI} {
+		assert.True(t, m.Match("foo"))
+		assert.True(t, m.Match("foobar"))
+		assert.False(t, m.Match("bar"))
+		assert.False(t, m.Match("barfoo"))
+		assert.False(t, m.Match(""))
+	}
+	assert.True(t, mI.Match("FoO"))
+	assert.False(t, mS.Match("FoO"))
+}
+
+func TestWildcardEndsWith(t *testing.T) {
+	mS := NewMatcher("*foo", CaseSensitive)
+	mI := NewMatcher("*foo", CaseInsensitive)
+	for _, m := range []*Matcher{mS, mI} {
+		assert.True(t, m.Match("foo"))
+		assert.True(t, m.Match("barfoo"))
+		assert.True(t, m.Match("\xed\xbf\xbf\x80foo"))
+		assert.False(t, m.Match("foobar"))
+		assert.False(t, m.Match("bar"))
+		assert.False(t, m.Match(""))
+	}
+	assert.True(t, mI.Match("BaRFoO"))
+	assert.False(t, mS.Match("BaRFoO"))
+}
+
+func TestWildcardEqual(t *testing.T) {
+	mS := NewMatcher("foo", CaseSensitive)
+	mI := NewMatcher("foo", CaseInsensitive)
+	for _, m := range []*Matcher{mS, mI} {
+		assert.True(t, m.Match("foo"))
+		assert.False(t, m.Match("foobar"))
+		assert.False(t, m.Match("bar"))
+		assert.False(t, m.Match("barfoo"))
+		assert.False(t, m.Match(""))
+	}
+	assert.True(t, mI.Match("FoO"))
+	assert.False(t, mS.Match("FoO"))
+}
+
+func TestWildcardAll(t *testing.T) {
+	mS := NewMatcher("*", CaseSensitive)
+	mI := NewMatcher("*", CaseInsensitive)
+	for _, m := range []*Matcher{mS, mI} {
+		assert.True(t, m.Match(""))
+		assert.True(t, m.Match("x"))
+	}
+}
+
+func TestWildcardEmptyPattern(t *testing.T) {
+	mS := NewMatcher("", CaseSensitive)
+	mI := NewMatcher("", CaseInsensitive)
+	for _, m := range []*Matcher{mS, mI} {
+		assert.True(t, m.Match(""))
+		assert.False(t, m.Match("x"))
+	}
+}
+
+func TestWildcardMultiples(t *testing.T) {
+	mS := NewMatcher("a*b*c", CaseSensitive)
+	mI := NewMatcher("a*b*c", CaseInsensitive)
+	for _, m := range []*Matcher{mS, mI} {
+		assert.True(t, m.Match("abc"))
+		assert.True(t, m.Match("abbc"))
+		assert.True(t, m.Match("aabc"))
+		assert.True(t, m.Match("abcc"))
+		assert.False(t, m.Match("ab"))
+		assert.False(t, m.Match("bc"))
+		assert.False(t, m.Match("ac"))
+		assert.False(t, m.Match("_abc_"))
+		assert.False(t, m.Match(""))
+	}
+}
+
+func TestWildcardSandwich(t *testing.T) {
+	mS := NewMatcher("a*c", CaseSensitive)
+	mI := NewMatcher("a*c", CaseInsensitive)
+	for _, m := range []*Matcher{mS, mI} {
+		assert.True(t, m.Match("abc"))
+		assert.True(t, m.Match("abbc"))
+		assert.True(t, m.Match("aabc"))
+		assert.True(t, m.Match("abcc"))
+		assert.True(t, m.Match("ac"))
+		assert.False(t, m.Match("ab"))
+		assert.False(t, m.Match("bc"))
+		assert.False(t, m.Match("_abc_"))
+		assert.False(t, m.Match(""))
+	}
+}
+
+var benchmarkPatterns = []string{
+	"password",
+	"passwd",
+	"pwd",
+	"secret",
+	"*key",
+	"*token",
+	"*session*",
+	"*credit*",
+	"*card*",
+}
+
+func BenchmarkWildcardMatcher(b *testing.B) {
+	matchers := make(Matchers, len(benchmarkPatterns))
+	for i, p := range benchmarkPatterns {
+		matchers[i] = NewMatcher(p, CaseInsensitive)
+	}
+	b.ResetTimer()
+	benchmarkMatch(b, matchers.MatchAny)
+}
+
+func BenchmarkRegexpMatcher(b *testing.B) {
+	patterns := make([]string, len(benchmarkPatterns))
+	for i, p := range benchmarkPatterns {
+		patterns[i] = strings.Replace(p, "*", ".*", -1)
+	}
+	re := regexp.MustCompile(fmt.Sprintf("(?i:%s)", strings.Join(patterns, "|")))
+	b.ResetTimer()
+	benchmarkMatch(b, re.MatchString)
+}
+
+func benchmarkMatch(b *testing.B, match func(s string) bool) {
+	var bytes int64
+	test := func(s string, expect bool) {
+		if match(s) != expect {
+			panic("nope")
+		}
+		bytes += int64(len(s))
+	}
+	for i := 0; i < b.N; i++ {
+		test("foo", false)
+		test("session", true)
+		test("passwork", false)
+		test("pwd", true)
+		test("credit_card", true)
+		test("zing", false)
+		test("boop", false)
+
+		b.SetBytes(bytes)
+		bytes = 0
+	}
+}

--- a/internal/wildcard/matchers.go
+++ b/internal/wildcard/matchers.go
@@ -1,0 +1,14 @@
+package wildcard
+
+// Matchers is a slice of Matcher, matching any of the contained matchers.
+type Matchers []*Matcher
+
+// MatchAny returns true iff any of the matchers returns true.
+func (m Matchers) MatchAny(s string) bool {
+	for _, m := range m {
+		if m.Match(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -91,7 +91,7 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 	}
 
 	out.Context = tx.Context.build()
-	if w.cfg.sanitizedFieldNames != nil && out.Context != nil && out.Context.Request != nil {
+	if len(w.cfg.sanitizedFieldNames) != 0 && out.Context != nil && out.Context.Request != nil {
 		sanitizeRequest(out.Context.Request, w.cfg.sanitizedFieldNames)
 	}
 }

--- a/module/apmhttp/ignorer.go
+++ b/module/apmhttp/ignorer.go
@@ -1,11 +1,12 @@
 package apmhttp
 
 import (
-	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 	"sync"
+
+	"github.com/elastic/apm-agent-go/internal/apmconfig"
+	"github.com/elastic/apm-agent-go/internal/wildcard"
 )
 
 const (
@@ -18,17 +19,14 @@ var (
 )
 
 // DefaultServerRequestIgnorer returns the default RequestIgnorer to use in
-// handlers. If ELASTIC_APM_IGNORE_URLS is set to a valid regular expression,
-// then it will be used to ignore matching requests; otherwise none are ignored.
+// handlers. If ELASTIC_APM_IGNORE_URLS is set, it will be treated as a
+// comma-separated list of wildcard patterns; requests that match any of the
+// patterns will be ignored.
 func DefaultServerRequestIgnorer() RequestIgnorerFunc {
 	defaultServerRequestIgnorerOnce.Do(func() {
-		value := os.Getenv(envIgnoreURLs)
-		if value == "" {
-			return
-		}
-		re, err := regexp.Compile(fmt.Sprintf("(?i:%s)", value))
-		if err == nil {
-			defaultServerRequestIgnorer = NewRegexpRequestIgnorer(re)
+		matchers := apmconfig.ParseWildcardPatternsEnv(envIgnoreURLs, nil)
+		if len(matchers) != 0 {
+			defaultServerRequestIgnorer = NewWildcardPatternsRequestIgnorer(matchers)
 		}
 	})
 	return defaultServerRequestIgnorer
@@ -43,8 +41,20 @@ func NewRegexpRequestIgnorer(re *regexp.Regexp) RequestIgnorerFunc {
 		panic("re == nil")
 	}
 	return func(r *http.Request) bool {
-		fmt.Println(re.String(), r.URL.String(), re.MatchString(r.URL.String()))
 		return re.MatchString(r.URL.String())
+	}
+}
+
+// NewWildcardPatternsRequestIgnorer returns a RequestIgnorerFunc which matches
+// requests' URLs against any of the matchers. Note that for server requests,
+// typically only Path and possibly RawQuery will be set, so the wildcard patterns
+// should take this into account.
+func NewWildcardPatternsRequestIgnorer(matchers wildcard.Matchers) RequestIgnorerFunc {
+	if len(matchers) == 0 {
+		panic("len(matchers) == 0")
+	}
+	return func(r *http.Request) bool {
+		return matchers.MatchAny(r.URL.String())
 	}
 }
 

--- a/module/apmhttp/ignorer_test.go
+++ b/module/apmhttp/ignorer_test.go
@@ -22,20 +22,20 @@ func TestDefaultServerRequestIgnorer(t *testing.T) {
 	testDefaultServerRequestIgnorer(t, "", r1, false)
 	testDefaultServerRequestIgnorer(t, "", r2, false)
 	testDefaultServerRequestIgnorer(t, "", r3, false)
-	testDefaultServerRequestIgnorer(t, "[", r1, false) // invalid regexp matches nothing
+	testDefaultServerRequestIgnorer(t, ",", r1, false) // equivalent to empty
 
-	testDefaultServerRequestIgnorer(t, "/foo", r1, true)
-	testDefaultServerRequestIgnorer(t, "/foo", r2, true)
-	testDefaultServerRequestIgnorer(t, "/foo", r3, true)
-	testDefaultServerRequestIgnorer(t, "/FOO", r3, true) // case insensitive by default
+	testDefaultServerRequestIgnorer(t, "*/foo*", r1, true)
+	testDefaultServerRequestIgnorer(t, "*/foo*", r2, true)
+	testDefaultServerRequestIgnorer(t, "*/foo*", r3, true)
+	testDefaultServerRequestIgnorer(t, "*/FOO*", r3, true) // case insensitive by default
 
-	testDefaultServerRequestIgnorer(t, "/foo\\?bar=baz", r1, false)
-	testDefaultServerRequestIgnorer(t, "/foo\\?bar=baz", r2, true)
-	testDefaultServerRequestIgnorer(t, "/foo\\?bar=baz", r3, true)
+	testDefaultServerRequestIgnorer(t, "*/foo?bar=baz", r1, false)
+	testDefaultServerRequestIgnorer(t, "*/foo?bar=baz", r2, true)
+	testDefaultServerRequestIgnorer(t, "*/foo?bar=baz", r3, true)
 
-	testDefaultServerRequestIgnorer(t, "http://.*", r1, false)
-	testDefaultServerRequestIgnorer(t, "http://.*", r2, false)
-	testDefaultServerRequestIgnorer(t, "http://.*", r3, true)
+	testDefaultServerRequestIgnorer(t, "http://*", r1, false)
+	testDefaultServerRequestIgnorer(t, "http://*", r2, false)
+	testDefaultServerRequestIgnorer(t, "http://*", r3, true)
 }
 
 func testDefaultServerRequestIgnorer(t *testing.T, ignoreURLs string, r *http.Request, expect bool) {

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -2,8 +2,8 @@ package elasticapm
 
 import (
 	"bytes"
-	"regexp"
 
+	"github.com/elastic/apm-agent-go/internal/wildcard"
 	"github.com/elastic/apm-agent-go/model"
 )
 
@@ -11,11 +11,11 @@ const redacted = "[REDACTED]"
 
 // sanitizeRequest sanitizes HTTP request data, redacting
 // the values of cookies and forms whose corresponding keys
-// match the given regular expression.
-func sanitizeRequest(r *model.Request, re *regexp.Regexp) {
+// match any of the given wildcard patterns.
+func sanitizeRequest(r *model.Request, matchers wildcard.Matchers) {
 	var anyCookiesRedacted bool
 	for _, c := range r.Cookies {
-		if !re.MatchString(c.Name) {
+		if !matchers.MatchAny(c.Name) {
 			continue
 		}
 		c.Value = redacted
@@ -33,7 +33,7 @@ func sanitizeRequest(r *model.Request, re *regexp.Regexp) {
 	}
 	if r.Body != nil && r.Body.Form != nil {
 		for key, values := range r.Body.Form {
-			if !re.MatchString(key) {
+			if !matchers.MatchAny(key) {
 				continue
 			}
 			for i := range values {


### PR DESCRIPTION
Implement wildcard matching, and update `ELASTIC_APM_SANITIZE_FIELD_NAMES` and `ELASTIC_APM_IGNORE_URLS` to use that instead of regular expressions. This will bring is in alignment with the Java agent.