### PR TITLE
module/apmrestful: add tracing filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
  - Timestamps are now reported as usec since epoch, spans no longer use "start" offset (#257)
  - `ELASTIC_APM_SANITIZE_FIELD_NAMES` and `ELASTIC_APM_IGNORE_URLS` now use wildcard matching (#260)
  - Changed top-level package name to "apm", and canonical import path to "go.elastic.co/apm" (#202)
+ - module/apmrestful: introduce emicklei/go-restful instrumentation (#270)
 
 ## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
 

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -295,9 +295,9 @@ used, and the context includes a transaction.
 
 [[builtin-modules-apmgorm]]
 ===== module/apmgorm
-Package apmgorm provides a means of instrumenting [gorm](http://gorm.io) database operations.
+Package apmgorm provides a means of instrumenting http://gorm.io[GORM] database operations.
 
-To trace GORM operations, import the appropriate `apmgorm/dialects` package (instead of the
+To trace `GORM` operations, import the appropriate `apmgorm/dialects` package (instead of the
 `gorm/dialects` package), and use `apmgorm.Open` (instead of `gorm.Open`). The parameters are
 exactly the same.
 
@@ -388,6 +388,37 @@ func handleRequest(w http.ResponseWriter, req *http.Request) {
 	// transaction.
 	conn := apmredigo.Wrap(redisPool.Get()).WithContext(req.Context())
 	defer conn.Close()
+	...
+}
+----
+
+[[builtin-modules-apmrestful]]
+===== module/apmrestful
+Package apmrestful provides a https://github.com/emicklei/go-restful[go-restful] filter
+for tracing requests, and capturing panics.
+
+For each request, a transaction is stored in the request context, which can be obtained via
+https://golang.org/pkg/net/http/#Request[http.Request]`.Context()` in your handler.
+
+[source,go]
+----
+import (
+	"github.com/emicklei/go-restful"
+
+	"go.elastic.co/apm/module/apmrestful"
+)
+
+func init() {
+	// Trace all requests to web services registered with the default container.
+	restful.Filter(apmrestful.Filter())
+}
+
+func main() {
+	var ws restful.WebService
+	ws.Path("/things").Consumes(restful.MIME_JSON, restful.MIME_XML).Produces(restful.MIME_JSON, restful.MIME_XML)
+	ws.Route(ws.GET("/{id:[0-1]+}").To(func(req *restful.Request, resp *restful.Response) {
+		// req.Request.Context() should be propagated to downstream operations such as database queries.
+	}))
 	...
 }
 ----

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -70,6 +70,15 @@ See <<builtin-modules-apmgorilla, module/apmgorilla>> for more information
 about gorilla/mux instrumentation.
 
 [float]
+==== go-restful
+
+We support https://github.com/emicklei/go-restful[go-restful],
+https://github.com/emicklei/go-restful/releases/tag/2.0.0[2.0.0] and greater.
+
+See <<builtin-modules-apmrestful, module/apmrestful>> for more information
+about go-restful instrumentation.
+
+[float]
 [[supported-tech-databases]]
 === Databases
 

--- a/module/apmrestful/doc.go
+++ b/module/apmrestful/doc.go
@@ -1,0 +1,3 @@
+// Package apmrestful provides a tracing and panic/exception
+// reporting filter for for the go-restful framework.
+package apmrestful

--- a/module/apmrestful/filter.go
+++ b/module/apmrestful/filter.go
@@ -1,0 +1,90 @@
+package apmrestful
+
+import (
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/module/apmhttp"
+)
+
+// Filter returns a new restful.Filter for tracing requests
+// and recovering and reporting panics to Elastic APM.
+//
+// By default, the filter will use apm.DefaultTracer.
+// Use WithTracer to specify an alternative tracer.
+func Filter(o ...Option) restful.FilterFunction {
+	opts := options{
+		tracer:         apm.DefaultTracer,
+		requestIgnorer: apmhttp.DefaultServerRequestIgnorer(),
+	}
+	for _, o := range o {
+		o(&opts)
+	}
+	return (&filter{
+		tracer:         opts.tracer,
+		requestIgnorer: opts.requestIgnorer,
+	}).filter
+}
+
+type filter struct {
+	tracer         *apm.Tracer
+	requestIgnorer apmhttp.RequestIgnorerFunc
+}
+
+func (f *filter) filter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	if !f.tracer.Active() || f.requestIgnorer(req.Request) {
+		chain.ProcessFilter(req, resp)
+		return
+	}
+
+	name := req.Request.Method + " " + massageRoutePath(req.SelectedRoutePath())
+	tx, httpRequest := apmhttp.StartTransaction(f.tracer, name, req.Request)
+	defer tx.End()
+	req.Request = httpRequest
+	body := f.tracer.CaptureHTTPRequestBody(httpRequest)
+
+	defer func() {
+		if v := recover(); v != nil {
+			e := f.tracer.Recovered(v)
+			e.SetTransaction(tx)
+			setContext(&e.Context, req, resp, body)
+			e.Send()
+			resp.WriteHeader(http.StatusInternalServerError)
+		}
+	}()
+	chain.ProcessFilter(req, resp)
+
+	tx.Result = apmhttp.StatusCodeResult(resp.StatusCode())
+	if tx.Sampled() {
+		setContext(&tx.Context, req, resp, body)
+	}
+}
+
+func setContext(ctx *apm.Context, req *restful.Request, resp *restful.Response, body *apm.BodyCapturer) {
+	ctx.SetFramework("go-restful", "")
+	ctx.SetHTTPRequest(req.Request)
+	ctx.SetHTTPRequestBody(body)
+	ctx.SetHTTPStatusCode(resp.StatusCode())
+	ctx.SetHTTPResponseHeaders(resp.Header())
+}
+
+type options struct {
+	tracer         *apm.Tracer
+	requestIgnorer apmhttp.RequestIgnorerFunc
+}
+
+// Option sets options for tracing.
+type Option func(*options)
+
+// WithTracer returns an Option which sets t as the tracer
+// to use for tracing server requests.
+func WithTracer(t *apm.Tracer) Option {
+	if t == nil {
+		panic("t == nil")
+	}
+	return func(o *options) {
+		o.tracer = t
+	}
+}

--- a/module/apmrestful/filter_example_test.go
+++ b/module/apmrestful/filter_example_test.go
@@ -1,0 +1,12 @@
+package apmrestful_test
+
+import (
+	"github.com/emicklei/go-restful"
+
+	"go.elastic.co/apm/module/apmrestful"
+)
+
+func ExampleFilter() {
+	// Install the filter into the default/global Container.
+	restful.Filter(apmrestful.Filter())
+}

--- a/module/apmrestful/filter_test.go
+++ b/module/apmrestful/filter_test.go
@@ -1,0 +1,127 @@
+package apmrestful_test
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/emicklei/go-restful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/model"
+	"go.elastic.co/apm/module/apmrestful"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func TestContainerFilter(t *testing.T) {
+	type Thing struct {
+		ID string
+	}
+
+	var ws restful.WebService
+	ws.Path("/things").Consumes(restful.MIME_JSON, restful.MIME_XML).Produces(restful.MIME_JSON, restful.MIME_XML)
+	ws.Route(ws.GET("/{id:[0-1]+}").To(func(req *restful.Request, resp *restful.Response) {
+		if apm.TransactionFromContext(req.Request.Context()) == nil {
+			panic("no transaction in context")
+		}
+		resp.WriteHeaderAndEntity(http.StatusTeapot, Thing{
+			ID: req.PathParameter("id"),
+		})
+	}))
+
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	container := restful.NewContainer()
+	container.Add(&ws)
+	container.Filter(apmrestful.Filter(apmrestful.WithTracer(tracer)))
+
+	server := httptest.NewServer(container)
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	serverHost, serverPort, err := net.SplitHostPort(serverURL.Host)
+	require.NoError(t, err)
+
+	resp, err := http.Get(server.URL + "/things/123")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusTeapot, resp.StatusCode)
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	assert.Len(t, payloads.Transactions, 1)
+	transaction := payloads.Transactions[0]
+
+	assert.Equal(t, "GET /things/{id}", transaction.Name)
+	assert.Equal(t, "request", transaction.Type)
+	assert.Equal(t, "HTTP 4xx", transaction.Result)
+
+	assert.Equal(t, &model.Context{
+		Service: &model.Service{
+			Framework: &model.Framework{
+				Name:    "go-restful",
+				Version: "unspecified",
+			},
+		},
+		Request: &model.Request{
+			Socket: &model.RequestSocket{
+				RemoteAddress: "127.0.0.1",
+			},
+			URL: model.URL{
+				Full:     server.URL + "/things/123",
+				Protocol: "http",
+				Hostname: serverHost,
+				Port:     serverPort,
+				Path:     "/things/123",
+			},
+			Method:      "GET",
+			HTTPVersion: "1.1",
+			Headers: &model.RequestHeaders{
+				UserAgent: "Go-http-client/1.1",
+			},
+		},
+		Response: &model.Response{
+			StatusCode: 418,
+			Headers: &model.ResponseHeaders{
+				ContentType: "application/json",
+			},
+		},
+	}, transaction.Context)
+}
+
+func TestContainerFilterPanic(t *testing.T) {
+	var ws restful.WebService
+	ws.Path("/things").Consumes(restful.MIME_JSON, restful.MIME_XML).Produces(restful.MIME_JSON, restful.MIME_XML)
+	ws.Route(ws.GET("/{id}/foo").To(handlePanic))
+
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	container := restful.NewContainer()
+	container.Add(&ws)
+	container.Filter(apmrestful.Filter(apmrestful.WithTracer(tracer)))
+
+	server := httptest.NewServer(container)
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/things/123/foo")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	require.Len(t, payloads.Transactions, 1)
+	require.Len(t, payloads.Errors, 1)
+	panicError := payloads.Errors[0]
+	assert.Equal(t, payloads.Transactions[0].ID, panicError.ParentID)
+	assert.Equal(t, "kablamo", panicError.Exception.Message)
+	assert.Equal(t, "handlePanic", panicError.Culprit)
+}
+
+func handlePanic(req *restful.Request, resp *restful.Response) {
+	panic("kablamo")
+}

--- a/module/apmrestful/route.go
+++ b/module/apmrestful/route.go
@@ -1,0 +1,38 @@
+package apmrestful
+
+import (
+	"bytes"
+	"strings"
+)
+
+// massageRoutePath removes the regexp patterns from route variables.
+func massageRoutePath(route string) string {
+	buf := bytes.NewBuffer(make([]byte, 0, len(route)))
+	end := 0
+	for end < len(route) {
+		var token string
+		i := strings.IndexRune(route[end:], '/')
+		if i == -1 {
+			token = route[end:]
+			end = len(route)
+		} else {
+			token = route[end : end+i+1]
+			end += i + 1
+		}
+		if strings.HasPrefix(token, "{") {
+			colon := strings.IndexRune(token, ':')
+			if colon != -1 {
+				buf.WriteString(token[:colon])
+				rbracket := strings.LastIndexByte(token[colon:], '}')
+				if rbracket != -1 {
+					buf.WriteString(token[colon+rbracket:])
+				}
+			} else {
+				buf.WriteString(token)
+			}
+		} else {
+			buf.WriteString(token)
+		}
+	}
+	return buf.String()
+}

--- a/module/apmrestful/route_test.go
+++ b/module/apmrestful/route_test.go
@@ -1,0 +1,12 @@
+package apmrestful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMassageRoutePath(t *testing.T) {
+	out := massageRoutePath("/articles/{category}/{id:[0-9]+}")
+	assert.Equal(t, "/articles/{category}/{id}", out)
+}

--- a/scripts/Dockerfile-testing
+++ b/scripts/Dockerfile-testing
@@ -3,6 +3,7 @@ FROM golang:latest
 WORKDIR /go/src/go.elastic.co/apm
 RUN go get -v github.com/aws/aws-lambda-go/lambda/messages
 RUN go get -v github.com/aws/aws-lambda-go/lambdacontext
+RUN go get -v github.com/emicklei/go-restful
 RUN go get -v github.com/gin-gonic/gin
 RUN go get -v github.com/go-sql-driver/mysql
 RUN go get -v github.com/gocql/gocql


### PR DESCRIPTION
Add a Filter for tracing go-restful requests.
Installing the filter into a container,
webservice, or route, will cause the requests
within that scope to be traced, and panics
recovered and reported.

Closes elastic/apm-agent-go#227