### PR TITLE
Add Docker container ID to system metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Stop pooling Transaction/Span/Error, introduce internal pooled objects (#319)
  - Enable metrics collection with default interval of 30s (#322)
  - `ELASTIC_APM_SERVER_CERT` enables server certificate pinning (#325)
+ - Add Docker container ID to metadata (#330)
 
 ## [v1.0.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.0.0)
 

--- a/internal/apmhostutil/container.go
+++ b/internal/apmhostutil/container.go
@@ -1,0 +1,13 @@
+package apmhostutil
+
+// ContainerID returns the full container ID in which the process is executing,
+// or an error if the container ID could not be determined.
+func ContainerID() (string, error) {
+	return DockerContainerID()
+}
+
+// DockerContainerID returns the full Docker container ID in which the process
+// is executing, or an error if the container ID could not be determined.
+func DockerContainerID() (string, error) {
+	return dockerContainerID()
+}

--- a/internal/apmhostutil/container_test.go
+++ b/internal/apmhostutil/container_test.go
@@ -1,0 +1,47 @@
+package apmhostutil_test
+
+import (
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm/internal/apmhostutil"
+)
+
+func TestContainerID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// Currently we only support ContainerID in Linux containers.
+		_, err := apmhostutil.ContainerID()
+		assert.Error(t, err)
+		return
+	}
+
+	// Ideally we would have the CI script pass the
+	// docker container ID into the test process,
+	// but this would make things convoluted. Instead,
+	// just do a basic check of cgroup to see if it's
+	// Docker-enabled, and then compare the ID to
+	// the container hostname.
+	data, err := ioutil.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		t.Skipf("failed to read cgroup (%s)", err)
+	}
+	if !strings.Contains(string(data), "docker") {
+		t.Skipf("not running inside docker")
+	}
+
+	id, err := apmhostutil.ContainerID()
+	require.NoError(t, err)
+	assert.Len(t, id, 64)
+
+	// Docker sets the container hostname to a prefix
+	// of the full container ID.
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+	assert.Equal(t, hostname, id[:len(hostname)])
+}

--- a/internal/apmhostutil/docker_linux.go
+++ b/internal/apmhostutil/docker_linux.go
@@ -1,0 +1,65 @@
+// +build linux
+
+package apmhostutil
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+func dockerContainerID() (string, error) {
+	f, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	id, ok, err := cgroupDockerContainerID(f)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", errors.New("could not determine Docker container ID")
+	}
+	return id, nil
+}
+
+func cgroupDockerContainerID(r io.Reader) (string, bool, error) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		fields := strings.SplitN(s.Text(), ":", 3)
+		if len(fields) != 3 {
+			continue
+		}
+		cgroupPath := fields[2]
+		if !strings.Contains(cgroupPath, "docker") {
+			continue
+		}
+
+		// Legacy: /system.slice/docker-<CID>.scope
+		// Current: /docker/<CID>
+		id := filepath.Base(cgroupPath)
+		id = strings.TrimPrefix(id, "docker-")
+		id = strings.TrimSuffix(id, ".scope")
+
+		// Sanity check the ID.
+		if len(id) != 64 {
+			return "", false, nil
+		}
+		for _, r := range id {
+			if !unicode.Is(unicode.ASCII_Hex_Digit, r) {
+				return "", false, nil
+			}
+		}
+		return id, true, nil
+	}
+	if err := s.Err(); err != nil {
+		return "", false, err
+	}
+	return "", false, nil
+}

--- a/internal/apmhostutil/docker_linux_test.go
+++ b/internal/apmhostutil/docker_linux_test.go
@@ -1,0 +1,73 @@
+package apmhostutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCgroupDockerContainerID(t *testing.T) {
+	id, ok, err := cgroupDockerContainerID(strings.NewReader(`
+12:devices:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+11:hugetlb:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+10:memory:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+9:freezer:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+8:perf_event:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+7:blkio:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+6:pids:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+5:rdma:/
+4:cpuset:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+3:net_cls,net_prio:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+2:cpu,cpuacct:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+1:name=systemd:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76
+0::/system.slice/docker.service`[1:]))
+
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76", id)
+}
+
+func TestCgroupDockerContainerIDNonContainer(t *testing.T) {
+	id, ok, err := cgroupDockerContainerID(strings.NewReader(`
+12:devices:/user.slice
+11:hugetlb:/
+10:memory:/user.slice
+9:freezer:/
+8:perf_event:/
+7:blkio:/user.slice
+6:pids:/user.slice/user-1000.slice/session-2.scope
+5:rdma:/
+4:cpuset:/
+3:net_cls,net_prio:/
+2:cpu,cpuacct:/user.slice
+1:name=systemd:/user.slice/user-1000.slice/session-2.scope
+0::/user.slice/user-1000.slice/session-2.scope`[1:]))
+
+	assert.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, "", id)
+}
+
+func TestCgroupDockerContainerIDLegacy(t *testing.T) {
+	id, ok, err := cgroupDockerContainerID(strings.NewReader(`
+1:name=systemd:/system.slice/docker-cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411.scope
+`[1:]))
+
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "cde7c2bab394630a42d73dc610b9c57415dced996106665d427f6d0566594411", id)
+}
+
+func TestCgroupDockerContainerIDNonHex(t *testing.T) {
+	// Imaginary future format. We use the last part of the path,
+	// trimming legacy prefix/suffix, and check the expected
+	// length and runes used.
+	id, ok, err := cgroupDockerContainerID(strings.NewReader(`
+1:name=systemd:/docker/051e2ee0bce99116029a13df4a9e943137f19f957f38ac02d6bad96f9b700f76/not_hex
+`[1:]))
+
+	assert.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, "", id)
+}

