### PR TITLE
Introduce Span.Subtype, Span.Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - `ELASTIC_APM_SERVER_CERT` enables server certificate pinning (#325)
  - Add Docker container ID to metadata (#330)
  - Added distributed trace context propagation to apmgrpc (#335)
+ - Introduce `Span.Subtype`, `Span.Action` (#332)
 
 ## [v1.0.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.0.0)
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -189,6 +189,9 @@ type, and optional parent span, and with the start time set to the current time.
 If you need to set the timestamp or parent <<trace-context, trace context>>, you should
 use <<transaction-start-span-options, Transaction.StartSpanOptions>>.
 
+If the span type contains two dots, they are assumed to separate the span type, subtype,
+and action; a single dot separates span type and subtype, and the action will not be set.
+
 If the transaction is sampled, then the span's ID will be set, and its stacktrace will
 be set if the tracer is configured accordingly. If the transaction is not sampled, then
 the returned span will be silently discarded when its End method is called. You can

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -303,6 +303,10 @@ func (v *Span) MarshalFastJSON(w *fastjson.Writer) error {
 	}
 	w.RawString(",\"type\":")
 	w.String(v.Type)
+	if v.Action != "" {
+		w.RawString(",\"action\":")
+		w.String(v.Action)
+	}
 	if v.Context != nil {
 		w.RawString(",\"context\":")
 		if err := v.Context.MarshalFastJSON(w); err != nil && firstErr == nil {
@@ -327,6 +331,10 @@ func (v *Span) MarshalFastJSON(w *fastjson.Writer) error {
 			}
 		}
 		w.RawByte(']')
+	}
+	if v.Subtype != "" {
+		w.RawString(",\"subtype\":")
+		w.String(v.Subtype)
 	}
 	w.RawByte('}')
 	return firstErr

--- a/model/model.go
+++ b/model/model.go
@@ -174,9 +174,16 @@ type Span struct {
 	// Duration holds the duration of the span, in milliseconds.
 	Duration float64 `json:"duration"`
 
-	// Type identifies the service-domain specific type of the span,
-	// e.g. "db.postgresql.query".
+	// Type identifies the overarching type of the span,
+	// e.g. "db" or "external".
 	Type string `json:"type"`
+
+	// Subtype identifies the subtype of the span,
+	// e.g. "mysql" or "http".
+	Subtype string `json:"subtype,omitempty"`
+
+	// Action identifies the action that is being undertaken, e.g. "query".
+	Action string `json:"action,omitempty"`
 
 	// ID holds the ID of the span.
 	ID SpanID `json:"id"`

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -115,6 +115,8 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *SpanData) {
 
 	out.Name = truncateString(span.Name)
 	out.Type = truncateString(span.Type)
+	out.Subtype = truncateString(span.Subtype)
+	out.Action = truncateString(span.Action)
 	out.Timestamp = model.Time(span.timestamp.UTC())
 	out.Duration = span.Duration.Seconds() * 1000
 	out.Context = span.Context.build()

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -80,8 +80,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	name := r.requestName(req)
-	spanType := "ext.http"
-	span := tx.StartSpan(name, spanType, apm.SpanFromContext(ctx))
+	span := tx.StartSpan(name, "external.http", apm.SpanFromContext(ctx))
 	span.Context.SetHTTPRequest(req)
 	if !span.Dropped() {
 		traceContext = span.TraceContext()

--- a/module/apmhttp/client_test.go
+++ b/module/apmhttp/client_test.go
@@ -54,7 +54,8 @@ func TestClient(t *testing.T) {
 	span := payloads.Spans[0]
 
 	assert.Equal(t, "GET "+server.Listener.Addr().String(), span.Name)
-	assert.Equal(t, "ext.http", span.Type)
+	assert.Equal(t, "external", span.Type)
+	assert.Equal(t, "http", span.Subtype)
 	assert.Equal(t, &model.SpanContext{
 		HTTP: &model.HTTPSpanContext{
 			// Note no user info included in server.URL.
@@ -163,7 +164,6 @@ func TestClientDuration(t *testing.T) {
 	span := spans[0]
 
 	assert.Equal(t, "GET "+server.Listener.Addr().String(), span.Name)
-	assert.Equal(t, "ext.http", span.Type)
 	assert.InDelta(t, delay/time.Millisecond, span.Duration, 100)
 }
 

--- a/module/apmot/example_test.go
+++ b/module/apmot/example_test.go
@@ -37,10 +37,10 @@ func Example() {
 	}
 
 	// Output:
-	// transaction: Parent/unknown
-	// span: span_0/unknown
-	// span: span_1/unknown
-	// span: span_2/unknown
-	// span: span_3/unknown
-	// span: span_4/unknown
+	// transaction: Parent/custom
+	// span: span_0/custom
+	// span: span_1/custom
+	// span: span_2/custom
+	// span: span_3/custom
+	// span: span_4/custom
 }

--- a/module/apmot/span.go
+++ b/module/apmot/span.go
@@ -145,7 +145,8 @@ func (s *otSpan) setSpanContext() {
 	switch {
 	case haveHTTPContext:
 		if s.span.Type == "" {
-			s.span.Type = "ext.http"
+			s.span.Type = "external"
+			s.span.Subtype = "http"
 		}
 		url, err := url.Parse(httpURL)
 		if err == nil {
@@ -158,19 +159,14 @@ func (s *otSpan) setSpanContext() {
 		}
 	case haveDBContext:
 		if s.span.Type == "" {
-			dbType := "sql"
-			if dbContext.Type != "" {
-				dbType = dbContext.Type
-			}
-			s.span.Type = fmt.Sprintf("db.%s.query", dbType)
+			s.span.Type = "db"
+			s.span.Subtype = dbContext.Type
 		}
 		s.span.Context.SetDatabase(dbContext)
 	}
 	if s.span.Type == "" {
-		s.span.Type = component
-		if s.span.Type == "" {
-			s.span.Type = "unknown"
-		}
+		s.span.Type = "custom"
+		s.span.Subtype = component
 	}
 }
 
@@ -219,7 +215,7 @@ func (s *otSpan) setTransactionContext() {
 		} else if component != "" {
 			s.ctx.tx.Type = component
 		} else {
-			s.ctx.tx.Type = "unknown"
+			s.ctx.tx.Type = "custom"
 		}
 	}
 	if s.ctx.tx.Result == "" {

--- a/module/apmredigo/conn.go
+++ b/module/apmredigo/conn.go
@@ -76,7 +76,7 @@ func Do(ctx context.Context, conn redis.Conn, commandName string, args ...interf
 	if spanName == "" {
 		spanName = "(flush pipeline)"
 	}
-	span, _ := apm.StartSpan(ctx, spanName, "cache.redis")
+	span, _ := apm.StartSpan(ctx, spanName, "db.redis")
 	defer span.End()
 	return conn.Do(commandName, args...)
 }
@@ -87,7 +87,7 @@ func DoWithTimeout(ctx context.Context, conn redis.Conn, timeout time.Duration, 
 	if spanName == "" {
 		spanName = "(flush pipeline)"
 	}
-	span, _ := apm.StartSpan(ctx, spanName, "cache.redis")
+	span, _ := apm.StartSpan(ctx, spanName, "db.redis")
 	defer span.End()
 	return redis.DoWithTimeout(conn, timeout, commandName, args...)
 }

--- a/module/apmredigo/conn_test.go
+++ b/module/apmredigo/conn_test.go
@@ -23,7 +23,8 @@ func TestWrap(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "PING", spans[0].Name)
-	assert.Equal(t, "cache.redis", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "redis", spans[0].Subtype)
 }
 
 func TestWithContext(t *testing.T) {
@@ -55,7 +56,6 @@ func TestConnWithTimeout(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "PING", spans[0].Name)
-	assert.Equal(t, "cache.redis", spans[0].Type)
 }
 
 func TestWrapPipeline(t *testing.T) {

--- a/module/apmsql/apmsql_go110_test.go
+++ b/module/apmsql/apmsql_go110_test.go
@@ -26,7 +26,7 @@ func TestConnect(t *testing.T) {
 	})
 	require.Len(t, spans, 2)
 	assert.Equal(t, "connect", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.connect", spans[0].Type)
+	assert.Equal(t, "connect", spans[0].Action)
 	assert.Equal(t, "ping", spans[1].Name)
-	assert.Equal(t, "db.sqlite3.ping", spans[1].Type)
+	assert.Equal(t, "ping", spans[1].Action)
 }

--- a/module/apmsql/apmsql_test.go
+++ b/module/apmsql/apmsql_test.go
@@ -26,7 +26,9 @@ func TestPingContext(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "ping", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.ping", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "ping", spans[0].Action)
 }
 
 func TestExecContext(t *testing.T) {
@@ -41,7 +43,9 @@ func TestExecContext(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "CREATE", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.exec", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "exec", spans[0].Action)
 }
 
 func TestQueryContext(t *testing.T) {
@@ -61,7 +65,9 @@ func TestQueryContext(t *testing.T) {
 
 	assert.NotNil(t, spans[0].ID)
 	assert.Equal(t, "SELECT FROM foo", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.query", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "query", spans[0].Action)
 	assert.Equal(t, &model.SpanContext{
 		Database: &model.DatabaseSpanContext{
 			Instance:  ":memory:",
@@ -86,7 +92,9 @@ func TestPrepareContext(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "CREATE", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.prepare", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "prepare", spans[0].Action)
 }
 
 func TestStmtExecContext(t *testing.T) {
@@ -107,7 +115,9 @@ func TestStmtExecContext(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "DELETE FROM foo", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.exec", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "exec", spans[0].Action)
 }
 
 func TestStmtQueryContext(t *testing.T) {
@@ -129,7 +139,9 @@ func TestStmtQueryContext(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "SELECT FROM foo", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.query", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "query", spans[0].Action)
 }
 
 func TestTxStmtQueryContext(t *testing.T) {
@@ -156,7 +168,9 @@ func TestTxStmtQueryContext(t *testing.T) {
 	})
 	require.Len(t, spans, 1)
 	assert.Equal(t, "SELECT FROM foo", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.query", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "query", spans[0].Action)
 }
 
 func TestCaptureErrors(t *testing.T) {
@@ -172,6 +186,8 @@ func TestCaptureErrors(t *testing.T) {
 	require.Len(t, spans, 1)
 	require.Len(t, errors, 1)
 	assert.Equal(t, "SELECT FROM thin_air", spans[0].Name)
-	assert.Equal(t, "db.sqlite3.query", spans[0].Type)
+	assert.Equal(t, "db", spans[0].Type)
+	assert.Equal(t, "sqlite3", spans[0].Subtype)
+	assert.Equal(t, "query", spans[0].Action)
 	assert.Equal(t, "no such table: thin_air", errors[0].Exception.Message)
 }

--- a/module/apmsql/mysql/mysql_test.go
+++ b/module/apmsql/mysql/mysql_test.go
@@ -37,7 +37,7 @@ func TestQueryContext(t *testing.T) {
 
 	assert.NotNil(t, spans[0].ID)
 	assert.Equal(t, "SELECT FROM foo", spans[0].Name)
-	assert.Equal(t, "db.mysql.query", spans[0].Type)
+	assert.Equal(t, "mysql", spans[0].Subtype)
 	assert.Equal(t, &model.SpanContext{
 		Database: &model.DatabaseSpanContext{
 			Instance:  "test_db",

--- a/module/apmsql/pq/pq_test.go
+++ b/module/apmsql/pq/pq_test.go
@@ -35,7 +35,7 @@ func TestQueryContext(t *testing.T) {
 
 	assert.NotNil(t, spans[0].ID)
 	assert.Equal(t, "SELECT FROM foo", spans[0].Name)
-	assert.Equal(t, "db.postgresql.query", spans[0].Type)
+	assert.Equal(t, "postgresql", spans[0].Subtype)
 	assert.Equal(t, &model.SpanContext{
 		Database: &model.DatabaseSpanContext{
 			Instance:  "test_db",


### PR DESCRIPTION
The type supplied via the StartSpan methods will now be split on dots, and the Type, Subtype, and Action fields populated in order. If the type has only one dot, then action will not be set.

Closes elastic/apm-agent-go#323 