### PR TITLE
apm: support combined exception/log errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - apm.StartSpanOptions fixed to stop ignoring options (#326)
  - Add Kubernetes pod info to metadata (#342)
  - module/apmsql: don't report driver.ErrBadConn, context.Canceled (#346, #348)
+ - Added ErrorLogRecord.Error field, for associating an error value with a log record (#380)
 
 ## [v1.0.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.0.0)
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -412,10 +412,15 @@ type ErrorLogRecord struct {
 	//
 	// This is optional.
 	LoggerName string
+
+	// Error is an error associated with the log record.
+	//
+	// This is optional.
+	Error error
 }
 ----
 
-The resulting Error's stacktrace will not be set. Call the SetStacktrace method to set it, if desired.
+The resulting Error's log stacktrace will not be set. Call the SetStacktrace method to set it, if desired.
 
 [source,go]
 ----


### PR DESCRIPTION
We introduce a new "Error" field to ErrorLogRecord,
which sets the error's exception data. This can be
used to report error details associated with log
entries, e.g. using logrus's WithError.

For an error created using NewErrorLog, the exception
stacktrace will only ever be populated from the error
value, e.g. by using github.com/pkg/error's StackTrace
method. Calling Error.SetStacktrace will only set the
log's stacktrace. The Culprit will be set from the exception
stacktrace in preference to the log stacktrace.