--- a/internal/apmhostutil/docker_nonlinux.go
+++ b/internal/apmhostutil/docker_nonlinux.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package apmhostutil
+
+import (
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+func dockerContainerID() (string, error) {
+	return "", errors.Errorf("docker container ID computation not implemented for %s", runtime.GOOS)
+}

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -135,6 +135,7 @@ func (v *Runtime) MarshalFastJSON(w *fastjson.Writer) error {
 }
 
 func (v *System) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
 	w.RawByte('{')
 	first := true
 	if v.Architecture != "" {
@@ -146,6 +147,18 @@ func (v *System) MarshalFastJSON(w *fastjson.Writer) error {
 			w.RawString(prefix)
 		}
 		w.String(v.Architecture)
+	}
+	if v.Container != nil {
+		const prefix = ",\"container\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.Container.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 	if v.Hostname != "" {
 		const prefix = ",\"hostname\":"
@@ -168,7 +181,7 @@ func (v *System) MarshalFastJSON(w *fastjson.Writer) error {
 		w.String(v.Platform)
 	}
 	w.RawByte('}')
-	return nil
+	return firstErr
 }
 
 func (v *Process) MarshalFastJSON(w *fastjson.Writer) error {
@@ -194,6 +207,14 @@ func (v *Process) MarshalFastJSON(w *fastjson.Writer) error {
 		w.RawString(",\"title\":")
 		w.String(v.Title)
 	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *Container) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	w.RawString("\"id\":")
+	w.String(v.ID)
 	w.RawByte('}')
 	return nil
 }

--- a/model/model.go
+++ b/model/model.go
@@ -82,6 +82,9 @@ type System struct {
 
 	// Platform is the system's platform, or operating system name.
 	Platform string `json:"platform,omitempty"`
+
+	// Container describes the container running the service.
+	Container *Container `json:"container,omitempty"`
 }
 
 // Process represents an operating system process.
@@ -97,6 +100,12 @@ type Process struct {
 
 	// Argv holds the command line arguments used to start the process.
 	Argv []string `json:"argv,omitempty"`
+}
+
+// Container represents the container (e.g. Docker) running the service.
+type Container struct {
+	// ID is the unique container ID.
+	ID string `json:"id"`
 }
 
 // Transaction represents a transaction handled by the service.

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.elastic.co/apm"
+	"go.elastic.co/apm/internal/apmhostutil"
 	"go.elastic.co/apm/transport"
 	"go.elastic.co/apm/transport/transporttest"
 )
@@ -350,6 +351,24 @@ func TestTracerBodyUnread(t *testing.T) {
 		tracer.StartTransaction("name", "type").End()
 	}
 	tracer.Flush(nil)
+}
+
+func TestTracerMetadata(t *testing.T) {
+	tracer, recorder := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	tracer.StartTransaction("name", "type").End()
+	tracer.Flush(nil)
+
+	// TODO(axw) check other metadata
+	system, _, _ := recorder.Metadata()
+	containerID, err := apmhostutil.ContainerID()
+	if err != nil {
+		assert.Nil(t, system.Container)
+	} else {
+		require.NotNil(t, system.Container)
+		assert.Equal(t, containerID, system.Container.ID)
+	}
 }
 
 type blockedTransport struct {

--- a/utils.go
+++ b/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"go.elastic.co/apm/internal/apmhostutil"
 	"go.elastic.co/apm/internal/apmstrings"
 	"go.elastic.co/apm/model"
 )
@@ -74,6 +75,11 @@ func getLocalSystem() model.System {
 		}
 	}
 	system.Hostname = truncateString(system.Hostname)
+	if containerID, err := apmhostutil.ContainerID(); err == nil {
+		system.Container = &model.Container{
+			ID: containerID,
+		}
+	}
 	return system
 }
 


### PR DESCRIPTION
Update the "system" metadata with the container ID, if we detect one. Currently we only support doing this from within Docker containers.

Closes #328 