### PR TITLE
Reuse tags memory

### DIFF
--- a/context.go
+++ b/context.go
@@ -35,10 +35,10 @@ func (c *Context) build() *model.Context {
 }
 
 func (c *Context) reset() {
-	// TODO(axw) reuse space for tags
-	modelContext := model.Context{}
 	*c = Context{
-		model:           modelContext,
+		model: model.Context{
+			Tags: c.model.Tags[:0],
+		},
 		captureBodyMask: c.captureBodyMask,
 		request: model.Request{
 			Headers: c.request.Headers[:0],
@@ -56,11 +56,12 @@ func (c *Context) SetTag(key, value string) {
 		return
 	}
 	value = truncateString(value)
-	if c.model.Tags == nil {
-		c.model.Tags = map[string]string{key: value}
-	} else {
-		c.model.Tags[key] = value
-	}
+	// Note that we do not attempt to de-duplicate the keys.
+	// This is OK, since json.Unmarshal will always take the
+	// final instance.
+	c.model.Tags = append(c.model.Tags, model.StringMapItem{
+		Key: key, Value: value,
+	})
 }
 
 // SetFramework sets the framework name and version in the context.

--- a/context_test.go
+++ b/context_test.go
@@ -12,6 +12,18 @@ import (
 	"go.elastic.co/apm/model"
 )
 
+func TestContextTags(t *testing.T) {
+	tx := testSendTransaction(t, func(tx *apm.Transaction) {
+		tx.Context.SetTag("foo", "bar")
+		tx.Context.SetTag("foo", "bar!") // Last instance wins
+		tx.Context.SetTag("bar", "baz")
+	})
+	assert.Equal(t, model.StringMap{
+		{Key: "bar", Value: "baz"},
+		{Key: "foo", Value: "bar!"},
+	}, tx.Context.Tags)
+}
+
 func TestContextUser(t *testing.T) {
 	t.Run("email", func(t *testing.T) {
 		tx := testSendTransaction(t, func(tx *apm.Transaction) {

--- a/model/maps.go
+++ b/model/maps.go
@@ -1,9 +1,5 @@
 package model
 
-import (
-	"sort"
-)
-
 // StringMap is a slice-representation of map[string]string,
 // optimized for fast JSON encoding.
 //
@@ -17,16 +13,4 @@ type StringMapItem struct {
 
 	// Value is the map item's value.
 	Value string
-}
-
-// Set sets the map item with given key and value.
-func (m *StringMap) Set(key, value string) {
-	i := sort.Search(len(*m), func(i int) bool {
-		return (*m)[i].Key >= key
-	})
-	if i < len(*m) && (*m)[i].Key == key {
-		(*m)[i].Value = value
-	} else {
-		*m = append(*m, StringMapItem{Key: key, Value: value})
-	}
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -339,7 +339,7 @@ func (v *SpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
-	if v.Tags != nil {
+	if !v.Tags.isZero() {
 		const prefix = ",\"tags\":"
 		if first {
 			first = false
@@ -347,21 +347,9 @@ func (v *SpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 		} else {
 			w.RawString(prefix)
 		}
-		w.RawByte('{')
-		{
-			first := true
-			for k, v := range v.Tags {
-				if first {
-					first = false
-				} else {
-					w.RawByte(',')
-				}
-				w.String(k)
-				w.RawByte(':')
-				w.String(v)
-			}
+		if err := v.Tags.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
 		}
-		w.RawByte('}')
 	}
 	w.RawByte('}')
 	return firstErr
@@ -454,7 +442,7 @@ func (v *Context) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
-	if v.Tags != nil {
+	if !v.Tags.isZero() {
 		const prefix = ",\"tags\":"
 		if first {
 			first = false
@@ -462,21 +450,9 @@ func (v *Context) MarshalFastJSON(w *fastjson.Writer) error {
 		} else {
 			w.RawString(prefix)
 		}
-		w.RawByte('{')
-		{
-			first := true
-			for k, v := range v.Tags {
-				if first {
-					first = false
-				} else {
-					w.RawByte(',')
-				}
-				w.String(k)
-				w.RawByte(':')
-				w.String(v)
-			}
+		if err := v.Tags.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
 		}
-		w.RawByte('}')
 	}
 	if v.User != nil {
 		const prefix = ",\"user\":"

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -467,9 +467,9 @@ func fakeTransaction() model.Transaction {
 			User: &model.User{
 				Username: "wanda",
 			},
-			Tags: map[string]string{
-				"tag": "urit",
-			},
+			Tags: model.StringMap{{
+				Key: "tag", Value: "urit",
+			}},
 			Service: &model.Service{
 				Framework: &model.Framework{
 					Name:    "framework-name",

--- a/model/model.go
+++ b/model/model.go
@@ -198,7 +198,7 @@ type SpanContext struct {
 	HTTP *HTTPSpanContext `json:"http,omitempty"`
 
 	// Tags holds user-defined key/value pairs.
-	Tags map[string]string `json:"tags,omitempty"`
+	Tags StringMap `json:"tags,omitempty"`
 }
 
 // DatabaseSpanContext holds contextual information for database
@@ -240,7 +240,7 @@ type Context struct {
 	User *User `json:"user,omitempty"`
 
 	// Tags holds user-defined key/value pairs.
-	Tags map[string]string `json:"tags,omitempty"`
+	Tags StringMap `json:"tags,omitempty"`
 
 	// Service holds values to overrides service-level metadata.
 	Service *Service `json:"service,omitempty"`

--- a/module/apmot/tracer_test.go
+++ b/module/apmot/tracer_test.go
@@ -215,8 +215,8 @@ func TestCustomTags(t *testing.T) {
 	payloads := recorder.Payloads()
 	require.Len(t, payloads.Transactions, 1)
 	require.Len(t, payloads.Spans, 1)
-	assert.Equal(t, map[string]string{"foo": "bar"}, payloads.Transactions[0].Context.Tags)
-	assert.Equal(t, map[string]string{"baz": "qux"}, payloads.Spans[0].Context.Tags)
+	assert.Equal(t, model.StringMap{{Key: "foo", Value: "bar"}}, payloads.Transactions[0].Context.Tags)
+	assert.Equal(t, model.StringMap{{Key: "baz", Value: "qux"}}, payloads.Spans[0].Context.Tags)
 }
 
 func TestStartSpanFromContextMixed(t *testing.T) {

--- a/spancontext_test.go
+++ b/spancontext_test.go
@@ -1,0 +1,28 @@
+package apm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/model"
+)
+
+func TestSpanContextSetTag(t *testing.T) {
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		span, _ := apm.StartSpan(ctx, "name", "type")
+		span.Context.SetTag("foo", "bar")
+		span.Context.SetTag("foo", "bar!") // Last instance wins
+		span.Context.SetTag("bar", "baz")
+		span.End()
+	})
+	require.Len(t, spans, 1)
+	assert.Equal(t, model.StringMap{
+		{Key: "bar", Value: "baz"},
+		{Key: "foo", Value: "bar!"},
+	}, spans[0].Context.Tags)
+}


### PR DESCRIPTION
Update model.Context.Tags and model.SpanContext.Tags
to use the model.StringMap type, which is a slice of
key/value pairs. Storing tags is now just an append,
with no de-duplication (the server will de-duplicate
when unmarshalling). When resetting transaction and
span objects, we'll now reuse these tags slices.

Closes #283