### PR TITLE
Introduce Transaction.EnsureParent

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -109,6 +109,51 @@ transaction.End()
 TraceContext returns the transaction's <<trace-context, trace context>>.
 
 [float]
+[[transaction-ensureparent]]
+==== `func (*Transaction) EnsureParent() SpanID`
+
+EnsureParent returns the transaction's parent span ID, generating and recording one if
+it did not previously have one.
+
+EnsureParent enables correlation with spans created by the JavaScript Real User Monitoring
+(RUM) agent for the initial page load. If your backend service generates the HTML page
+dynamically, you can inject the trace and parent span ID into the page in order to initialize
+the JavaScript RUM agent, such that the web browser's page load appears as the root of the
+trace.
+
+[source,go]
+----
+var initialPageTemplate = template.Must(template.New("").Parse(`
+<html>
+<head>
+<script src="elastic-apm-js-base/dist/bundles/elastic-apm-js-base.umd.min.js"></script>
+<script>
+  elasticApm.init({
+    serviceName: '',
+    serverUrl: 'http://localhost:8200',
+    pageLoadTraceId: {{.TraceContext.Trace}},
+    pageLoadSpanId: {{.EnsureParent}},
+    pageLoadSampled: {{.Sampled}},
+  })
+</script>
+</head>
+<body>...</body>
+</html>
+`))
+
+func initialPageHandler(w http.ResponseWriter, req *http.Request) {
+	err := initialPageTemplate.Execute(w, apm.TransactionFromContext(req.Context()))
+	if err != nil {
+		...
+	}
+}
+----
+
+See the
+https://www.elastic.co/guide/en/apm/agent/js-base/current/distributed-tracing-guide.html[JavaScript RUM agent documentation]
+for more information.
+
+[float]
 [[apm-context-with-transaction]]
 ==== `func ContextWithTransaction(context.Context, *Transaction) context.Context`
 

--- a/example_tracecontext_test.go
+++ b/example_tracecontext_test.go
@@ -1,0 +1,77 @@
+package apm_test
+
+import (
+	"context"
+	"html/template"
+	"os"
+
+	"go.elastic.co/apm"
+)
+
+func ExampleTransaction_EnsureParent() {
+	tx := apm.DefaultTracer.StartTransactionOptions("name", "type", apm.TransactionOptions{
+		TraceContext: apm.TraceContext{
+			Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+		},
+	})
+	defer tx.Discard()
+
+	tpl := template.Must(template.New("").Parse(`
+<script src="elastic-apm-js-base/dist/bundles/elastic-apm-js-base.umd.min.js"></script>
+<script>
+  elasticApm.init({
+    serviceName: '',
+    serverUrl: 'http://localhost:8200',
+    pageLoadTraceId: {{.TraceContext.Trace}},
+    pageLoadSpanId: {{.EnsureParent}},
+    pageLoadSampled: {{.Sampled}},
+  })
+</script>
+`))
+
+	if err := tpl.Execute(os.Stdout, tx); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// <script src="elastic-apm-js-base/dist/bundles/elastic-apm-js-base.umd.min.js"></script>
+	// <script>
+	//   elasticApm.init({
+	//     serviceName: '',
+	//     serverUrl: 'http://localhost:8200',
+	//     pageLoadTraceId: "000102030405060708090a0b0c0d0e0f",
+	//     pageLoadSpanId: "0001020304050607",
+	//     pageLoadSampled:  false ,
+	//   })
+	// </script>
+}
+
+func ExampleTransaction_EnsureParent_nilTransaction() {
+	tpl := template.Must(template.New("").Parse(`
+<script>
+elasticApm.init({
+  {{.TraceContext.Trace}},
+  {{.EnsureParent}},
+  {{.Sampled}},
+})
+</script>
+`))
+
+	// Demonstrate that Transaction's TraceContext, EnsureParent,
+	// and Sampled methods will not panic when called with a nil
+	// Transaction.
+	tx := apm.TransactionFromContext(context.Background())
+	if err := tpl.Execute(os.Stdout, tx); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// <script>
+	// elasticApm.init({
+	//   "00000000000000000000000000000000",
+	//   "0000000000000000",
+	//    false ,
+	// })
+	// </script>
+}


### PR DESCRIPTION
Introduce a new method, Transaction.EnsureParent, which returns
the transaction's parent ID. If the transaction does not have a
parent span recorded, then one is recorded based on the trace ID.

This change is in support of correlation with the RUM agent, for
applications where the initial page load is served by the backend
agent.

Closes elastic/apm-agent-go#298 