### PR TITLE
module/...: stop setting custom context

### DIFF
--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -4,7 +4,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
 	"go.elastic.co/apm"
@@ -42,20 +41,8 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 		defer tx.End()
 		tx.Context.SetFramework("grpc", grpc.Version)
 
-		if tx.Sampled() {
-			p, ok := peer.FromContext(ctx)
-			if ok {
-				grpcContext := map[string]interface{}{
-					"peer.address": p.Addr.String(),
-				}
-				if p.AuthInfo != nil {
-					grpcContext["auth"] = map[string]interface{}{
-						"type": p.AuthInfo.AuthType(),
-					}
-				}
-				tx.Context.SetCustom("grpc", grpcContext)
-			}
-		}
+		// TODO(axw) define context schema for RPC,
+		// including at least the peer address.
 
 		defer func() {
 			r := recover()

--- a/module/apmgrpc/server_test.go
+++ b/module/apmgrpc/server_test.go
@@ -78,11 +78,6 @@ func testServerTransactionHappy(t *testing.T, p testParams) {
 	assert.Equal(t, "grpc", tx.Type)
 	assert.Equal(t, "OK", tx.Result)
 
-	require.Len(t, tx.Context.Custom, 1)
-	assert.Equal(t, "grpc", tx.Context.Custom[0].Key)
-	grpcContext := tx.Context.Custom[0].Value.(map[string]interface{})
-	assert.Contains(t, grpcContext, "peer.address")
-	delete(grpcContext, "peer.address")
 	assert.Equal(t, &model.Context{
 		Service: &model.Service{
 			Framework: &model.Framework{
@@ -90,10 +85,6 @@ func testServerTransactionHappy(t *testing.T, p testParams) {
 				Version: grpc.Version,
 			},
 		},
-		Custom: model.IfaceMap{{
-			Key:   "grpc",
-			Value: map[string]interface{}{},
-		}},
 	}, tx.Context)
 }
 

--- a/module/apmlambda/example.go
+++ b/module/apmlambda/example.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"context" // Trace lambda function invocations.
+	"context"
 
 	"github.com/aws/aws-lambda-go/lambda"
 

--- a/module/apmlambda/lambda.go
+++ b/module/apmlambda/lambda.go
@@ -67,9 +67,8 @@ func (f *Function) Invoke(req *messages.InvokeRequest, response *messages.Invoke
 			e.Send()
 		}
 	}()
-	if tx.Sampled() {
-		tx.Context.SetCustom("lambda", &lambdaContext)
-	}
+
+	// TODO(axw) define a schema for lambda/serverless/FaaS.
 
 	lambdaContext.RequestID = req.RequestId
 	lambdaContext.XAmznTraceID = req.XAmznTraceId
@@ -80,7 +79,6 @@ func (f *Function) Invoke(req *messages.InvokeRequest, response *messages.Invoke
 	if err != nil {
 		e := f.tracer.NewError(err)
 		e.SetTransaction(tx)
-		e.Context.SetCustom("lambda", &lambdaContext)
 		e.Send()
 		return err
 	}
@@ -91,7 +89,6 @@ func (f *Function) Invoke(req *messages.InvokeRequest, response *messages.Invoke
 	if response.Error != nil {
 		e := f.tracer.NewError(invokeResponseError{response.Error})
 		e.SetTransaction(tx)
-		e.Context.SetCustom("lambda", &lambdaContext)
 		e.Send()
 	}
 	return nil

--- a/scripts/Dockerfile-testing
+++ b/scripts/Dockerfile-testing
@@ -36,7 +36,6 @@ RUN go get -v golang.org/x/net/http2
 RUN go get -v google.golang.org/grpc
 RUN go get -v google.golang.org/grpc/codes
 RUN go get -v google.golang.org/grpc/examples/helloworld/helloworld
-RUN go get -v google.golang.org/grpc/peer
 RUN go get -v google.golang.org/grpc/status
 
 ADD . /go/src/go.elastic.co/apm


### PR DESCRIPTION
Custom context is meant for user code, not for
canned instrumentation. We'll extend the schema
later to satisfy RPC and FaaS.

Closes elastic/apm-agent-go#251 