### PR TITLE
internal/tracecontexttest: allow empty Tracestate

### DIFF
--- a/internal/tracecontexttest/main.go
+++ b/internal/tracecontexttest/main.go
@@ -143,7 +143,7 @@ func (s *traceState) init(vs ...string) bool {
 	for _, v := range vs {
 		v = strings.TrimSpace(v)
 		if v == "" {
-			return false
+			continue
 		}
 		for _, field := range strings.Split(v, ",") {
 			kv := strings.SplitN(strings.TrimSpace(field), "=", 2)


### PR DESCRIPTION
Update test service to allow empty Tracestate headers.
See https://github.com/w3c/trace-context/pull/188.