### PR TITLE
module/apmgin: don't abort on panic after write

### DIFF
--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -84,7 +84,11 @@ func (m *middleware) handle(c *gin.Context) {
 	body := m.tracer.CaptureHTTPRequestBody(c.Request)
 	defer func() {
 		if v := recover(); v != nil {
-			c.AbortWithStatus(http.StatusInternalServerError)
+			if !c.Writer.Written() {
+				c.AbortWithStatus(http.StatusInternalServerError)
+			} else {
+				c.Abort()
+			}
 			e := m.tracer.Recovered(v)
 			e.SetTransaction(tx)
 			setContext(&e.Context, c, body)


### PR DESCRIPTION
If the headers have already been written, don't
attempt to override the status code. Doing so is
not harmful, but it causes an annoying warning.