### PR TITLE
module/apmgrpc: only run tests on Go 1.9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
  - Return a more helpful error message when /intake/v2/events 404s, to detect old servers (#290)
  - Implement test service for w3c/distributed-tracing test harness (#293)
  - End HTTP client spans on response body closure (#289)
+ - module/apmgrpc requires Go 1.9+ (#300)
 
 ## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
 

--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,21 @@ check: precheck test
 precheck: check-goimports check-lint check-vet check-dockerfile-testing
 
 .PHONY: check-goimports
+.PHONY: check-dockerfile-testing
+.PHONY: check-lint
+ifeq ($(shell go run ./scripts/mingoversion.go -print 1.10),true)
 check-goimports:
 	sh scripts/check_goimports.sh
 
-.PHONY: check-dockerfile-testing
 check-dockerfile-testing:
-ifeq ($(shell go run ./scripts/mingoversion.go -print 1.9),true)
 	go run ./scripts/gendockerfile.go -d
-endif
 
-.PHONY: check-lint
 check-lint:
-ifeq ($(shell go run ./scripts/mingoversion.go -print 1.10),true)
 	go list ./... | grep -v vendor | xargs golint -set_exit_status
+else
+check-goimports:
+check-dockerfile-testing:
+check-lint:
 endif
 
 .PHONY: check-vet

--- a/module/apmgrpc/client.go
+++ b/module/apmgrpc/client.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgrpc
 
 import (

--- a/module/apmgrpc/client_test.go
+++ b/module/apmgrpc/client_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgrpc_test
 
 import (

--- a/module/apmgrpc/doc.go
+++ b/module/apmgrpc/doc.go
@@ -1,2 +1,4 @@
+// +build go1.9
+
 // Package apmgrpc provides interceptors for tracing gRPC.
 package apmgrpc

--- a/module/apmgrpc/packages.go
+++ b/module/apmgrpc/packages.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgrpc
 
 import "go.elastic.co/apm/stacktrace"

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgrpc
 
 import (

--- a/module/apmgrpc/server_test.go
+++ b/module/apmgrpc/server_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package apmgrpc_test
 
 import (

--- a/scripts/check_goimports.sh
+++ b/scripts/check_goimports.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 out=$(GOIMPORTSFLAGS=-l ./scripts/goimports.sh)
 if [ -n "$out" ]; then


### PR DESCRIPTION
grpc-go dropped support for versions of Go older than 1.9, so we must do the same.