### PR TITLE
Implement test service for w3c/distributed-tracing harness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,14 @@ script:
 jobs:
   include:
     - os: osx     
+
+    - name: "W3C Distributed Tracing Validation"
+      sudo: required
+      services:
+        - docker
+      script:
+        - scripts/docker-compose-testing run -T --rm trace-context-harness
+
     - stage: coverage
       sudo: required
       services:

--- a/internal/tracecontexttest/Dockerfile
+++ b/internal/tracecontexttest/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:latest
+WORKDIR /go/src/go.elastic.co/apm
+RUN go get -v github.com/pkg/errors
+RUN go get -v go.elastic.co/fastjson
+RUN go get -v golang.org/x/net/context
+RUN go get -v golang.org/x/net/context/ctxhttp
+
+ADD . /go/src/go.elastic.co/apm
+EXPOSE 5000/tcp
+CMD go run internal/tracecontexttest/main.go

--- a/internal/tracecontexttest/Dockerfile-harness
+++ b/internal/tracecontexttest/Dockerfile-harness
@@ -1,0 +1,10 @@
+FROM alpine:latest
+WORKDIR /w3c
+RUN apk add --no-cache git
+RUN git clone https://github.com/w3c/distributed-tracing.git
+
+FROM python:3
+RUN pip install aiohttp
+WORKDIR /w3c/distributed-tracing
+COPY --from=0 /w3c/distributed-tracing .
+EXPOSE 7777/tcp

