### PR TITLE
module/apmsql: don't report driver.ErrBadConn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Added distributed trace context propagation to apmgrpc (#335)
  - Introduce `Span.Subtype`, `Span.Action` (#332)
  - apm.StartSpanOptions fixed to stop ignoring options (#326)
+ - module/apmsql: don't report driver.ErrBadConn (#346)
 
 ## [v1.0.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.0.0)
 

--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -68,8 +68,15 @@ func (c *conn) finishSpan(ctx context.Context, span *apm.Span, resultError *erro
 		// in check.
 		return
 	}
-	if e := apm.CaptureError(ctx, *resultError); e != nil {
-		e.Send()
+	switch *resultError {
+	case nil, driver.ErrBadConn:
+		// ErrBadConn is used by the connection pooling
+		// logic in database/sql, and so is expected and
+		// should not be reported.
+	default:
+		if e := apm.CaptureError(ctx, *resultError); e != nil {
+			e.Send()
+		}
 	}
 	span.End()
 }


### PR DESCRIPTION
database/sql drivers may return driver.ErrBadConn
to indicate that the connection is bad, and should
not be reused. We should not report these errors,
as they are expected by database/sql, and used for
connection pooling/reuse.

Closes #345 