### PR TITLE
Reduce ELASTIC_APM_API_BUFFER_SIZE default to 1MB

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -260,7 +260,7 @@ to the APM server.
 [options="header"]           
 |============
 | Environment                   | Default | Minimum | Maximum
-| `ELASTIC_APM_API_BUFFER_SIZE` | `10MB`  | `10KB`  | `100MB`
+| `ELASTIC_APM_API_BUFFER_SIZE` | `1MB`   | `10KB`  | `100MB`
 |============
 
 The maximum number of bytes of uncompressed, encoded events to store in memory

--- a/env.go
+++ b/env.go
@@ -31,7 +31,7 @@ const (
 
 	defaultAPIRequestSize        = 750 * apmconfig.KByte
 	defaultAPIRequestTime        = 10 * time.Second
-	defaultAPIBufferSize         = 10 * apmconfig.MByte
+	defaultAPIBufferSize         = 1 * apmconfig.MByte
 	defaultMetricsInterval       = 0 // disabled by default
 	defaultMaxSpans              = 500
 	defaultCaptureBody           = CaptureBodyOff


### PR DESCRIPTION
Reduce ELASTIC_APM_API_BUFFER_SIZE default from 10MB to 1MB. The previous default was excessive. Users can increase it as necessary, which we expect to be uncommon.