--- a/internal/tracecontexttest/main.go
+++ b/internal/tracecontexttest/main.go
@@ -1,0 +1,181 @@
+// Copyright 2018 Elasticsearch BV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program is a test service for the W3C Distributed Tracing test harness:
+//     https://github.com/w3c/trace-context/tree/master/test
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"go.elastic.co/apm/module/apmhttp"
+)
+
+var (
+	listenAddr = flag.String("listen", ":5000", "Address to listen on for test requests")
+)
+
+const (
+	standardTraceparentHeader = "Traceparent"
+	standardTracestateHeader  = "Tracestate"
+)
+
+var (
+	tracestateKeyRegexp = regexp.MustCompile(`^[a-z](([a-z0-9_*/-]{0,255})|([a-z0-9_*/-]{0,240}@[a-z][a-z0-9_*/-]{0,13}))$`)
+)
+
+func main() {
+	flag.Parse()
+
+	type TestCase struct {
+		URL  string            `json:"url"`
+		Args []json.RawMessage `json:"arguments,omitempty"`
+	}
+
+	client := http.DefaultClient
+	client.Transport = compatRoundTripper{roundTripper: http.DefaultTransport}
+	client = apmhttp.WrapClient(client)
+
+	var handler http.HandlerFunc = func(w http.ResponseWriter, req *http.Request) {
+		// We don't handle Tracestate in Elastic APM currently,
+		// so we implement it in this test service just to pass
+		// the test suite.
+		var traceState traceState
+		var traceStateOK bool
+		if _, ok := req.Header[apmhttp.TraceparentHeader]; ok {
+			if values, ok := req.Header[standardTracestateHeader]; ok {
+				traceStateOK = traceState.init(values...)
+			}
+		}
+
+		var testCases []TestCase
+		if err := json.NewDecoder(req.Body).Decode(&testCases); err != nil {
+			log.Printf("decoding error: %s", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		for _, tc := range testCases {
+			var buf bytes.Buffer
+			if err := json.NewEncoder(&buf).Encode(tc.Args); err != nil {
+				log.Printf("encoding error: %s", err)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			outReq, err := http.NewRequest("POST", tc.URL, &buf)
+			if err != nil {
+				log.Printf("error creating request: %s", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				continue
+			}
+			outReq = outReq.WithContext(req.Context())
+			outReq.Header.Set("Content-Type", "application/json")
+			if traceStateOK {
+				outReq.Header.Set(standardTracestateHeader, traceState.String())
+			}
+
+			resp, err := client.Do(outReq)
+			if err != nil {
+				log.Printf("error sending request: %s", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				log.Printf("status: %s", resp.Status)
+			}
+		}
+	}
+	log.Printf("Starting Trace-Context test service, listening on %s", *listenAddr)
+	log.Fatal(http.ListenAndServe(*listenAddr, compatHandler(apmhttp.Wrap(handler))))
+}
+
+// compatRoundTripper renames Elastic-Apm-Traceparent headers to Traceparent.
+type compatRoundTripper struct {
+	roundTripper http.RoundTripper
+}
+
+func (t compatRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	headerValues, ok := req.Header[apmhttp.TraceparentHeader]
+	if ok {
+		req.Header[standardTraceparentHeader] = headerValues
+		req.Header.Del(apmhttp.TraceparentHeader)
+	}
+	return t.roundTripper.RoundTrip(req)
+}
+
+// compatHandler renames Traceparent headers to Elastic-Apm-Traceparent.
+func compatHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		headerValues, ok := req.Header[standardTraceparentHeader]
+		if ok {
+			req.Header[apmhttp.TraceparentHeader] = headerValues
+			req.Header.Del(standardTraceparentHeader)
+		}
+		h.ServeHTTP(w, req)
+	})
+}
+
+type traceState []traceStateItem
+
+func (s *traceState) init(vs ...string) bool {
+	recorded := make(map[string]bool)
+	*s = (*s)[:0]
+	for _, v := range vs {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return false
+		}
+		for _, field := range strings.Split(v, ",") {
+			kv := strings.SplitN(strings.TrimSpace(field), "=", 2)
+			if len(kv) != 2 {
+				return false
+			}
+			item := traceStateItem{key: kv[0], value: kv[1]}
+			if !tracestateKeyRegexp.MatchString(item.key) {
+				return false
+			}
+			if len(item.value) > 256 {
+				return false
+			}
+			if recorded[item.key] {
+				return false
+			}
+			recorded[item.key] = true
+			*s = append(*s, item)
+		}
+	}
+	return len(*s) <= 32
+}
+
+func (s *traceState) String() string {
+	fields := make([]string, len(*s))
+	for i, item := range *s {
+		fields[i] = fmt.Sprintf("%s=%s", item.key, item.value)
+	}
+	return strings.Join(fields, ",")
+}
+
+type traceStateItem struct {
+	key   string
+	value string
+}

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -80,9 +80,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // returned with the transaction added to its context.
 func StartTransaction(tracer *apm.Tracer, name string, req *http.Request) (*apm.Transaction, *http.Request) {
 	var opts apm.TransactionOptions
-	if v := req.Header.Get(TraceparentHeader); v != "" {
-		c, err := ParseTraceparentHeader(v)
-		if err == nil {
+	if values := req.Header[TraceparentHeader]; len(values) == 1 && values[0] != "" {
+		if c, err := ParseTraceparentHeader(values[0]); err == nil {
 			opts.TraceContext = c
 		}
 	}

--- a/module/apmhttp/traceheaders_test.go
+++ b/module/apmhttp/traceheaders_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmhttp"
@@ -20,17 +19,33 @@ func TestParseTraceparentHeader(t *testing.T) {
 	assertParseError("", `invalid traceparent header ""`)
 	assertParseError("00~", `invalid traceparent header "00~"`)
 	assertParseError("zz-", `error decoding traceparent header version: encoding/hex: invalid byte:.*`)
-	assertParseError("fe-", "traceparent header version 254 is unknown")
 	assertParseError("ff-", "traceparent header version 255 is forbidden")
 
 	assertParseError("00-0-0-01", `invalid version 0 traceparent header`)
 	assertParseError("00-0af7651916cd43dd8448eb211c80319c~b7ad6b7169203331-01", `invalid version 0 traceparent header`)
 	assertParseError("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331~01", `invalid version 0 traceparent header`)
+	assertParseError("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-", `invalid version 0 traceparent header`)
+	assertParseError("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-zz", `error decoding trace-options for version 0`)
+	assertParseError("00-0af7651916cd43dd8448eb211c80319c-zzzzzzzzzzzzzzzz-zz", `error decoding span-id for version 0`)
+	assertParseError("00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-zzzzzzzzzzzzzzzz-zz", `error decoding trace-id for version 0: .*`)
 
-	out, err := apmhttp.ParseTraceparentHeader("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
-	require.NoError(t, err)
-	assert.Equal(t, "\x0a\xf7\x65\x19\x16\xcd\x43\xdd\x84\x48\xeb\x21\x1c\x80\x31\x9c", string(out.Trace[:]))
-	assert.Equal(t, "\xb7\xad\x6b\x71\x69\x20\x33\x31", string(out.Span[:]))
-	assert.Equal(t, apm.TraceOptions(1), out.Options)
-	assert.True(t, out.Options.Recorded())
+	assertParse := func(h string) (apm.TraceContext, bool) {
+		out, err := apmhttp.ParseTraceparentHeader(h)
+		return out, assert.NoError(t, err)
+	}
+
+	// "If higher version is detected - implementation SHOULD try to parse it."
+	//        -- https://w3c.github.io/trace-context/#versioning-of-traceparent
+	for _, versionPrefix := range []string{"00", "fe"} {
+		if out, ok := assertParse(versionPrefix + "-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"); ok {
+			assert.Equal(t, "\x0a\xf7\x65\x19\x16\xcd\x43\xdd\x84\x48\xeb\x21\x1c\x80\x31\x9c", string(out.Trace[:]))
+			assert.Equal(t, "\xb7\xad\x6b\x71\x69\x20\x33\x31", string(out.Span[:]))
+			assert.Equal(t, apm.TraceOptions(1), out.Options)
+			assert.True(t, out.Options.Recorded())
+		}
+	}
+
+	// For an unknown version, there may be a trailing string trailing string, but it must start with "-".
+	assertParse("fe-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-foo")
+	assertParseError("fe-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01.foo", `invalid version 254 traceparent header`)
 }

--- a/scripts/docker-compose-testing.yml
+++ b/scripts/docker-compose-testing.yml
@@ -21,6 +21,19 @@ services:
       - postgres
       - redis
 
+  trace-context-service:
+    build:
+      context: ..
+      dockerfile: internal/tracecontexttest/Dockerfile
+
+  trace-context-harness:
+    build:
+      context: ../internal/tracecontexttest
+      dockerfile: Dockerfile-harness
+    command: /bin/bash -c 'HARNESS_HOST=$$HOSTNAME python test/test.py http://trace-context-service:5000/'
+    depends_on:
+      - trace-context-service
+
   mysql:
     image: mysql:latest
     environment:


### PR DESCRIPTION
Implement a test service for running the w3c/distributed-tracing test harness, run as a pair of docker-compose services. This showed up a couple of minor issues in our header handling, which are also fixed by this PR.

Closes https://github.com/elastic/apm-agent-go/issues/291