### PR TITLE
 module/...: fix panic handling in web instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - `ELASTIC_APM_SANITIZE_FIELD_NAMES` and `ELASTIC_APM_IGNORE_URLS` now use wildcard matching (#260)
  - Changed top-level package name to "apm", and canonical import path to "go.elastic.co/apm" (#202)
  - module/apmrestful: introduce emicklei/go-restful instrumentation (#270)
+ - Fix panic handling in web instrumentations (#273)
 
 ## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
 

--- a/apmtest/httpsuite.go
+++ b/apmtest/httpsuite.go
@@ -1,0 +1,120 @@
+package apmtest
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+// HTTPTestSuite is a test suite for HTTP instrumentation modules.
+type HTTPTestSuite struct {
+	suite.Suite
+
+	// Handler holds an instrumented HTTP handler. Handler must
+	// support the following routes:
+	//
+	//   GET /implicit_write (no explicit write on the response)
+	//   GET /panic_before_write (panic without writing response)
+	//   GET /panic_after_write (panic after writing response)
+	//
+	Handler http.Handler
+
+	// Tracer is the apm.Tracer used to instrument Handler.
+	//
+	// HTTPTestSuite will close the tracer when all tests have
+	// been completed.
+	Tracer *apm.Tracer
+
+	// Recorder is the transport used as the transport for Tracer.
+	Recorder *transporttest.RecorderTransport
+
+	server *httptest.Server
+}
+
+// SetupTest runs before each test.
+func (s *HTTPTestSuite) SetupTest() {
+	s.Recorder.ResetPayloads()
+}
+
+// SetupSuite runs before the tests in the suite are run.
+func (s *HTTPTestSuite) SetupSuite() {
+	s.server = httptest.NewServer(s.Handler)
+}
+
+// TearDownSuite runs after the tests in the suite are run.
+func (s *HTTPTestSuite) TearDownSuite() {
+	if s.server != nil {
+		s.server.Close()
+	}
+	s.Tracer.Close()
+}
+
+// TestImplicitWrite tests the behaviour of instrumented handlers
+// for routes which do not explicitly write a response, but instead
+// leave it to the framework to write an empty 200 response.
+func (s *HTTPTestSuite) TestImplicitWrite() {
+	resp, err := http.Get(s.server.URL + "/implicit_write")
+	require.NoError(s.T(), err)
+	resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	s.Tracer.Flush(nil)
+	ps := s.Recorder.Payloads()
+	require.Len(s.T(), ps.Transactions, 1)
+
+	tx := ps.Transactions[0]
+	s.Equal("HTTP 2xx", tx.Result)
+	s.Equal(resp.StatusCode, tx.Context.Response.StatusCode)
+}
+
+// TestPanicBeforeWrite tests the behaviour of instrumented handlers
+// for routes which panic before any headers are written. The handler
+// is expected to recover the panic and write an empty 500 response.
+func (s *HTTPTestSuite) TestPanicBeforeWrite() {
+	resp, err := http.Get(s.server.URL + "/panic_before_write")
+	require.NoError(s.T(), err)
+	resp.Body.Close()
+	s.Equal(http.StatusInternalServerError, resp.StatusCode)
+
+	s.Tracer.Flush(nil)
+	ps := s.Recorder.Payloads()
+	require.Len(s.T(), ps.Transactions, 1)
+	require.Len(s.T(), ps.Errors, 1)
+
+	tx := ps.Transactions[0]
+	s.Equal("HTTP 5xx", tx.Result)
+	s.Equal(resp.StatusCode, tx.Context.Response.StatusCode)
+
+	e := ps.Errors[0]
+	s.Equal(tx.ID, e.ParentID)
+	s.Equal(resp.StatusCode, e.Context.Response.StatusCode)
+}
+
+// TestPanicAfterWrite tests the behaviour of instrumented handlers
+// for routes which panic after writing headers. The handler is
+// expected to recover the panic without otherwise affecting the
+// response.
+func (s *HTTPTestSuite) TestPanicAfterWrite() {
+	resp, err := http.Get(s.server.URL + "/panic_after_write")
+	require.NoError(s.T(), err)
+	resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	s.Tracer.Flush(nil)
+	ps := s.Recorder.Payloads()
+	require.Len(s.T(), ps.Transactions, 1)
+	require.Len(s.T(), ps.Errors, 1)
+
+	tx := ps.Transactions[0]
+	s.Equal("HTTP 2xx", tx.Result)
+	s.Equal(resp.StatusCode, tx.Context.Response.StatusCode)
+
+	e := ps.Errors[0]
+	s.Equal(tx.ID, e.ParentID)
+	s.Equal(resp.StatusCode, e.Context.Response.StatusCode)
+}

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -94,6 +94,7 @@ func (m *middleware) handle(c *gin.Context) {
 			setContext(&e.Context, c, body)
 			e.Send()
 		}
+		c.Writer.WriteHeaderNow()
 		tx.Result = apmhttp.StatusCodeResult(c.Writer.Status())
 
 		if tx.Sampled() {
@@ -115,10 +116,8 @@ func setContext(ctx *apm.Context, c *gin.Context, body *apm.BodyCapturer) {
 	ctx.SetFramework("gin", gin.Version)
 	ctx.SetHTTPRequest(c.Request)
 	ctx.SetHTTPRequestBody(body)
-	if c.Writer.Written() {
-		ctx.SetHTTPStatusCode(c.Writer.Status())
-		ctx.SetHTTPResponseHeaders(c.Writer.Header())
-	}
+	ctx.SetHTTPStatusCode(c.Writer.Status())
+	ctx.SetHTTPResponseHeaders(c.Writer.Header())
 }
 
 // Option sets options for tracing.

--- a/module/apmhttp/handler_test.go
+++ b/module/apmhttp/handler_test.go
@@ -13,13 +13,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/http2"
 
 	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/model"
 	"go.elastic.co/apm/module/apmhttp"
 	"go.elastic.co/apm/transport/transporttest"
 )
+
+func TestHandlerHTTPSuite(t *testing.T) {
+	tracer, recorder := transporttest.NewRecorderTracer()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/implicit_write", func(w http.ResponseWriter, req *http.Request) {})
+	mux.HandleFunc("/panic_before_write", func(w http.ResponseWriter, req *http.Request) {
+		panic("boom")
+	})
+	mux.HandleFunc("/panic_after_write", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("hello, world"))
+		panic("boom")
+	})
+	suite.Run(t, &apmtest.HTTPTestSuite{
+		Handler:  apmhttp.Wrap(mux, apmhttp.WithTracer(tracer)),
+		Tracer:   tracer,
+		Recorder: recorder,
+	})
+}
 
 func TestHandler(t *testing.T) {
 	tracer, transport := transporttest.NewRecorderTracer()
@@ -229,6 +249,36 @@ func TestHandlerRecovery(t *testing.T) {
 	assert.Equal(t, &model.Response{
 		StatusCode: 418,
 	}, transaction.Context.Response)
+}
+
+func TestHandlerRecoveryNoHeaders(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	h := apmhttp.Wrap(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			panic("foo")
+		}),
+		apmhttp.WithTracer(tracer),
+	)
+
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Panic is translated into a 500 response.
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	error0 := payloads.Errors[0]
+	transaction := payloads.Transactions[0]
+
+	assert.Equal(t, &model.Response{StatusCode: resp.StatusCode}, transaction.Context.Response)
+	assert.Equal(t, &model.Response{StatusCode: resp.StatusCode}, error0.Context.Response)
 }
 
 func TestHandlerRequestIgnorer(t *testing.T) {

--- a/module/apmhttp/recovery.go
+++ b/module/apmhttp/recovery.go
@@ -21,6 +21,8 @@ type RecoveryFunc func(
 // The returned RecoveryFunc will report recovered error to Elastic APM
 // using the given Tracer, or apm.DefaultTracer if t is nil. The
 // error will be linked to the given transaction.
+//
+// If headers have not already been written, a 500 response will be sent.
 func NewTraceRecovery(t *apm.Tracer) RecoveryFunc {
 	if t == nil {
 		t = apm.DefaultTracer
@@ -35,7 +37,7 @@ func NewTraceRecovery(t *apm.Tracer) RecoveryFunc {
 	) {
 		e := t.Recovered(recovered)
 		e.SetTransaction(tx)
-		setContext(&e.Context, req, resp, body)
+		SetContext(&e.Context, req, resp, body)
 		e.Send()
 	}
 }

--- a/scripts/Dockerfile-testing
+++ b/scripts/Dockerfile-testing
@@ -31,6 +31,7 @@ RUN go get -v github.com/rcrowley/go-metrics
 RUN go get -v github.com/santhosh-tekuri/jsonschema
 RUN go get -v github.com/stretchr/testify/assert
 RUN go get -v github.com/stretchr/testify/require
+RUN go get -v github.com/stretchr/testify/suite
 RUN go get -v golang.org/x/net/context
 RUN go get -v golang.org/x/net/context/ctxhttp
 RUN go get -v golang.org/x/net/http2

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -35,6 +35,13 @@ type RecorderTransport struct {
 	payloads Payloads
 }
 
+// ResetPayloads clears out any recorded payloads.
+func (r *RecorderTransport) ResetPayloads() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.payloads = Payloads{}
+}
+
 // SendStream records the stream such that it can later be obtained via Payloads.
 func (r *RecorderTransport) SendStream(ctx context.Context, stream io.Reader) error {
 	return r.record(stream)


### PR DESCRIPTION
Introduce a basic HTTP test suite for each of
the web framework instrumentation modules to
run, to test functionality that is expected
to be common across each of them.

For now there are just a few tests for some
edge cases:

 - handler does not explicitly write a response
 - handler panics before writing a response
 - handler panics after writing a response

This uncovered a handful of bugs in the various
web instrumentation modules which have now
been fixed.

We exposed apmhttp.setContext as SetContext,
using it in apmrestful to set context. This allows us
to set the framework for errors originating from
go-restful handlers.

Fixes elastic/apm-agent-go#272 