### PR TITLE
Don't scale CPU metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,11 @@ matrix:
     - go: "1.x"
 
 before_install:
-  - go get -v golang.org/x/tools/cmd/goimports
-  - if (go run scripts/mingoversion.go 1.10 &>/dev/null); then go get -v golang.org/x/lint/golint; fi
+  - |
+      if (go run scripts/mingoversion.go 1.10 &>/dev/null); then
+        go get -v golang.org/x/lint/golint;
+        go get -v golang.org/x/tools/cmd/goimports;
+      fi
 
 script:
   - make install check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.1.0...master)
+## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.1.1...master)
+
+## [v1.1.1](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.1)
+
+ - CPU% metrics are now correctly in the range [0,1]
 
 ## [v1.1.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.0)
 

--- a/builtin_metrics.go
+++ b/builtin_metrics.go
@@ -97,11 +97,11 @@ func calculateCPUUsage(current, last cpuMetrics) (systemUsage, processUsage floa
 		return 0, 0
 	}
 
-	idlePercent := 100 * float64(idleDelta) / float64(systemTotalDelta)
-	systemUsage = 100 - idlePercent
+	idlePercent := float64(idleDelta) / float64(systemTotalDelta)
+	systemUsage = 1 - idlePercent
 
 	processTotalDelta := current.process.Total() - last.process.Total()
-	processUsage = 100 * float64(processTotalDelta) / float64(systemTotalDelta)
+	processUsage = float64(processTotalDelta) / float64(systemTotalDelta)
 
 	return systemUsage, processUsage
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -46,6 +46,14 @@ func TestTracerMetricsBuiltin(t *testing.T) {
 		}, "value: %v", gcPct.Value)
 	}
 
+	// CPU% should be in the range [0,1], not [0,100].
+	cpuTotalNormPct := builtinMetrics.Samples["system.cpu.total.norm.pct"]
+	if assert.NotNil(t, gcPct.Value) {
+		assert.Condition(t, func() bool {
+			return cpuTotalNormPct.Value >= 0 && cpuTotalNormPct.Value <= 1
+		}, "value: %v", cpuTotalNormPct.Value)
+	}
+
 	expected := []string{
 		"golang.goroutines",
 		"golang.heap.allocations.mallocs",

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package apm
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "1.1.0"
+	AgentVersion = "1.1.1"
 )


### PR DESCRIPTION
The CPU% metrics should be in the range [0,1], so stop scaling by 100.

Fixes https://github.com/elastic/apm-agent-go/issues/392