### PR TITLE
Move SQL scanning/parsing test cases to JSON

### DIFF
--- a/internal/sqlscanner/scanner_test.go
+++ b/internal/sqlscanner/scanner_test.go
@@ -1,87 +1,49 @@
 package sqlscanner
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestScanEOF(t *testing.T) {
-	s := NewScanner("  ")
-	assert.False(t, s.Scan())
+type test struct {
+	Name    string `json:"name"`
+	Comment string `json:"comment,omitempty"`
+	Input   string `json:"input"`
+	Tokens  []struct {
+		Kind string `json:"kind"`
+		Text string `json:"text"`
+	} `json:"tokens,omitempty"`
 }
 
-func TestScanKeyword(t *testing.T) {
-	s := NewScanner("INSERT or rEpLaCe")
-	assertScan(t, s, INSERT, "INSERT")
-	assertScan(t, s, OR, "or")
-	assertScan(t, s, REPLACE, "rEpLaCe")
-}
+func TestScanner(t *testing.T) {
+	var tests []test
+	data, err := ioutil.ReadFile("testdata/tests.json")
+	require.NoError(t, err)
+	err = json.Unmarshal(data, &tests)
+	require.NoError(t, err)
 
-func TestScanQualifiedTable(t *testing.T) {
-	s := NewScanner("schema.Abc_123")
-	assertScan(t, s, IDENT, "schema")
-	assertScan(t, s, PERIOD, ".")
-	assertScan(t, s, IDENT, "Abc_123")
-}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			msgFormat := "%s"
+			args := []interface{}{test.Input}
+			if test.Comment != "" {
+				msgFormat += " (%s)"
+				args = append(args, test.Comment)
+			}
 
-func TestScanVariable(t *testing.T) {
-	s := NewScanner("$123")
-	assertScan(t, s, OTHER, "$123")
-}
-
-func TestScanIdent(t *testing.T) {
-	s := NewScanner("_foo foo$")
-	assertScan(t, s, IDENT, "_foo")
-	assertScan(t, s, IDENT, "foo$")
-}
-
-func TestScanQuotedIdent(t *testing.T) {
-	s := NewScanner("`SELECT` \"SELECT \"\"\" [SELECT '']")
-	assertScan(t, s, IDENT, "SELECT")
-	assertScan(t, s, IDENT, `SELECT ""`)
-	assertScan(t, s, IDENT, "SELECT ''")
-}
-
-func TestScanComment(t *testing.T) {
-	s := NewScanner("/* /*nested*/ */ -- SELECT /*")
-	assertScan(t, s, COMMENT, "/* /*nested*/ */")
-	assertScan(t, s, COMMENT, "-- SELECT /*")
-}
-
-func TestScanString(t *testing.T) {
-	s := NewScanner("'abc '' def\\''")
-	assertScan(t, s, STRING, "'abc '' def\\''")
-}
-
-func TestScanDollarQuotedString(t *testing.T) {
-	s := NewScanner("$$f$o$o$$ $$ $$ $foo$'`$$$$\"$foo$ $foo $bar")
-	assertScan(t, s, STRING, "$$f$o$o$$")
-	assertScan(t, s, STRING, "$$ $$")
-	assertScan(t, s, STRING, "$foo$'`$$$$\"$foo$")
-	assertScan(t, s, OTHER, "$foo")
-	assertScan(t, s, OTHER, "$bar")
-
-	// Unterminated dollar-quoted string stops tokenizing
-	// at the first whitespace, under the assumption that
-	// the input is valid and we've interpreted it wrongly.
-	s = NewScanner("$foo$ banana $")
-	assertScan(t, s, OTHER, "$foo$")
-	assertScan(t, s, IDENT, "banana")
-	assertScan(t, s, OTHER, "$")
-}
-
-func TestScanNumber(t *testing.T) {
-	s := NewScanner("123 123.456 123E45 123e+45 123e-45")
-	assertScan(t, s, NUMBER, "123")
-	assertScan(t, s, NUMBER, "123.456")
-	assertScan(t, s, NUMBER, "123E45")
-	assertScan(t, s, NUMBER, "123e+45")
-	assertScan(t, s, NUMBER, "123e-45")
-}
-
-func assertScan(t *testing.T, s *Scanner, tok Token, text string) {
-	assert.True(t, s.Scan())
-	assert.Equal(t, tok, s.Token())
-	assert.Equal(t, text, s.Text())
+			s := NewScanner(test.Input)
+			for _, tok := range test.Tokens {
+				if !assert.True(t, s.Scan()) {
+					return
+				}
+				assert.Equal(t, tok.Kind, s.Token().String())
+				assert.Equal(t, tok.Text, s.Text())
+			}
+			assert.False(t, s.Scan())
+		})
+	}
 }

