### PR TITLE
module/apmgokit: add tests, examples, docs

### DIFF
--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -151,3 +151,17 @@ the client interceptor will create a span for each outgoing request.
 
 See <<builtin-modules-apmgrpc, module/apmgrpc>> for more information
 about gRPC instrumentation.
+
+[float]
+[[supported-tech-services]]
+=== Service Frameworks
+
+[float]
+==== Go kit
+
+We support tracing https://gokit.io/[Go kit] clients and servers when
+using the gRPC or HTTP transport, by way of <<builtin-modules-apmgrpc, module/apmgrpc>>
+and <<builtin-modules-apmhttp, module/apmhttp>> respectively.
+
+Code examples are available at https://godoc.org/go.elastic.co/apm/module/apmgokit
+for getting started.

--- a/module/apmgokit/README.md
+++ b/module/apmgokit/README.md
@@ -1,0 +1,16 @@
+# apmgokit
+
+Package apmgokit provides examples and integration tests
+for tracing services implemented with Go kit.
+
+We do not provide any Go kit specific code, as the other
+generic modules ([module/apmhttp](../apmhttp) and [module/apmgrpc](../apmgrpc))
+are sufficient.
+
+Go kit-based HTTP servers can be traced by instrumenting the
+kit/transport/http.Server with apmhttp.Wrap, and HTTP clients
+can be traced by providing a net/http.Client instrumented with
+apmhttp.WrapClient.
+
+Go kit-based gRPC servers and clients can both be wrapped using
+the interceptors provided in module/apmgrpc.

--- a/module/apmgokit/doc.go
+++ b/module/apmgokit/doc.go
@@ -1,0 +1,14 @@
+// Package apmgokit provides examples and integration tests
+// for tracing services implemented with Go kit.
+//
+// We do not provide any Go kit specific code, as the other
+// generic modules (apmhttp and apmgrpc) are sufficient.
+//
+// Go kit-based HTTP servers can be traced by instrumenting
+// the kit/transport/http.Server with apmhttp.Wrap, and HTTP
+// clients can be traced by providing a net/http.Client
+// instrumented with apmhttp.WrapClient.
+//
+// Go kit-based gRPC servers and clients can both be wrapped
+// using the interceptors provided in module/apmgrpc.
+package apmgokit

