### PR TITLE
module/apmsql: don't report context.Canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
  - Introduce `Span.Subtype`, `Span.Action` (#332)
  - apm.StartSpanOptions fixed to stop ignoring options (#326)
  - Add Kubernetes pod info to metadata (#342)
- - module/apmsql: don't report driver.ErrBadConn (#346)
+ - module/apmsql: don't report driver.ErrBadConn, context.Canceled (#346, #348)
 
 ## [v1.0.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.0.0)
 

--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -69,10 +69,13 @@ func (c *conn) finishSpan(ctx context.Context, span *apm.Span, resultError *erro
 		return
 	}
 	switch *resultError {
-	case nil, driver.ErrBadConn:
+	case nil, driver.ErrBadConn, context.Canceled:
 		// ErrBadConn is used by the connection pooling
 		// logic in database/sql, and so is expected and
 		// should not be reported.
+		//
+		// context.Canceled means the callers canceled
+		// the operation, so this is also expected.
 	default:
 		if e := apm.CaptureError(ctx, *resultError); e != nil {
 			e.Send()


### PR DESCRIPTION
Don't report context.Canceled errors from
module/apmsql, they should be expected since
it is only returned due to the caller having
canceled the request.

Closes #347 