--- a/internal/sqlscanner/testdata/tests.json
+++ b/internal/sqlscanner/testdata/tests.json
@@ -1,0 +1,212 @@
+[
+  {
+    "name": "whitespace-only",
+    "comment": "whitespace between tokens is ignored",
+    "input": "  "
+  },
+  {
+    "name": "keywords",
+    "comment": "keywords each have their own kind, and are scanned case-insensitively",
+    "input": "INSERT or rEpLaCe",
+    "tokens": [
+      {
+        "kind": "INSERT",
+        "text": "INSERT"
+      },
+      {
+        "kind": "OR",
+        "text": "or"
+      },
+      {
+        "kind": "REPLACE",
+        "text": "rEpLaCe"
+      }
+    ]
+  },
+  {
+    "name": "qualified-table",
+    "input": "schema.Abc_123",
+    "tokens": [
+      {
+        "kind": "IDENT",
+        "text": "schema"
+      },
+      {
+        "kind": "PERIOD",
+        "text": "."
+      },
+      {
+        "kind": "IDENT",
+        "text": "Abc_123"
+      }
+    ]
+  },
+  {
+    "name": "dollar-variable",
+    "comment": "dollar variables mustn't confuse dollar quoting",
+    "input": "$123",
+    "tokens": [
+      {
+        "kind": "OTHER",
+        "text": "$123"
+      }
+    ]
+  },
+  {
+    "name": "identifiers",
+    "input": "_foo foo$",
+    "tokens": [
+      {
+        "kind": "IDENT",
+        "text": "_foo"
+      },
+      {
+        "kind": "IDENT",
+        "text": "foo$"
+      }
+    ]
+  },
+  {
+    "name": "quoted-identifiers",
+    "input": "`SELECT` \"SELECT \"\"\" [SELECT '']",
+    "tokens": [
+      {
+        "kind": "IDENT",
+        "text": "SELECT"
+      },
+      {
+        "kind": "IDENT",
+        "text": "SELECT \"\""
+      },
+      {
+        "kind": "IDENT",
+        "text": "SELECT ''"
+      }
+    ]
+  },
+  {
+    "name": "punctuation",
+    "input": "().",
+    "tokens": [
+      {
+        "kind": "LPAREN",
+        "text": "("
+      },
+      {
+        "kind": "RPAREN",
+        "text": ")"
+      },
+      {
+        "kind": "PERIOD",
+        "text": "."
+      }
+    ]
+  },
+  {
+    "name": "comments",
+    "input": "/* /*nested*/ */ -- SELECT /*",
+    "tokens": [
+      {
+        "kind": "COMMENT",
+        "text": "/* /*nested*/ */"
+      },
+      {
+        "kind": "COMMENT",
+        "text": "-- SELECT /*"
+      }
+    ]
+  },
+  {
+    "name": "string-literal",
+    "input": "'abc '' def\\''",
+    "tokens": [
+      {
+        "kind": "STRING",
+        "text": "'abc '' def\\''"
+      }
+    ]
+  },
+  {
+    "name": "dollar-quoted-string-literal",
+    "input": "$$f$o$o$$ $$ $$ $foo$'`$$$$\"$foo$ $foo $bar",
+    "tokens": [
+      {
+        "kind": "STRING",
+        "text": "$$f$o$o$$"
+      },
+      {
+        "kind": "STRING",
+        "text": "$$ $$"
+      },
+      {
+        "kind": "STRING",
+        "text": "$foo$'`$$$$\"$foo$"
+      },
+      {
+        "kind": "OTHER",
+        "text": "$foo"
+      },
+      {
+        "kind": "OTHER",
+        "text": "$bar"
+      }
+    ]
+  },
+  {
+    "name": "unterminated-dollar-quoted-string-literal",
+    "comment": "Unterminated dollar-quoted string rewinds back to the first whitespace, under the assumption that the input is valid and we've interpreted it wrongly",
+    "input": "$foo$ banana $",
+    "tokens": [
+      {
+        "kind": "OTHER",
+        "text": "$foo$"
+      },
+      {
+        "kind": "IDENT",
+        "text": "banana"
+      },
+      {
+        "kind": "OTHER",
+        "text": "$"
+      }
+    ]
+  },
+  {
+    "name": "numeric-literals",
+    "input": "123 123.456 123E45 123e+45 123e-45 1.2.3",
+    "tokens": [
+      {
+        "kind": "NUMBER",
+        "text": "123"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123.456"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123E45"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123e+45"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "123e-45"
+      },
+      {
+        "kind": "NUMBER",
+        "text": "1.2"
+      },
+      {
+        "kind": "PERIOD",
+	"text": "."
+      },
+      {
+        "kind": "NUMBER",
+	"text": "3"
+      }
+    ]
+  }
+]