--- a/module/apmgokit/grpc_test.go
+++ b/module/apmgokit/grpc_test.go
@@ -1,0 +1,180 @@
+// +build go1.9
+
+package apmgokit_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	kitgrpc "github.com/go-kit/kit/transport/grpc"
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	netcontext "golang.org/x/net/context"
+	"google.golang.org/grpc"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/module/apmgrpc"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func Example_grpcServer() {
+	// Create your go-kit/kit/transport/grpc.Server as usual, without any tracing middleware.
+	endpoint := func(ctx context.Context, req interface{}) (interface{}, error) {
+		// The middleware added to the underlying gRPC server will be propagate
+		// a transaction to the context passed to your endpoint. You can then
+		// report endpoint-specific spans using apm.StartSpan.
+		span, ctx := apm.StartSpan(ctx, "name", "endpoint")
+		defer span.End()
+		return nil, nil
+	}
+	var encodeRequest func(ctx context.Context, req interface{}) (interface{}, error)
+	var decodeResponse func(ctx context.Context, req interface{}) (interface{}, error)
+	service := &helloWorldService{kitgrpc.NewServer(
+		endpoint,
+		encodeRequest,
+		decodeResponse,
+	)}
+
+	// When creating the underlying gRPC server, use the apmgrpc.NewUnaryServerInterceptor
+	// function (from module/apmgrpc). This will trace all incoming requests.
+	s := grpc.NewServer(grpc.UnaryInterceptor(apmgrpc.NewUnaryServerInterceptor()))
+	defer s.GracefulStop()
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		panic(err)
+	}
+	go s.Serve(lis)
+	pb.RegisterGreeterServer(s, service)
+}
+
+func Example_grpcClient() {
+	// When dialling the gRPC client connection, use the apmgrpc.NewUnaryClientInterceptor
+	// function (from module/apmgrpc). This will trace all outgoing requests, as long as
+	// the context supplied to methods include an apm.Transaction.
+	conn, err := grpc.Dial("localhost:1234", grpc.WithUnaryInterceptor(apmgrpc.NewUnaryClientInterceptor()))
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	// Create your go-kit/kit/transport/grpc.Client as usual, without any tracing middleware.
+	client := kitgrpc.NewClient(
+		conn, "helloworld.Greeter", "SayHello",
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return &pb.HelloRequest{Name: req.(string)}, nil
+		},
+		func(ctx context.Context, resp interface{}) (interface{}, error) {
+			return resp, nil
+		},
+		&pb.HelloReply{},
+	)
+
+	tx := apm.DefaultTracer.StartTransaction("name", "type")
+	ctx := apm.ContextWithTransaction(context.Background(), tx)
+	defer tx.End()
+
+	_, err = client.Endpoint()(ctx, "world")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestGRPCTransport(t *testing.T) {
+	serverTracer, serverTransport := transporttest.NewRecorderTracer()
+	defer serverTracer.Close()
+
+	sayHelloEndpoint := func(ctx context.Context, req interface{}) (interface{}, error) {
+		span, ctx := apm.StartSpan(ctx, "SayHello", "endpoint")
+		defer span.End()
+		return nil, nil
+	}
+
+	s, addr := newServer(t, serverTracer, &helloWorldService{
+		sayHello: kitgrpc.NewServer(
+			sayHelloEndpoint,
+			func(ctx context.Context, req interface{}) (interface{}, error) {
+				return req, nil
+			},
+			func(ctx context.Context, resp interface{}) (interface{}, error) {
+				return &pb.HelloReply{}, nil
+			},
+		),
+	})
+	defer s.GracefulStop()
+
+	conn := newClient(t, addr)
+	defer conn.Close()
+
+	client := kitgrpc.NewClient(
+		conn, "helloworld.Greeter", "SayHello",
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return &pb.HelloRequest{Name: req.(string)}, nil
+		},
+		func(ctx context.Context, resp interface{}) (interface{}, error) {
+			return &pb.HelloReply{}, nil
+		},
+		&pb.HelloReply{},
+	)
+	_, clientSpans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		_, err := client.Endpoint()(ctx, "birita")
+		assert.NoError(t, err)
+	})
+	require.Len(t, clientSpans, 1)
+	assert.Equal(t, "/helloworld.Greeter/SayHello", clientSpans[0].Name)
+
+	serverTracer.Flush(nil)
+	payloads := serverTransport.Payloads()
+	require.Len(t, payloads.Transactions, 1)
+	require.Len(t, payloads.Spans, 1)
+	assert.Equal(t, "/helloworld.Greeter/SayHello", payloads.Transactions[0].Name)
+	assert.Equal(t, "endpoint", payloads.Spans[0].Type)
+	assert.Equal(t, clientSpans[0].ID, payloads.Transactions[0].ParentID)
+	assert.Equal(t, clientSpans[0].TraceID, payloads.Transactions[0].TraceID)
+}
+
+type helloWorldService struct {
+	sayHello *kitgrpc.Server
+}
+
+func (s *helloWorldService) SayHello(ctx netcontext.Context, req *pb.HelloRequest) (*pb.HelloReply, error) {
+	_, rep, err := s.sayHello.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return rep.(*pb.HelloReply), nil
+}
+
+func newServer(t *testing.T, tracer *apm.Tracer, server pb.GreeterServer, opts ...apmgrpc.ServerOption) (*grpc.Server, net.Addr) {
+	// We always install grpc_recovery first to avoid panics
+	// aborting the test process. We install it before the
+	// apmgrpc interceptor so that apmgrpc can recover panics
+	// itself if configured to do so.
+	interceptors := []grpc.UnaryServerInterceptor{grpc_recovery.UnaryServerInterceptor()}
+	serverOpts := []grpc.ServerOption{}
+	if tracer != nil {
+		opts = append(opts, apmgrpc.WithTracer(tracer))
+		interceptors = append(interceptors, apmgrpc.NewUnaryServerInterceptor(opts...))
+	}
+	serverOpts = append(serverOpts, grpc_middleware.WithUnaryServerChain(interceptors...))
+
+	s := grpc.NewServer(serverOpts...)
+	pb.RegisterGreeterServer(s, server)
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	go s.Serve(lis)
+	return s, lis.Addr()
+}
+
+func newClient(t *testing.T, addr net.Addr) *grpc.ClientConn {
+	conn, err := grpc.Dial(
+		addr.String(), grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(apmgrpc.NewUnaryClientInterceptor()),
+	)
+	require.NoError(t, err)
+	return conn
+}

