### PR TITLE
Buffer metrics separately

### DIFF
--- a/env.go
+++ b/env.go
@@ -28,19 +28,23 @@ const (
 	envAPIRequestSize        = "ELASTIC_APM_API_REQUEST_SIZE"
 	envAPIRequestTime        = "ELASTIC_APM_API_REQUEST_TIME"
 	envAPIBufferSize         = "ELASTIC_APM_API_BUFFER_SIZE"
+	envMetricsBufferSize     = "ELASTIC_APM_METRICS_BUFFER_SIZE"
 
 	defaultAPIRequestSize        = 750 * apmconfig.KByte
 	defaultAPIRequestTime        = 10 * time.Second
 	defaultAPIBufferSize         = 1 * apmconfig.MByte
+	defaultMetricsBufferSize     = 100 * apmconfig.KByte
 	defaultMetricsInterval       = 0 // disabled by default
 	defaultMaxSpans              = 500
 	defaultCaptureBody           = CaptureBodyOff
 	defaultSpanFramesMinDuration = 5 * time.Millisecond
 
-	minAPIBufferSize  = 10 * apmconfig.KByte
-	maxAPIBufferSize  = 100 * apmconfig.MByte
-	minAPIRequestSize = 1 * apmconfig.KByte
-	maxAPIRequestSize = 5 * apmconfig.MByte
+	minAPIBufferSize     = 10 * apmconfig.KByte
+	maxAPIBufferSize     = 100 * apmconfig.MByte
+	minAPIRequestSize    = 1 * apmconfig.KByte
+	maxAPIRequestSize    = 5 * apmconfig.MByte
+	minMetricsBufferSize = 10 * apmconfig.KByte
+	maxMetricsBufferSize = 100 * apmconfig.MByte
 )
 
 var (
@@ -65,6 +69,20 @@ func initialRequestDuration() (time.Duration, error) {
 
 func initialMetricsInterval() (time.Duration, error) {
 	return apmconfig.ParseDurationEnv(envMetricsInterval, defaultMetricsInterval)
+}
+
+func initialMetricsBufferSize() (int, error) {
+	size, err := apmconfig.ParseSizeEnv(envMetricsBufferSize, defaultMetricsBufferSize)
+	if err != nil {
+		return 0, err
+	}
+	if size < minMetricsBufferSize || size > maxMetricsBufferSize {
+		return 0, errors.Errorf(
+			"%s must be at least %s and less than %s, got %s",
+			envMetricsBufferSize, minMetricsBufferSize, maxMetricsBufferSize, size,
+		)
+	}
+	return int(size), nil
 }
 
 func initialAPIBufferSize() (int, error) {

--- a/env_test.go
+++ b/env_test.go
@@ -104,6 +104,21 @@ func TestTracerBufferSizeEnvInvalid(t *testing.T) {
 	})
 }
 
+func TestTracerMetricsBufferSizeEnvInvalid(t *testing.T) {
+	t.Run("too_small", func(t *testing.T) {
+		os.Setenv("ELASTIC_APM_METRICS_BUFFER_SIZE", "1B")
+		defer os.Unsetenv("ELASTIC_APM_METRICS_BUFFER_SIZE")
+		_, err := apm.NewTracer("tracer_testing", "")
+		assert.EqualError(t, err, "ELASTIC_APM_METRICS_BUFFER_SIZE must be at least 10KB and less than 100MB, got 1B")
+	})
+	t.Run("too_large", func(t *testing.T) {
+		os.Setenv("ELASTIC_APM_METRICS_BUFFER_SIZE", "500GB")
+		defer os.Unsetenv("ELASTIC_APM_METRICS_BUFFER_SIZE")
+		_, err := apm.NewTracer("tracer_testing", "")
+		assert.EqualError(t, err, "ELASTIC_APM_METRICS_BUFFER_SIZE must be at least 10KB and less than 100MB, got 500GB")
+	})
+}
+
 func TestTracerTransactionRateEnv(t *testing.T) {
 	t.Run("0.5", func(t *testing.T) {
 		testTracerTransactionRateEnv(t, "0.5", 0.5)

--- a/tracer.go
+++ b/tracer.go
@@ -543,6 +543,7 @@ func (t *Tracer) loop() {
 		var gatherMetrics bool
 		select {
 		case <-t.closing:
+			cancelContext() // informs transport that EOF is expected
 			iochanReader.CloseRead(io.EOF)
 			return
 		case cmd := <-t.configCommands:


### PR DESCRIPTION
Buffer metrics separately from transactions, spans, and errors, so that the periodically collected metrics do not get evicted by the more frequently reported transactions and spans in a busy system.

Fixes #311