### PR TITLE
apm: set canonical import path

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
 // Package apm provides an API for tracing
 // transactions and capturing errors, sending the
 // data to Elastic APM.
-package apm
+package apm // import "go.elastic.co/apm"


### PR DESCRIPTION
The canonical import path is now go.elastic.co/apm.
Since there are internal packages in use, it's not
possible to use any other package path.