### PR TITLE
Only permit DB statement to be 10000 runes

### DIFF
--- a/capturebody.go
+++ b/capturebody.go
@@ -85,7 +85,7 @@ func (bc *BodyCapturer) setContext(out *model.RequestBody) bool {
 		for k, v := range bc.request.PostForm {
 			vcopy := make([]string, len(v))
 			for i := range vcopy {
-				vcopy[i] = truncateText(v[i])
+				vcopy[i] = truncateString(v[i])
 			}
 			postForm[k] = vcopy
 		}
@@ -100,6 +100,6 @@ func (bc *BodyCapturer) setContext(out *model.RequestBody) bool {
 		// TODO(axw) log error?
 		return false
 	}
-	out.Raw = truncateText(string(all))
+	out.Raw = truncateString(string(all))
 	return true
 }

--- a/context.go
+++ b/context.go
@@ -70,7 +70,7 @@ func (c *Context) SetTag(key, value string) {
 	if !validTagKey(key) {
 		return
 	}
-	value = truncateKeyword(value)
+	value = truncateString(value)
 	if c.model.Tags == nil {
 		c.model.Tags = map[string]string{key: value}
 	} else {
@@ -94,8 +94,8 @@ func (c *Context) SetFramework(name, version string) {
 		version = "unspecified"
 	}
 	c.serviceFramework = model.Framework{
-		Name:    truncateKeyword(name),
-		Version: truncateKeyword(version),
+		Name:    truncateString(name),
+		Version: truncateString(version),
 	}
 	c.service.Framework = &c.serviceFramework
 	c.model.Service = &c.service
@@ -134,7 +134,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 	c.request = model.Request{
 		Body:        c.request.Body,
 		URL:         apmhttputil.RequestURL(req, forwarded),
-		Method:      truncateKeyword(req.Method),
+		Method:      truncateString(req.Method),
 		HTTPVersion: httpVersion,
 		Cookies:     req.Cookies(),
 	}
@@ -142,7 +142,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 
 	c.requestHeaders = model.RequestHeaders{
 		ContentType: req.Header.Get("Content-Type"),
-		Cookie:      truncateText(strings.Join(req.Header["Cookie"], ";")),
+		Cookie:      truncateString(strings.Join(req.Header["Cookie"], ";")),
 		UserAgent:   req.UserAgent(),
 	}
 	if c.requestHeaders != (model.RequestHeaders{}) {
@@ -161,7 +161,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 	if !ok && req.URL.User != nil {
 		username = req.URL.User.Username()
 	}
-	c.user.Username = truncateKeyword(username)
+	c.user.Username = truncateString(username)
 	if c.user.Username != "" {
 		c.model.User = &c.user
 	}
@@ -195,7 +195,7 @@ func (c *Context) SetHTTPStatusCode(statusCode int) {
 
 // SetUserID sets the ID of the authenticated user.
 func (c *Context) SetUserID(id string) {
-	c.user.ID = truncateKeyword(id)
+	c.user.ID = truncateString(id)
 	if c.user.ID != "" {
 		c.model.User = &c.user
 	}
@@ -203,7 +203,7 @@ func (c *Context) SetUserID(id string) {
 
 // SetUserEmail sets the email for the authenticated user.
 func (c *Context) SetUserEmail(email string) {
-	c.user.Email = truncateKeyword(email)
+	c.user.Email = truncateString(email)
 	if c.user.Email != "" {
 		c.model.User = &c.user
 	}
@@ -211,7 +211,7 @@ func (c *Context) SetUserEmail(email string) {
 
 // SetUsername sets the username of the authenticated user.
 func (c *Context) SetUsername(username string) {
-	c.user.Username = truncateKeyword(username)
+	c.user.Username = truncateString(username)
 	if c.user.Username != "" {
 		c.model.User = &c.user
 	}

--- a/error.go
+++ b/error.go
@@ -65,7 +65,7 @@ func (t *Tracer) NewError(err error) *Error {
 	}
 	e := t.newError()
 	rand.Read(e.ID[:]) // ignore error, can't do anything about it
-	e.model.Exception.Message = truncateText(err.Error())
+	e.model.Exception.Message = truncateString(err.Error())
 	if e.model.Exception.Message == "" {
 		e.model.Exception.Message = "[EMPTY]"
 	}
@@ -86,10 +86,10 @@ func (t *Tracer) NewError(err error) *Error {
 func (t *Tracer) NewErrorLog(r ErrorLogRecord) *Error {
 	e := t.newError()
 	e.model.Log = model.Log{
-		Message:      truncateText(r.Message),
-		Level:        truncateKeyword(r.Level),
-		LoggerName:   truncateKeyword(r.LoggerName),
-		ParamMessage: truncateKeyword(r.MessageFormat),
+		Message:      truncateString(r.Message),
+		Level:        truncateString(r.Level),
+		LoggerName:   truncateString(r.LoggerName),
+		ParamMessage: truncateString(r.MessageFormat),
 	}
 	if e.model.Log.Message == "" {
 		e.model.Log.Message = "[EMPTY]"
@@ -301,8 +301,8 @@ func initException(e *model.Exception, err error) {
 	if errTimeout(err) {
 		setAttr("timeout", true)
 	}
-	e.Code.String = truncateKeyword(e.Code.String)
-	e.Type = truncateKeyword(e.Type)
+	e.Code.String = truncateString(e.Code.String)
+	e.Type = truncateString(e.Type)
 }
 
 func initStacktrace(e *Error, err error) {

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -78,9 +78,9 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 	out.TraceID = model.TraceID(tx.traceContext.Trace)
 	out.ParentID = model.SpanID(tx.parentSpan)
 
-	out.Name = truncateKeyword(tx.Name)
-	out.Type = truncateKeyword(tx.Type)
-	out.Result = truncateKeyword(tx.Result)
+	out.Name = truncateString(tx.Name)
+	out.Type = truncateString(tx.Type)
+	out.Result = truncateString(tx.Result)
 	out.Timestamp = model.Time(tx.timestamp.UTC())
 	out.Duration = tx.Duration.Seconds() * 1000
 	out.SpanCount.Started = tx.spansCreated
@@ -103,8 +103,8 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span) {
 	out.ParentID = model.SpanID(span.parentID)
 	out.TransactionID = model.SpanID(span.transactionID)
 
-	out.Name = truncateKeyword(span.Name)
-	out.Type = truncateKeyword(span.Type)
+	out.Name = truncateString(span.Name)
+	out.Type = truncateString(span.Type)
 	out.Timestamp = model.Time(span.timestamp.UTC())
 	out.Duration = span.Duration.Seconds() * 1000
 	out.Context = span.Context.build()

--- a/spancontext.go
+++ b/spancontext.go
@@ -51,7 +51,7 @@ func (c *SpanContext) SetTag(key, value string) {
 	if !validTagKey(key) {
 		return
 	}
-	value = truncateKeyword(value)
+	value = truncateString(value)
 	if c.model.Tags == nil {
 		c.model.Tags = map[string]string{key: value}
 	} else {
@@ -62,10 +62,10 @@ func (c *SpanContext) SetTag(key, value string) {
 // SetDatabase sets the span context for database-related operations.
 func (c *SpanContext) SetDatabase(db DatabaseSpanContext) {
 	c.database = model.DatabaseSpanContext{
-		Instance:  truncateKeyword(db.Instance),
-		Statement: truncateText(db.Statement),
-		Type:      truncateKeyword(db.Type),
-		User:      truncateKeyword(db.User),
+		Instance:  truncateString(db.Instance),
+		Statement: truncateLongString(db.Statement),
+		Type:      truncateString(db.Type),
+		User:      truncateString(db.User),
 	}
 	c.model.Database = &c.database
 }

--- a/utils.go
+++ b/utils.go
@@ -45,16 +45,16 @@ func getCurrentProcess() model.Process {
 	return model.Process{
 		Pid:   os.Getpid(),
 		Ppid:  &ppid,
-		Title: truncateKeyword(title),
+		Title: truncateString(title),
 		Argv:  os.Args,
 	}
 }
 
 func makeService(name, version, environment string) model.Service {
 	return model.Service{
-		Name:        truncateKeyword(name),
-		Version:     truncateKeyword(version),
-		Environment: truncateKeyword(environment),
+		Name:        truncateString(name),
+		Version:     truncateString(version),
+		Environment: truncateString(environment),
 		Agent:       &goAgent,
 		Language:    &goLanguage,
 		Runtime:     &goRuntime,
@@ -72,7 +72,7 @@ func getLocalSystem() model.System {
 			system.Hostname = hostname
 		}
 	}
-	system.Hostname = truncateKeyword(system.Hostname)
+	system.Hostname = truncateString(system.Hostname)
 	return system
 }
 
@@ -95,17 +95,18 @@ func sanitizeServiceName(name string) string {
 	return serviceNameInvalidRegexp.ReplaceAllString(name, "_")
 }
 
-func truncateKeyword(s string) string {
+func truncateString(s string) string {
 	// At the time of writing, all keyword length
 	// limits are 1024, enforced by JSON Schema.
 	return apmstrings.Truncate(s, 1024)
 }
 
-func truncateText(s string) string {
-	// Non-keyword string fields should be limited
-	// to 10000 characters/runes. This is not
-	// currently enforced by JSON Schema, as we
-	// may want to make it configurable.
+func truncateLongString(s string) string {
+	// Non-keyword string fields are not limited
+	// in length by JSON Schema, but we still
+	// truncate all strings. Some strings, such
+	// as database statement, we explicitly allow
+	// to be longer than others.
 	return apmstrings.Truncate(s, 10000)
 }
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -76,7 +76,7 @@ func TestValidateDatabaseSpanContextInstance(t *testing.T) {
 	validateSpan(t, func(s *apm.Span) {
 		s.Context.SetDatabase(apm.DatabaseSpanContext{
 			Instance:  strings.Repeat("x", 1025),
-			Statement: strings.Repeat("x", 10001),
+			Statement: strings.Repeat("x", 1025),
 			Type:      strings.Repeat("x", 1025),
 			User:      strings.Repeat("x", 1025),
 		})
@@ -156,7 +156,7 @@ func TestValidateRequestBody(t *testing.T) {
 			tx := tracer.StartTransaction("name", "type")
 			defer tx.End()
 
-			body := strings.NewReader(strings.Repeat("x", 10001))
+			body := strings.NewReader(strings.Repeat("x", 1025))
 			req, _ := http.NewRequest("GET", "/", body)
 			captureBody := tracer.CaptureHTTPRequestBody(req)
 			tx.Context.SetHTTPRequest(req)
@@ -171,7 +171,7 @@ func TestValidateRequestBody(t *testing.T) {
 
 			req, _ := http.NewRequest("GET", "/", strings.NewReader("x"))
 			req.PostForm = url.Values{
-				"unsanitized_field": []string{strings.Repeat("x", 10001)},
+				"unsanitized_field": []string{strings.Repeat("x", 1025)},
 			}
 			captureBody := tracer.CaptureHTTPRequestBody(req)
 			tx.Context.SetHTTPRequest(req)
@@ -216,7 +216,7 @@ func TestValidateErrorException(t *testing.T) {
 	t.Run("long_message", func(t *testing.T) {
 		validatePayloads(t, func(tracer *apm.Tracer) {
 			tracer.NewError(&testError{
-				message: strings.Repeat("x", 10001),
+				message: strings.Repeat("x", 1025),
 			}).Send()
 		})
 	})
@@ -244,7 +244,7 @@ func TestValidateErrorLog(t *testing.T) {
 			Message: "",
 		},
 		"long_message": {
-			Message: strings.Repeat("x", 10001),
+			Message: strings.Repeat("x", 1025),
 		},
 		"level": {
 			Message: "x",


### PR DESCRIPTION
Truncate database statements at 10000 runes, and all other strings at 1024 runes.