### PR TITLE
apm: add nil check for Error.Send

### DIFF
--- a/error.go
+++ b/error.go
@@ -196,6 +196,9 @@ func (e *Error) reset() {
 // Send enqueues the error for sending to the Elastic APM server.
 // The Error must not be used after this.
 func (e *Error) Send() {
+	if e == nil {
+		return
+	}
 	select {
 	case e.tracer.errors <- e:
 	default:

--- a/error_test.go
+++ b/error_test.go
@@ -100,6 +100,17 @@ func TestErrorAutoStackTraceReuse(t *testing.T) {
 	}
 }
 
+func TestCaptureErrorNoTransaction(t *testing.T) {
+	// When there's no transaction or span in the context,
+	// CaptureError returns nil as it has no tracer with
+	// which it can create the error.
+	e := apm.CaptureError(context.Background(), errors.New("boom"))
+	assert.Nil(t, e)
+
+	// Send is a no-op on a nil Error.
+	e.Send()
+}
+
 func sendError(t *testing.T, err error, f ...func(*apm.Error)) model.Error {
 	tracer, r := transporttest.NewRecorderTracer()
 	defer tracer.Close()


### PR DESCRIPTION
For nil Errors, Error.Send is a no-op.