### PR TITLE
module/apmhttp: don't test http2 with Go 1.8

### DIFF
--- a/module/apmhttp/handler_http2_test.go
+++ b/module/apmhttp/handler_http2_test.go
@@ -1,0 +1,86 @@
+// +build go1.9
+
+package apmhttp_test
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"go.elastic.co/apm/model"
+	"go.elastic.co/apm/module/apmhttp"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func TestHandlerHTTP2(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	mux := http.NewServeMux()
+	mux.Handle("/foo", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		w.Write([]byte("bar"))
+	}))
+	srv := httptest.NewUnstartedServer(apmhttp.Wrap(mux, apmhttp.WithTracer(tracer)))
+	err := http2.ConfigureServer(srv.Config, nil)
+	require.NoError(t, err)
+	srv.TLS = srv.Config.TLSConfig
+	srv.StartTLS()
+	defer srv.Close()
+	srvAddr := srv.Listener.Addr().(*net.TCPAddr)
+
+	client := &http.Client{Transport: &http2.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}}
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/foo", nil)
+	req.Header.Set("X-Real-IP", "client.testing")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	transaction := payloads.Transactions[0]
+
+	assert.Equal(t, &model.Context{
+		Request: &model.Request{
+			Socket: &model.RequestSocket{
+				Encrypted:     true,
+				RemoteAddress: "client.testing",
+			},
+			URL: model.URL{
+				Full:     srv.URL + "/foo",
+				Protocol: "https",
+				Hostname: srvAddr.IP.String(),
+				Port:     strconv.Itoa(srvAddr.Port),
+				Path:     "/foo",
+			},
+			Method: "GET",
+			Headers: model.Headers{{
+				Key:    "Accept-Encoding",
+				Values: []string{"gzip"},
+			}, {
+				Key:    "User-Agent",
+				Values: []string{"Go-http-client/2.0"},
+			}, {
+				Key:    "X-Real-Ip",
+				Values: []string{"client.testing"},
+			}},
+			HTTPVersion: "2.0",
+		},
+		Response: &model.Response{
+			StatusCode: 418,
+		},
+	}, transaction.Context)
+}

--- a/module/apmhttp/handler_test.go
+++ b/module/apmhttp/handler_test.go
@@ -1,20 +1,16 @@
 package apmhttp_test
 
 import (
-	"crypto/tls"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/http2"
 
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/apmtest"
@@ -82,72 +78,6 @@ func TestHandler(t *testing.T) {
 				Values: []string{"apmhttp_test"},
 			}},
 			HTTPVersion: "1.1",
-		},
-		Response: &model.Response{
-			StatusCode: 418,
-		},
-	}, transaction.Context)
-}
-
-func TestHandlerHTTP2(t *testing.T) {
-	tracer, transport := transporttest.NewRecorderTracer()
-	defer tracer.Close()
-
-	mux := http.NewServeMux()
-	mux.Handle("/foo", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(http.StatusTeapot)
-		w.Write([]byte("bar"))
-	}))
-	srv := httptest.NewUnstartedServer(apmhttp.Wrap(mux, apmhttp.WithTracer(tracer)))
-	err := http2.ConfigureServer(srv.Config, nil)
-	require.NoError(t, err)
-	srv.TLS = srv.Config.TLSConfig
-	srv.StartTLS()
-	defer srv.Close()
-	srvAddr := srv.Listener.Addr().(*net.TCPAddr)
-
-	client := &http.Client{Transport: &http2.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-	}}
-	require.NoError(t, err)
-
-	req, _ := http.NewRequest("GET", srv.URL+"/foo", nil)
-	req.Header.Set("X-Real-IP", "client.testing")
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	resp.Body.Close()
-	tracer.Flush(nil)
-
-	payloads := transport.Payloads()
-	transaction := payloads.Transactions[0]
-
-	assert.Equal(t, &model.Context{
-		Request: &model.Request{
-			Socket: &model.RequestSocket{
-				Encrypted:     true,
-				RemoteAddress: "client.testing",
-			},
-			URL: model.URL{
-				Full:     srv.URL + "/foo",
-				Protocol: "https",
-				Hostname: srvAddr.IP.String(),
-				Port:     strconv.Itoa(srvAddr.Port),
-				Path:     "/foo",
-			},
-			Method: "GET",
-			Headers: model.Headers{{
-				Key:    "Accept-Encoding",
-				Values: []string{"gzip"},
-			}, {
-				Key:    "User-Agent",
-				Values: []string{"Go-http-client/2.0"},
-			}, {
-				Key:    "X-Real-Ip",
-				Values: []string{"client.testing"},
-			}},
-			HTTPVersion: "2.0",
 		},
 		Response: &model.Response{
 			StatusCode: 418,


### PR DESCRIPTION
http2 no longer builds with Go 1.8, add a build constraint.