### PR TITLE
apm: remove Context.SetCustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
  - Fix panic handling in web instrumentations (#273)
  - Migrate internal/fastjson to go.elastic.co/fastjson (#275)
  - Report all HTTP request/response headers (#280)
+ - Drop Context.SetCustom (#284)
 
 ## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
 

--- a/context.go
+++ b/context.go
@@ -27,7 +27,6 @@ func (c *Context) build() *model.Context {
 	case c.model.Response != nil:
 	case c.model.User != nil:
 	case c.model.Service != nil:
-	case len(c.model.Custom) != 0:
 	case len(c.model.Tags) != 0:
 	default:
 		return nil
@@ -36,10 +35,8 @@ func (c *Context) build() *model.Context {
 }
 
 func (c *Context) reset() {
-	modelContext := model.Context{
-		// TODO(axw) reuse space for tags
-		Custom: c.model.Custom[:0],
-	}
+	// TODO(axw) reuse space for tags
+	modelContext := model.Context{}
 	*c = Context{
 		model:           modelContext,
 		captureBodyMask: c.captureBodyMask,
@@ -50,21 +47,6 @@ func (c *Context) reset() {
 			Headers: c.response.Headers[:0],
 		},
 	}
-}
-
-// SetCustom sets a custom context key/value pair. If the key is invalid
-// (contains '.', '*', or '"'), the call is a no-op. The value must be
-// JSON-encodable.
-//
-// If value implements interface{AppendJSON([]byte) []byte}, that will be
-// used to encode the value. Otherwise, value will be encoded using
-// json.Marshal. As a special case, values of type map[string]interface{}
-// will be traversed and values encoded according to the same rules.
-func (c *Context) SetCustom(key string, value interface{}) {
-	if !validTagKey(key) {
-		return
-	}
-	c.model.Custom.Set(key, value)
 }
 
 // SetTag sets a tag in the context. If the key is invalid

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -64,7 +64,6 @@ further describe the transaction.
 ----
 transaction.Result = "Success"
 transaction.Context.SetTag("region", "us-east-1")
-transaction.Context.SetCustom("key", "value")
 ----
 
 See <<context-api>> for more details on setting transaction context.
@@ -254,15 +253,6 @@ SetTag tags the transaction or error with the given key and value. The
 key must not contain any special characters (`.`, `*`, or `"`). Values
 longer than 1024 characters will be truncated. Tags will be indexed in
 Elasticsearch as keyword fields.
-
-[float]
-[[context-set-custom]]
-==== `func (*Context) SetCustom(key string, value interface{})`
-
-SetCustom associates arbitrary context with the transaction or error. The
-only restriction is that the name may not contain any special characters
-(`.`, `*`, or `"`), and the value must be JSON-encodable. Custom context
-will not be indexed in Elasticsearch, but will be included in the document.
 
 [float]
 [[context-set-username]]

--- a/example_test.go
+++ b/example_test.go
@@ -105,14 +105,14 @@ func ExampleTracer() {
 	//   transaction 0:
 	//     name: order
 	//     type: request
-	//     context: map[custom:map[product:fish fingers]]
+	//     context: map[tags:map[product:fish fingers]]
 	//     span 0:
 	//       name: store_order
 	//       type: rpc
 	//   transaction 1:
 	//     name: order
 	//     type: request
-	//     context: map[custom:map[product:detergent]]
+	//     context: map[tags:map[product:detergent]]
 	//     span 1:
 	//       name: store_order
 	//       type: rpc
@@ -127,7 +127,7 @@ func (api *api) handleOrder(ctx context.Context, product string) {
 	defer tx.End()
 	ctx = apm.ContextWithTransaction(ctx, tx)
 
-	tx.Context.SetCustom("product", product)
+	tx.Context.SetTag("product", product)
 
 	time.Sleep(10 * time.Millisecond)
 	storeOrder(ctx, product)

--- a/gofuzz.go
+++ b/gofuzz.go
@@ -44,9 +44,6 @@ func Fuzz(data []byte) int {
 		if in == nil {
 			return nil
 		}
-		for _, item := range in.Custom {
-			out.SetCustom(item.Key, item.Value)
-		}
 		for k, v := range in.Tags {
 			out.SetTag(k, v)
 		}

--- a/model/maps.go
+++ b/model/maps.go
@@ -4,33 +4,6 @@ import (
 	"sort"
 )
 
-// IfaceMap is a slice-representation of map[string]interface{},
-// optimized for fast JSON encoding.
-//
-// Slice items are expected to be ordered by key.
-type IfaceMap []IfaceMapItem
-
-// IfaceMapItem holds a string key and arbitrary JSON-encodable value.
-type IfaceMapItem struct {
-	// Key is the map item's key.
-	Key string
-
-	// Value is an arbitrary JSON-encodable value.
-	Value interface{}
-}
-
-// Set sets the map item with given key and value.
-func (m *IfaceMap) Set(key string, value interface{}) {
-	i := sort.Search(len(*m), func(i int) bool {
-		return (*m)[i].Key >= key
-	})
-	if i < len(*m) && (*m)[i].Key == key {
-		(*m)[i].Value = value
-	} else {
-		*m = append(*m, IfaceMapItem{Key: key, Value: value})
-	}
-}
-
 // StringMap is a slice-representation of map[string]string,
 // optimized for fast JSON encoding.
 //

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -469,51 +469,6 @@ func (b *RequestBody) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (m IfaceMap) isZero() bool {
-	return len(m) == 0
-}
-
-// MarshalFastJSON writes the JSON representation of m to w.
-func (m IfaceMap) MarshalFastJSON(w *fastjson.Writer) (firstErr error) {
-	w.RawByte('{')
-	first := true
-	for _, item := range m {
-		if first {
-			first = false
-		} else {
-			w.RawByte(',')
-		}
-		w.String(item.Key)
-		w.RawByte(':')
-		if err := fastjson.Marshal(w, item.Value); err != nil && firstErr == nil {
-			firstErr = err
-		}
-	}
-	w.RawByte('}')
-	return nil
-}
-
-// UnmarshalJSON unmarshals the JSON data into m.
-func (m *IfaceMap) UnmarshalJSON(data []byte) error {
-	var mm map[string]interface{}
-	if err := json.Unmarshal(data, &mm); err != nil {
-		return err
-	}
-	*m = make(IfaceMap, 0, len(mm))
-	for k, v := range mm {
-		*m = append(*m, IfaceMapItem{Key: k, Value: v})
-	}
-	sort.Slice(*m, func(i, j int) bool {
-		return (*m)[i].Key < (*m)[j].Key
-	})
-	return nil
-}
-
-// MarshalFastJSON exists to prevent code generation for IfaceMapItem.
-func (*IfaceMapItem) MarshalFastJSON(*fastjson.Writer) error {
-	panic("unreachable")
-}
-
 func (m StringMap) isZero() bool {
 	return len(m) == 0
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -418,18 +418,6 @@ func (v *Context) MarshalFastJSON(w *fastjson.Writer) error {
 	var firstErr error
 	w.RawByte('{')
 	first := true
-	if !v.Custom.isZero() {
-		const prefix = ",\"custom\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		if err := v.Custom.MarshalFastJSON(w); err != nil && firstErr == nil {
-			firstErr = err
-		}
-	}
 	if v.Request != nil {
 		const prefix = ",\"request\":"
 		if first {

--- a/model/model.go
+++ b/model/model.go
@@ -239,9 +239,6 @@ type Context struct {
 	// transaction or error, if relevant.
 	User *User `json:"user,omitempty"`
 
-	// Custom holds arbitrary additional metadata.
-	Custom IfaceMap `json:"custom,omitempty"`
-
 	// Tags holds user-defined key/value pairs.
 	Tags map[string]string `json:"tags,omitempty"`
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -100,28 +100,6 @@ func TestValidateContextUserBasicAuth(t *testing.T) {
 	})
 }
 
-func TestValidateContextCustom(t *testing.T) {
-	t.Run("long_key", func(t *testing.T) {
-		// NOTE(axw) this should probably fail, but does not. See:
-		// https://github.com/elastic/apm-server/issues/910
-		validateTransaction(t, func(tx *apm.Transaction) {
-			tx.Context.SetCustom(strings.Repeat("x", 1025), "x")
-		})
-	})
-	t.Run("reserved_key_chars", func(t *testing.T) {
-		validateTransaction(t, func(tx *apm.Transaction) {
-			tx.Context.SetCustom("x.y", "z")
-		})
-	})
-	t.Run("newline_value", func(t *testing.T) {
-		validateTransaction(t, func(tx *apm.Transaction) {
-			// Newlines should be escaped by the JSON encoder,
-			// so they don't interfere with NDJSON encoding.
-			tx.Context.SetCustom("key", "value\nwith\nnewlines")
-		})
-	})
-}
-
 func TestValidateContextTags(t *testing.T) {
 	t.Run("long_key", func(t *testing.T) {
 		// NOTE(axw) this should probably fail, but does not. See:


### PR DESCRIPTION
Remove the ability to set custom context from
instrumentation modules. It's unclear whether
we will retain this feature, or consolidate on
tags. Until we've made a decision on that, we'll
keep it out of the API for new agents.

Closes elastic/apm-agent-go#282