### PR TITLE
apm: replace invalid tag key chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
  - Implement test service for w3c/distributed-tracing test harness (#293)
  - End HTTP client spans on response body closure (#289)
  - module/apmgrpc requires Go 1.9+ (#300)
+ - Invalid tag key characters are replaced with underscores (#308)
 
 ## [v0.5.2](https://github.com/elastic/apm-agent-go/releases/tag/v0.5.2)
 

--- a/context.go
+++ b/context.go
@@ -49,18 +49,16 @@ func (c *Context) reset() {
 	}
 }
 
-// SetTag sets a tag in the context. If the key is invalid
-// (contains '.', '*', or '"'), the call is a no-op.
+// SetTag sets a tag in the context. Invalid characters
+// ('.', '*', and '"') in the key will be replaced with
+// an underscore.
 func (c *Context) SetTag(key, value string) {
-	if !validTagKey(key) {
-		return
-	}
-	value = truncateString(value)
 	// Note that we do not attempt to de-duplicate the keys.
 	// This is OK, since json.Unmarshal will always take the
 	// final instance.
 	c.model.Tags = append(c.model.Tags, model.StringMapItem{
-		Key: key, Value: value,
+		Key:   cleanTagKey(key),
+		Value: truncateString(value),
 	})
 }
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -292,10 +292,10 @@ custom context and tags.
 [[context-set-tag]]
 ==== `func (*Context) SetTag(key, value string)`
 
-SetTag tags the transaction or error with the given key and value. The
-key must not contain any special characters (`.`, `*`, or `"`). Values
-longer than 1024 characters will be truncated. Tags will be indexed in
-Elasticsearch as keyword fields.
+SetTag tags the transaction or error with the given key and value. If the
+key contains any special characters (`.`, `*`, `"`), they will be replaced
+with underscores. Values longer than 1024 characters will be truncated.
+Tags will be indexed in Elasticsearch as keyword fields.
 
 [float]
 [[context-set-username]]

--- a/spancontext.go
+++ b/spancontext.go
@@ -41,7 +41,6 @@ func (c *SpanContext) build() *model.SpanContext {
 }
 
 func (c *SpanContext) reset() {
-	// TODO(axw) reuse space for tags
 	*c = SpanContext{
 		model: model.SpanContext{
 			Tags: c.model.Tags[:0],
@@ -49,18 +48,16 @@ func (c *SpanContext) reset() {
 	}
 }
 
-// SetTag sets a tag in the context. If the key is invalid
-// (contains '.', '*', or '"'), the call is a no-op.
+// SetTag sets a tag in the context. Invalid characters
+// ('.', '*', and '"') in the key will be replaced with
+// an underscore.
 func (c *SpanContext) SetTag(key, value string) {
-	if !validTagKey(key) {
-		return
-	}
-	value = truncateString(value)
 	// Note that we do not attempt to de-duplicate the keys.
 	// This is OK, since json.Unmarshal will always take the
 	// final instance.
 	c.model.Tags = append(c.model.Tags, model.StringMapItem{
-		Key: key, Value: value,
+		Key:   cleanTagKey(key),
+		Value: truncateString(value),
 	})
 }
 

--- a/utils.go
+++ b/utils.go
@@ -23,6 +23,7 @@ var (
 	localSystem    model.System
 
 	serviceNameInvalidRegexp = regexp.MustCompile("[^" + serviceNameValidClass + "]")
+	tagKeyReplacer           = strings.NewReplacer(`.`, `_`, `*`, `_`, `"`, `_`)
 )
 
 const (
@@ -76,8 +77,8 @@ func getLocalSystem() model.System {
 	return system
 }
 
-func validTagKey(k string) bool {
-	return !strings.ContainsAny(k, `.*"`)
+func cleanTagKey(k string) string {
+	return tagKeyReplacer.Replace(k)
 }
 
 func validateServiceName(name string) error {


### PR DESCRIPTION
We were silently dropping any tags with invalid keys.
Instead, we will now replace the invalid key characters
with underscores.

Closes #307 