### PR TITLE
Feature/391 implement error interface

### DIFF
--- a/error.go
+++ b/error.go
@@ -204,7 +204,7 @@ func (e *Error) Cause() error {
 }
 
 // Error returns string message for error.
-// if Error is nil or Error.Cause() returns nil, "[EMPTY]" will be used.
+// if Error or Error.cause is nil, "[EMPTY]" will be used.
 func (e *Error) Error() string {
 	if e != nil && e.cause != nil {
 		return e.cause.Error()

--- a/error.go
+++ b/error.go
@@ -194,16 +194,19 @@ func (e *Error) SetTransaction(tx *Transaction) {
 	tx.mu.RUnlock()
 }
 
-// Cause returns original error assigned to Error
+// Cause returns original error assigned to Error, nil if Error or Error.cause is nil.
 // https://godoc.org/github.com/pkg/errors#Cause
 func (e *Error) Cause() error {
-	return e.cause
+	if e != nil {
+		return e.cause
+	}
+	return nil
 }
 
 // Error returns string message for error.
-// if Error.Cause() returns nil, "[EMPTY]" will be used
+// if Error is nil or Error.Cause() returns nil, "[EMPTY]" will be used.
 func (e *Error) Error() string {
-	if e.cause != nil {
+	if e != nil && e.cause != nil {
 		return e.cause.Error()
 	}
 

--- a/gocontext.go
+++ b/gocontext.go
@@ -64,13 +64,15 @@ func StartSpanOptions(ctx context.Context, name, spanType string, opts SpanOptio
 // set either from err, or from the caller.
 //
 // If there is no span or transaction in the context, CaptureError returns
-// nil. As a convenience, if the provided error is nil, then CaptureError
-// will also return nil.
+// Error with nil ErrorData field. As a convenience, if the provided error is nil,
+// then CaptureError will also return nil.
 func CaptureError(ctx context.Context, err error) *Error {
 	if err == nil {
 		return nil
 	}
-	var e *Error
+	var e = &Error{
+		cause: err,
+	}
 	if span := SpanFromContext(ctx); span != nil {
 		span.mu.RLock()
 		if !span.ended() {
@@ -86,7 +88,7 @@ func CaptureError(ctx context.Context, err error) *Error {
 		}
 		tx.mu.RUnlock()
 	}
-	if e != nil {
+	if e.ErrorData != nil {
 		e.Handled = true
 	}
 	return e


### PR DESCRIPTION
Fixes #391 
Had to change `apm.captureError` behavior a little bit - instead of returning nil, `Error` with nil `ErrorData` is returned. Comments are adjusted. 

I think `Error.sent()` name may be adjusted as there are more cases when `ErrorData` is nil. 

Tests for `causer` and `error` interfaces added. 