### PR TITLE
[APM-CI] use new step to download the docs repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
   parameters {
     string(name: 'branch_specifier', defaultValue: "", description: "the Git branch specifier to build (<branchName>, <tagName>, <commitId>, etc.)")
     string(name: 'GO_VERSION', defaultValue: "1.10.3", description: "Go version to use.")
+    booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'linux_ci', defaultValue: true, description: 'Enable Linux build')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
     booleanParam(name: 'integration_test_ci', defaultValue: true, description: 'Enable run integration test')
@@ -136,7 +137,16 @@ pipeline {
           when {
             beforeAgent true
             allOf {
-              branch 'master';
+              anyOf {
+                not {
+                  changeRequest()
+                }
+                branch 'master'
+                branch "\\d+\\.\\d+"
+                branch "v\\d?"
+                tag "v\\d+\\.\\d+\\.\\d+*"
+                environment name: 'Run_As_Master_Branch', value: 'true'
+              }
               environment name: 'bench_ci', value: 'true'
             }
           }
@@ -202,7 +212,16 @@ pipeline {
           when {
             beforeAgent true
             allOf {
-              branch 'master';
+              anyOf {
+                not {
+                  changeRequest()
+                }
+                branch 'master'
+                branch "\\d+\\.\\d+"
+                branch "v\\d?"
+                tag "v\\d+\\.\\d+\\.\\d+*"
+                environment name: 'Run_As_Master_Branch', value: 'true'
+              }
               environment name: 'integration_test_master_ci', value: 'true'
             }
           }
@@ -266,7 +285,16 @@ pipeline {
       when {
         beforeAgent true
         allOf {
-          branch 'master';
+          anyOf {
+            not {
+              changeRequest()
+            }
+            branch 'master'
+            branch "\\d+\\.\\d+"
+            branch "v\\d?"
+            tag "v\\d+\\.\\d+\\.\\d+*"
+            environment name: 'Run_As_Master_Branch', value: 'true'
+          }
           environment name: 'doc_ci', value: 'true'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,9 +273,7 @@ pipeline {
       steps {
         withEnvWrapper() {
           unstash 'source'
-          dir("${ELASTIC_DOCS}"){
-            git "https://github.com/elastic/docs.git"
-          }
+          checkoutElasticDocsTools(basedir: "${ELASTIC_DOCS}")
           dir("${BASE_DIR}"){
             sh """#!/bin/bash
             make docs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'master || linux' }
+      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         PATH = "${env.PATH}:${env.HUDSON_HOME}/go/bin/:${env.WORKSPACE}/bin"


### PR DESCRIPTION
The new step checkoutElasticDocsTools make the checkout only of the tools to build the docs, it saves about 4G of download.

* The documentation build step goes from 4 min to 1.5 min, so we are about 3 min faster now.
* We added a branch filter for some stages, before those stages only run on master
* We added a parameter to be able running any stage on a PR or branch