### PR TITLE
module/apmgocql: remove expected failure

### DIFF
--- a/module/apmgocql/apmgocql_test.go
+++ b/module/apmgocql/apmgocql_test.go
@@ -199,10 +199,7 @@ func TestQueryObserverErrorIntegration(t *testing.T) {
 	require.Len(t, errors, 1)
 	require.Len(t, spans, 1)
 
-	// BUG(axw) gocql executes queries, and notifies observers, in another
-	// goroutine whose stack does not include the original caller.
-	// See https://go.elastic.co/apm/issues/258.
-	assert.Equal(t, errors[0].Culprit, "")
+	assert.Equal(t, errors[0].Culprit, "execQuery")
 	assert.EqualError(t, queryError, errors[0].Exception.Message)
 }
 


### PR DESCRIPTION
TestQueryObserverErrorIntegration has been fixed by
an upstream change to gocql.