### PR TITLE
README: link elastic.co docs, ref supported tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 This is the official Go package for [Elastic APM](https://www.elastic.co/solutions/apm).
 
 The Go agent enables you to trace the execution of operations in your application,
-sending performance metrics and errors to the Elastic APM server.
+sending performance metrics and errors to the Elastic APM server. You can find a
+list of the supported frameworks and other technologies in the [documentation](https://www.elastic.co/guide/en/apm/agent/go/current/supported-tech.html).
 
 We'd love to hear your feedback, please take a minute to fill out our [survey](https://docs.google.com/forms/d/e/1FAIpQLScbW7D8m-otPO7cxqeg7XstWR8vMnxG6brnXLs_TFVSTHuHvg/viewform?usp=sf_link).
 
@@ -29,7 +30,7 @@ Apache 2.0.
 
 ## Documentation
 
-[Elastic APM Go documentation](./docs/index.asciidoc).
+[Elastic APM Go documentation](https://www.elastic.co/guide/en/apm/agent/go/current/index.html).
 
 ## Getting Help
 


### PR DESCRIPTION
Update the documentation link to point to elastic.co,
and add a direct link to supported technologies.