--- a/internal/sqlscanner/token.go
+++ b/internal/sqlscanner/token.go
@@ -52,10 +52,10 @@ var tokenStrings = [...]string{
 	NUMBER: "NUMBER",
 	STRING: "STRING",
 
-	PERIOD: ".",
-	COMMA:  ",",
-	LPAREN: "(",
-	RPAREN: ")",
+	PERIOD: "PERIOD",
+	COMMA:  "COMMA",
+	LPAREN: "LPAREN",
+	RPAREN: "RPAREN",
 
 	AS:       "AS",
 	CALL:     "CALL",

--- a/internal/sqlscanner/token.go
+++ b/internal/sqlscanner/token.go
@@ -28,6 +28,7 @@ const (
 	LPAREN // (
 	RPAREN // )
 
+	AS
 	CALL
 	DELETE
 	FROM
@@ -56,6 +57,7 @@ var tokenStrings = [...]string{
 	LPAREN: "(",
 	RPAREN: ")",
 
+	AS:       "AS",
 	CALL:     "CALL",
 	DELETE:   "DELETE",
 	FROM:     "FROM",
@@ -73,7 +75,7 @@ var tokenStrings = [...]string{
 // keywords contains keyword tokens, indexed
 // at the position of keyword length.
 var keywords = [...][]Token{
-	2: []Token{OR},
+	2: []Token{AS, OR},
 	3: []Token{SET},
 	4: []Token{CALL, FROM, INTO},
 	5: []Token{TABLE},

--- a/internal/sqlutil/signature.go
+++ b/internal/sqlutil/signature.go
@@ -129,7 +129,7 @@ func QuerySignature(query string) string {
 				haveFirstPeriod = true
 				havePeriod = true
 				tableName += "."
-			case sqlscanner.SET:
+			default:
 				return "UPDATE " + tableName
 			}
 		}

--- a/internal/sqlutil/signature_test.go
+++ b/internal/sqlutil/signature_test.go
@@ -37,6 +37,7 @@ func TestQuerySignature(t *testing.T) {
 
 	assertSignatureEqual("DELETE FROM foo.bar", "DELETE FROM foo.bar WHERE baz=1")
 	assertSignatureEqual("UPDATE foo.bar", "UPDATE IGNORE foo.bar SET bar=1 WHERE baz=2")
+	assertSignatureEqual("UPDATE foo", "UPDATE ONLY foo AS bar SET baz=1")
 	assertSignatureEqual("INSERT INTO foo.bar", "INSERT INTO foo.bar (col) VALUES(?)")
 	assertSignatureEqual("INSERT INTO foo.bar", "INSERT LOW_PRIORITY IGNORE INTO foo.bar (col) VALUES(?)")
 	assertSignatureEqual("CALL foo", "CALL foo(bar, 123)")

--- a/internal/sqlutil/testdata/tests.json
+++ b/internal/sqlutil/testdata/tests.json
@@ -1,0 +1,146 @@
+[
+  {
+    "input": "",
+    "output": ""
+  },
+  {
+    "input": " ",
+    "output": ""
+  },
+  {
+    "input": "SELECT * FROM foo.bar",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT * FROM foo.bar.baz",
+    "output": "SELECT FROM foo.bar.baz"
+  },
+  {
+    "input": "SELECT * FROM `foo.bar`",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT * FROM \"foo.bar\"",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT * FROM [foo.bar]",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "input": "SELECT (x, y) FROM foo,bar,baz",
+    "output": "SELECT FROM foo"
+  },
+  {
+    "input": "SELECT * FROM foo JOIN bar",
+    "output": "SELECT FROM foo"
+  },
+  {
+    "input": "SELECT * FROM dollar$bill",
+    "output": "SELECT FROM dollar$bill"
+  },
+  {
+    "input": "SELECT id FROM \"myta\n-æøåble\" WHERE id = 2323",
+    "output": "SELECT FROM myta\n-æøåble"
+  },
+  {
+    "input": "SELECT * FROM foo-- abc\n./*def*/bar",
+    "output": "SELECT FROM foo.bar"
+  },
+  {
+    "comment": "We capture the first table of the outermost select statement",
+    "input": "SELECT *,(SELECT COUNT(*) FROM table2 WHERE table2.field1 = table1.id) AS count FROM table1 WHERE table1.field1 = 'value'",
+    "output": "SELECT FROM table1"
+  },
+  {
+    "comment": "If the outermost select operates on derived tables, then we just return 'SELECT' (i.e. the fallback)",
+    "input": "SELECT * FROM (SELECT foo FROM bar) AS foo_bar",
+    "output": "SELECT"
+  },
+  {
+    "input": "DELETE FROM foo.bar WHERE baz=1",
+    "output": "DELETE FROM foo.bar"
+  },
+  {
+    "input": "UPDATE IGNORE foo.bar SET bar=1 WHERE baz=2",
+    "output": "UPDATE foo.bar"
+  },
+  {
+    "input": "UPDATE ONLY foo AS bar SET baz=1",
+    "output": "UPDATE foo"
+  },
+  {
+    "input": "INSERT INTO foo.bar (col) VALUES(?)",
+    "output": "INSERT INTO foo.bar"
+  },
+  {
+    "input": "INSERT LOW_PRIORITY IGNORE INTO foo.bar (col) VALUES(?)",
+    "output": "INSERT INTO foo.bar"
+  },
+  {
+    "input": "CALL foo(bar, 123)",
+    "output": "CALL foo"
+  },
+  {
+    "comment": "For DDL we only capture the first token",
+    "input": "ALTER TABLE foo ADD ()",
+    "output": "ALTER"
+  },
+  {
+    "input": "CREATE TABLE foo ...",
+    "output": "CREATE"
+  },
+  {
+    "input": "DROP TABLE foo",
+    "output": "DROP"
+  },
+  {
+    "input": "SAVEPOINT x_asd1234",
+    "output": "SAVEPOINT"
+  },
+  {
+    "input": "BEGIN",
+    "output": "BEGIN"
+  },
+  {
+    "input": "COMMIT",
+    "output": "COMMIT"
+  },
+  {
+    "input": "ROLLBACK",
+    "output": "ROLLBACK"
+  },
+  {
+    "comment": "For broken statements we only capture the first token",
+    "input": "SELECT * FROM (SELECT EOF",
+    "output": "SELECT"
+  },
+  {
+    "input": "SELECT 'neverending literal FROM (SELECT * FROM ...",
+    "output": "SELECT"
+  },
+  {
+    "input": "INSERT COIN TO PLAY",
+    "output": "INSERT"
+  },
+  {
+    "input": "INSERT $2 INTO",
+    "output": "INSERT"
+  },
+  {
+    "input": "UPDATE 99",
+    "output": "UPDATE"
+  },
+  {
+    "input": "DELETE 99",
+    "output": "DELETE"
+  },
+  {
+    "input": "DELETE FROM",
+    "output": "DELETE"
+  },
+  {
+    "input": "CALL",
+    "output": "CALL"
+  }
+]


### PR DESCRIPTION
Move the test cases to JSON docs, so they can be shared with other agents.

Fix a special form of UPDATE where the target table is aliased.