### PR TITLE
Stop pooling top-level objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.0.0...master)
 
+ - Stop pooling Transaction/Span/Error, introduce internal pooled objects (#319)
+
 ## [v1.0.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.0.0)
 
  - Implement v2 intake protocol (#180)

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -90,7 +90,7 @@ transaction := apm.DefaultTracer.StartTransactionOptions("GET /", "request", opt
 ==== `func (*Transaction) End()`
 
 End enqueues the transaction for sending to the Elastic APM server.
-The Transaction must not be used after this.
+The Transaction must not be modified after this.
 
 The transaction's duration will be calculated as the amount of time
 elapsed since the transaction was started until this call. To override
@@ -239,7 +239,7 @@ span, ctx := apm.StartSpan(ctx, "SELECT FROM foo", "db.mysql.query")
 [[span-end]]
 ==== `func (*Span) End()`
 
-End marks the span as complete; it must not be used after this.
+End marks the span as complete. The Span must not be modified after this.
 
 The span's duration will be calculated as the amount of time elapsed
 since the span was started until this call. To override this behaviour,
@@ -250,8 +250,8 @@ the span's Duration field may be set before calling End.
 ==== `func (*Span) Dropped() bool`
 
 Dropped indicates whether or not the span is dropped, meaning it will not be reported to
-the APM server. Spans are dropped when the created via a nil or non-sampled transaction,
-or one whose max spans limit has been reached.
+the APM server. Spans are dropped when the created with a nil, ended, or non-sampled
+transaction, or one whose max spans limit has been reached.
 
 [float]
 [[span-tracecontext]]
@@ -427,21 +427,20 @@ e.Send()
 [[error-set-transaction]]
 ==== `func (*Error) SetTransaction(*Transaction)`
 
-SetTransaction associates the error with the given transaction. The transaction's End method must
-not yet have been called.
+SetTransaction associates the error with the given transaction.
 
 [float]
 [[error-set-span]]
 ==== `func (*Error) SetSpan(*Span)`
 
 SetSpan associates the error with the given span, and the span's transaction. When calling SetSpan,
-it is not necessary to also call SetTransaction. The span's End method must not yet have been called.
+it is not necessary to also call SetTransaction.
 
 [float]
 [[error-send]]
 ==== `func (*Error) Send()`
 
-Send enqueues the error for sending to the Elastic APM server. The Error must not be used after this.
+Send enqueues the error for sending to the Elastic APM server.
 
 [float]
 [[tracer-recovered]]

--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -1,0 +1,67 @@
+package apm_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func TestContextStartSpanTransactionEnded(t *testing.T) {
+	tracer, err := apm.NewTracer("tracer_testing", "")
+	assert.NoError(t, err)
+	defer tracer.Close()
+	tracer.Transport = transporttest.Discard
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				tx := tracer.StartTransaction("name", "type")
+				ctx := apm.ContextWithTransaction(context.Background(), tx)
+				tx.End()
+				apm.CaptureError(ctx, errors.New("boom")).Send()
+				span, _ := apm.StartSpan(ctx, "name", "type")
+				assert.True(t, span.Dropped())
+				span.End()
+			}
+		}()
+	}
+	tracer.Flush(nil)
+	wg.Wait()
+}
+
+func TestContextStartSpanSpanEnded(t *testing.T) {
+	tracer, err := apm.NewTracer("tracer_testing", "")
+	assert.NoError(t, err)
+	defer tracer.Close()
+	tracer.Transport = transporttest.Discard
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				tx := tracer.StartTransaction("name", "type")
+				ctx := apm.ContextWithTransaction(context.Background(), tx)
+				span1, ctx := apm.StartSpan(ctx, "name", "type")
+				span1.End()
+				apm.CaptureError(ctx, errors.New("boom")).Send()
+				span2, _ := apm.StartSpan(ctx, "name", "type")
+				assert.True(t, span2.Dropped())
+				span2.End()
+				tx.End()
+			}
+		}()
+	}
+	tracer.Flush(nil)
+	wg.Wait()
+}

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -79,12 +79,11 @@ func (o *Observer) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) 
 		Instance:  query.Keyspace,
 		Statement: query.Statement,
 	})
-	span.End()
-
 	if e := apm.CaptureError(ctx, query.Err); e != nil {
 		e.Timestamp = query.End
 		e.Send()
 	}
+	span.End()
 }
 
 type options struct {

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -74,7 +74,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = &reqCopy
 
 	traceContext := tx.TraceContext()
-	if !tx.Sampled() {
+	if !traceContext.Options.Recorded() {
 		req.Header.Set(TraceparentHeader, FormatTraceparentHeader(traceContext))
 		return r.r.RoundTrip(req)
 	}

--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -68,10 +68,10 @@ func (c *conn) finishSpan(ctx context.Context, span *apm.Span, resultError *erro
 		// in check.
 		return
 	}
-	span.End()
 	if e := apm.CaptureError(ctx, *resultError); e != nil {
 		e.Send()
 	}
+	span.End()
 }
 
 func (c *conn) Ping(ctx context.Context) (resultError error) {

--- a/tracer.go
+++ b/tracer.go
@@ -179,9 +179,9 @@ type Tracer struct {
 	forceFlush       chan chan<- struct{}
 	forceSendMetrics chan chan<- struct{}
 	configCommands   chan tracerConfigCommand
-	transactions     chan *Transaction
-	spans            chan *Span
-	errors           chan *Error
+	transactions     chan *TransactionData
+	spans            chan *SpanData
+	errors           chan *ErrorData
 
 	statsMu sync.Mutex
 	stats   TracerStats
@@ -198,9 +198,9 @@ type Tracer struct {
 	captureBodyMu sync.RWMutex
 	captureBody   CaptureBodyMode
 
-	errorPool       sync.Pool
-	spanPool        sync.Pool
-	transactionPool sync.Pool
+	errorDataPool       sync.Pool
+	spanDataPool        sync.Pool
+	transactionDataPool sync.Pool
 }
 
 // NewTracer returns a new Tracer, using the default transport,
@@ -235,9 +235,9 @@ func newTracer(opts options) *Tracer {
 		forceFlush:            make(chan chan<- struct{}),
 		forceSendMetrics:      make(chan chan<- struct{}),
 		configCommands:        make(chan tracerConfigCommand),
-		transactions:          make(chan *Transaction, transactionsChannelCap),
-		spans:                 make(chan *Span, spansChannelCap),
-		errors:                make(chan *Error, errorsChannelCap),
+		transactions:          make(chan *TransactionData, transactionsChannelCap),
+		spans:                 make(chan *SpanData, spansChannelCap),
+		errors:                make(chan *ErrorData, errorsChannelCap),
 		maxSpans:              opts.maxSpans,
 		sampler:               opts.sampler,
 		captureBody:           opts.captureBody,


### PR DESCRIPTION
Transaction, Span, and Error are no longer pooled.
Instead, new *Data types are introduced which are
pooled, and those are embedded within their related
top-level object types. We add a read-write mutex
to the Transaction and Span types to guard access
to those such that a concurrent StartSpan and
Transaction.End will not panic.

This change introduces an additional allocation for
each of StartTransaction, StartSpan, and NewError.
The time overhead (measured in nanoseconds) is not
enough to warrant living with the lack of safety.

It is now safe to call End() multiple times, and
to call StartSpan with an ended transaction or parent
span. When StartSpan is called with an ended
transaction, a dropped span will be created.

Closes #317 