--- a/module/apmgokit/http_test.go
+++ b/module/apmgokit/http_test.go
@@ -1,0 +1,118 @@
+package apmgokit_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/model"
+	"go.elastic.co/apm/module/apmhttp"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func Example_httpServer() {
+	// Create your go-kit/kit/transport/http.Server as usual, without any tracing middleware.
+	endpoint := func(ctx context.Context, req interface{}) (interface{}, error) {
+		// The middleware added to the underlying gRPC server will be propagate
+		// a transaction to the context passed to your endpoint. You can then
+		// report endpoint-specific spans using apm.StartSpan.
+		span, ctx := apm.StartSpan(ctx, "name", "endpoint")
+		defer span.End()
+		return nil, nil
+	}
+	server := kithttp.NewServer(
+		endpoint,
+		kithttp.NopRequestDecoder,
+		func(_ context.Context, w http.ResponseWriter, _ interface{}) error { return nil },
+	)
+
+	// Use apmhttp.Wrap (from module/apmhttp) to instrument the
+	// kit/transport/http.Server. This will trace all incoming requests.
+	http.ListenAndServe("localhost:1234", apmhttp.Wrap(server))
+}
+
+func Example_httpClient() {
+	// When constructing the kit/transport/http.Client, pass in an http.Client
+	// instrumented using apmhttp.WrapClient (from module/apmhttp). This will
+	// trace all outgoing requests, as long as the context supplied to methods
+	// include an apm.Transaction.
+	client := kithttp.NewClient(
+		"GET", &url.URL{ /*...*/ },
+		kithttp.EncodeJSONRequest,
+		func(_ context.Context, r *http.Response) (interface{}, error) { return nil, nil },
+		kithttp.SetClient(apmhttp.WrapClient(http.DefaultClient)),
+	)
+
+	tx := apm.DefaultTracer.StartTransaction("name", "type")
+	ctx := apm.ContextWithTransaction(context.Background(), tx)
+	defer tx.End()
+
+	_, err := client.Endpoint()(ctx, struct{}{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestHTTPTransport(t *testing.T) {
+	serverTracer, serverRecorder := transporttest.NewRecorderTracer()
+	defer serverTracer.Close()
+
+	endpoint := func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		span, ctx := apm.StartSpan(ctx, "name", "type")
+		defer span.End()
+		return struct{}{}, nil
+	}
+
+	server := httptest.NewServer(apmhttp.Wrap(kithttp.NewServer(
+		endpoint,
+		kithttp.NopRequestDecoder,
+		func(_ context.Context, w http.ResponseWriter, _ interface{}) error {
+			w.Header().Set("foo", "bar")
+			w.WriteHeader(http.StatusTeapot)
+			return nil
+		},
+	), apmhttp.WithTracer(serverTracer)))
+	defer server.Close()
+
+	url, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	url.Path = "/foo"
+	client := kithttp.NewClient(
+		"GET", url,
+		kithttp.EncodeJSONRequest,
+		func(_ context.Context, r *http.Response) (interface{}, error) {
+			assert.Equal(t, http.StatusTeapot, r.StatusCode)
+			return nil, nil
+		},
+		kithttp.SetClient(apmhttp.WrapClient(http.DefaultClient)),
+	)
+	clientTransaction, clientSpans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		client.Endpoint()(ctx, struct{}{})
+	})
+	require.Len(t, clientSpans, 1)
+
+	serverTracer.Flush(nil)
+	payloads := serverRecorder.Payloads()
+	require.Len(t, payloads.Transactions, 1)
+	require.Len(t, payloads.Spans, 1)
+
+	assert.Equal(t, "GET /foo", payloads.Transactions[0].Name)
+	assert.Equal(t, "name", payloads.Spans[0].Name)
+	assert.Equal(t, payloads.Transactions[0].ID, payloads.Spans[0].ParentID)
+	assert.Equal(t, clientTransaction.TraceID, payloads.Transactions[0].TraceID)
+	assert.Equal(t, clientSpans[0].ID, payloads.Transactions[0].ParentID)
+
+	responseContext := payloads.Transactions[0].Context.Response
+	assert.Equal(t, http.StatusTeapot, responseContext.StatusCode)
+	assert.Equal(t, model.Headers{
+		{Key: "Foo", Values: []string{"bar"}},
+	}, responseContext.Headers)
+}

--- a/scripts/Dockerfile-testing
+++ b/scripts/Dockerfile-testing
@@ -5,6 +5,8 @@ RUN go get -v github.com/aws/aws-lambda-go/lambda/messages
 RUN go get -v github.com/aws/aws-lambda-go/lambdacontext
 RUN go get -v github.com/emicklei/go-restful
 RUN go get -v github.com/gin-gonic/gin
+RUN go get -v github.com/go-kit/kit/transport/grpc
+RUN go get -v github.com/go-kit/kit/transport/http
 RUN go get -v github.com/go-sql-driver/mysql
 RUN go get -v github.com/gocql/gocql
 RUN go get -v github.com/gomodule/redigo/redis


### PR DESCRIPTION
Instrumentation is handled by apmhttp and apmgrpc. This package just has tests and example code.