### PR TITLE
Drop "requested" option from trace context

### DIFF
--- a/module/apmhttp/traceheaders_test.go
+++ b/module/apmhttp/traceheaders_test.go
@@ -32,6 +32,5 @@ func TestParseTraceparentHeader(t *testing.T) {
 	assert.Equal(t, "\x0a\xf7\x65\x19\x16\xcd\x43\xdd\x84\x48\xeb\x21\x1c\x80\x31\x9c", string(out.Trace[:]))
 	assert.Equal(t, "\xb7\xad\x6b\x71\x69\x20\x33\x31", string(out.Span[:]))
 	assert.Equal(t, apm.TraceOptions(1), out.Options)
-	assert.True(t, out.Options.Requested())
-	assert.False(t, out.Options.MaybeRecorded())
+	assert.True(t, out.Options.Recorded())
 }

--- a/span.go
+++ b/span.go
@@ -82,7 +82,7 @@ func (t *Tracer) StartSpan(name, spanType string, transactionID SpanID, opts Spa
 	if opts.Parent.Trace.Validate() != nil || opts.Parent.Span.Validate() != nil || transactionID.Validate() != nil {
 		return newDroppedSpan()
 	}
-	if !opts.Parent.Options.MaybeRecorded() {
+	if !opts.Parent.Options.Recorded() {
 		return newDroppedSpan()
 	}
 	var spanID SpanID

--- a/tracecontext.go
+++ b/tracecontext.go
@@ -11,8 +11,7 @@ var (
 )
 
 const (
-	traceOptionsRequestedFlag = 0x01
-	traceOptionsRecordedFlag  = 0x02
+	traceOptionsRecordedFlag = 0x01
 )
 
 // TraceContext holds trace context for an incoming or outgoing request.
@@ -74,31 +73,15 @@ func (id SpanID) String() string {
 // TraceOptions describes the options for a trace.
 type TraceOptions uint8
 
-// Requested reports whether or not it has been requested that this
-// transaction/span be recorded.
-func (o TraceOptions) Requested() bool {
-	return (o & traceOptionsRequestedFlag) == traceOptionsRequestedFlag
-}
-
-// MaybeRecorded reports whether or not the transaction/span may have been
-// (or may be) recorded.
-func (o TraceOptions) MaybeRecorded() bool {
+// Recorded reports whether or not the transaction/span may have been (or may be) recorded.
+func (o TraceOptions) Recorded() bool {
 	return (o & traceOptionsRecordedFlag) == traceOptionsRecordedFlag
 }
 
-// WithRequested changes the "requested" flag, and returns the new options without
-// modifying the original value.
-func (o TraceOptions) WithRequested(requested bool) TraceOptions {
-	if requested {
-		return o | traceOptionsRequestedFlag
-	}
-	return o & (0xFF ^ traceOptionsRequestedFlag)
-}
-
-// WithMaybeRecorded changes the "recorded" flag, and returns the new options
+// WithRecorded changes the "recorded" flag, and returns the new options
 // without modifying the original value.
-func (o TraceOptions) WithMaybeRecorded(maybeRecorded bool) TraceOptions {
-	if maybeRecorded {
+func (o TraceOptions) WithRecorded(recorded bool) TraceOptions {
+	if recorded {
 		return o | traceOptionsRecordedFlag
 	}
 	return o & (0xFF ^ traceOptionsRecordedFlag)

--- a/tracecontext_test.go
+++ b/tracecontext_test.go
@@ -26,21 +26,13 @@ func TestSpanID(t *testing.T) {
 
 func TestTraceOptions(t *testing.T) {
 	opts := apm.TraceOptions(0xFE)
-	assert.False(t, opts.Requested())
-	assert.True(t, opts.MaybeRecorded())
+	assert.False(t, opts.Recorded())
 
-	opts = opts.WithRequested(true)
-	assert.True(t, opts.Requested())
-	assert.True(t, opts.MaybeRecorded())
+	opts = opts.WithRecorded(true)
+	assert.True(t, opts.Recorded())
 	assert.Equal(t, apm.TraceOptions(0xFF), opts)
 
-	opts = opts.WithRequested(false)
-	assert.False(t, opts.Requested())
-	assert.True(t, opts.MaybeRecorded())
+	opts = opts.WithRecorded(false)
+	assert.False(t, opts.Recorded())
 	assert.Equal(t, apm.TraceOptions(0xFE), opts)
-
-	opts = opts.WithMaybeRecorded(false)
-	assert.False(t, opts.Requested())
-	assert.False(t, opts.MaybeRecorded())
-	assert.Equal(t, apm.TraceOptions(0xFC), opts)
 }

--- a/transaction.go
+++ b/transaction.go
@@ -66,16 +66,16 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 		sampler := t.sampler
 		t.samplerMu.RUnlock()
 		if sampler == nil || sampler.Sample(tx.traceContext) {
-			o := tx.traceContext.Options.WithRequested(true).WithMaybeRecorded(true)
+			o := tx.traceContext.Options.WithRecorded(true)
 			tx.traceContext.Options = o
 		}
-	} else if opts.TraceContext.Options.Requested() {
+	} else {
 		// TODO(axw) make this behaviour configurable. In some cases
-		// it may not be a good idea to honour the requested flag, as
+		// it may not be a good idea to honour the recorded flag, as
 		// it may open up the application to DoS by forced sampling.
 		// Even ignoring bad actors, a service that has many feeder
 		// applications may end up being sampled at a very high rate.
-		tx.traceContext.Options = opts.TraceContext.Options.WithMaybeRecorded(true)
+		tx.traceContext.Options = opts.TraceContext.Options
 	}
 	tx.timestamp = opts.Start
 	if tx.timestamp.IsZero() {
@@ -126,7 +126,7 @@ func (tx *Transaction) Discard() {
 
 // Sampled reports whether or not the transaction is sampled.
 func (tx *Transaction) Sampled() bool {
-	return tx.traceContext.Options.MaybeRecorded()
+	return tx.traceContext.Options.Recorded()
 }
 
 // TraceContext returns the transaction's TraceContext.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -10,24 +10,14 @@ import (
 )
 
 func TestStartTransactionTraceContextOptions(t *testing.T) {
-	traceContext := startTransactionTraceContextOptions(t, false, false)
-	assert.False(t, traceContext.Options.Requested())
-	assert.False(t, traceContext.Options.MaybeRecorded())
+	traceContext := startTransactionTraceContextOptions(t, false)
+	assert.False(t, traceContext.Options.Recorded())
 
-	traceContext = startTransactionTraceContextOptions(t, false, true)
-	assert.False(t, traceContext.Options.Requested())
-	assert.False(t, traceContext.Options.MaybeRecorded())
-
-	traceContext = startTransactionTraceContextOptions(t, true, false)
-	assert.True(t, traceContext.Options.Requested())
-	assert.True(t, traceContext.Options.MaybeRecorded())
-
-	traceContext = startTransactionTraceContextOptions(t, true, true)
-	assert.True(t, traceContext.Options.Requested())
-	assert.True(t, traceContext.Options.MaybeRecorded())
+	traceContext = startTransactionTraceContextOptions(t, true)
+	assert.True(t, traceContext.Options.Recorded())
 }
 
-func startTransactionTraceContextOptions(t *testing.T, requested, maybeRecorded bool) apm.TraceContext {
+func startTransactionTraceContextOptions(t *testing.T, recorded bool) apm.TraceContext {
 	tracer, _ := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 	tracer.SetSampler(samplerFunc(func(apm.TraceContext) bool {
@@ -40,8 +30,7 @@ func startTransactionTraceContextOptions(t *testing.T, requested, maybeRecorded 
 			Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
 		},
 	}
-	opts.TraceContext.Options = opts.TraceContext.Options.WithRequested(requested)
-	opts.TraceContext.Options = opts.TraceContext.Options.WithMaybeRecorded(maybeRecorded)
+	opts.TraceContext.Options = opts.TraceContext.Options.WithRecorded(recorded)
 
 	tx := tracer.StartTransactionOptions("name", "type", opts)
 	result := tx.TraceContext()


### PR DESCRIPTION
Requested has been dropped from trace-context, following suit.

Closes elastic/apm-agent-go#262 