### PR TITLE
Docs: version documentation links

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -15,6 +15,7 @@ endif::[]
 
 ifndef::env-github[]
 :branch: current
+:server-branch: 6.5
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::./introduction.asciidoc[Introduction]
 include::./supported-tech.asciidoc[Supported Technologies]

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -15,8 +15,8 @@ https://golang.org/pkg/database/sql/[database/sql] drivers, and APIs for custom 
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-Please view the {apm-get-started-ref}/index.html[APM Overview] for details on how these components work together. 
+APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together. 
 
 ifdef::env-github[]
 NOTE: For the best reading experience, please head over to this document at https://www.elastic.co/guide/en/apm/agent/go/current/index.html[elastic.co]


### PR DESCRIPTION
Versions go master links to APM Server and APM Overview v6.5 per elastic/apm/issues/19.