### PR TITLE
module/apmecho: Set *apm.Transaction on echo.Context

### DIFF
--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -11,6 +11,9 @@ import (
 	"go.elastic.co/apm/module/apmhttp"
 )
 
+// TxContextKey is used as a key to get *apm.Transaction from echo.Context
+const TxContextKey = "apm-transaction"
+
 // Middleware returns a new Echo middleware handler for tracing
 // requests and reporting errors.
 //
@@ -51,6 +54,7 @@ func (m *middleware) handle(c echo.Context) error {
 	name := req.Method + " " + c.Path()
 	tx, req := apmhttp.StartTransaction(m.tracer, name, req)
 	defer tx.End()
+	c.Set(TxContextKey, tx)
 	c.SetRequest(req)
 	body := m.tracer.CaptureHTTPRequestBody(req)
 


### PR DESCRIPTION
Now, we can't get `*apm.Transaction` in the handler.
It is hard to track some behavior in the handler.

So, I create some code to set `*apm.Transaction` on `echo.Context`.
I think that it makes me track some behavior in the handler easily.