### PR TITLE
#391; implement error interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - module/apmot: report error log records (#415)
  - Introduce `ELASTIC_APM_CAPTURE_HEADERS` to control HTTP header capture (#418)
  - module/apmzap: introduce zap log correlation and exception-tracking hook (#426)
+ - type Error implements error interface (#399)
 
 ## [v1.1.3](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.3)
 

--- a/error.go
+++ b/error.go
@@ -89,6 +89,8 @@ func (t *Tracer) NewError(err error) *Error {
 		panic("NewError must be called with a non-nil error")
 	}
 	e := t.newError()
+	e.cause = err
+	e.err = err.Error()
 	rand.Read(e.ID[:]) // ignore error, can't do anything about it
 	initException(&e.exception, err)
 	initStacktrace(e, err)
@@ -116,6 +118,8 @@ func (t *Tracer) NewErrorLog(r ErrorLogRecord) *Error {
 	if e.log.Message == "" {
 		e.log.Message = "[EMPTY]"
 	}
+	e.cause = r.Error
+	e.err = e.log.Message
 	rand.Read(e.ID[:]) // ignore error, can't do anything about it
 	if r.Error != nil {
 		initException(&e.exception, r.Error)
@@ -150,6 +154,14 @@ type Error struct {
 	// ErrorData holds the error data. This field is set to nil when
 	// the error's Send method is called.
 	*ErrorData
+
+	// cause holds original error.
+	// It is accessible by Cause method
+	// https://godoc.org/github.com/pkg/errors#Cause
+	cause error
+
+	// string holds original error string
+	err string
 }
 
 // ErrorData holds the details for an error, and is embedded inside Error.
@@ -216,6 +228,24 @@ func (e *Error) SetTransaction(tx *Transaction) {
 		e.setTransactionData(tx.TransactionData)
 	}
 	tx.mu.RUnlock()
+}
+
+// Cause returns original error assigned to Error, nil if Error or Error.cause is nil.
+// https://godoc.org/github.com/pkg/errors#Cause
+func (e *Error) Cause() error {
+	if e != nil {
+		return e.cause
+	}
+	return nil
+}
+
+// Error returns string message for error.
+// if Error or Error.cause is nil, "[EMPTY]" will be used.
+func (e *Error) Error() string {
+	if e != nil {
+		return e.err
+	}
+	return "[EMPTY]"
 }
 
 func (e *Error) setTransactionData(td *TransactionData) {

--- a/error_test.go
+++ b/error_test.go
@@ -120,12 +120,12 @@ func TestErrorAutoStackTraceReuse(t *testing.T) {
 
 func TestCaptureErrorNoTransaction(t *testing.T) {
 	// When there's no transaction or span in the context,
-	// CaptureError returns nil as it has no tracer with
+	// CaptureError returns Error with nil ErrorData as it has no tracer with
 	// which it can create the error.
 	e := apm.CaptureError(context.Background(), errors.New("boom"))
-	assert.Nil(t, e)
+	assert.Nil(t, e.ErrorData)
 
-	// Send is a no-op on a nil Error.
+	// Send is a no-op on a Error with nil ErrorData.
 	e.Send()
 }
 
@@ -151,6 +151,35 @@ func TestErrorLogRecord(t *testing.T) {
 	assert.Equal(t, err0.Log.Stacktrace[0].Function, "TestErrorLogRecord")
 	assert.Equal(t, err0.Exception.Stacktrace[0].Function, "makeError")
 	assert.Equal(t, "makeError", err0.Culprit) // based on exception stacktrace
+}
+
+func TestErrorCauserInterface(t *testing.T) {
+	type Causer interface {
+		Cause() error
+	}
+	var e Causer = apm.CaptureError(context.Background(), errors.New("boom"))
+	assert.EqualError(t, e.Cause(), "boom")
+}
+
+func TestErrorNilCauser(t *testing.T) {
+	var e *apm.Error
+	assert.Nil(t, e.Cause())
+
+	e = &apm.Error{}
+	assert.Nil(t, e.Cause())
+}
+
+func TestErrorErrorInterface(t *testing.T) {
+	var e error = apm.CaptureError(context.Background(), errors.New("boom"))
+	assert.EqualError(t, e, "boom")
+}
+
+func TestErrorNilError(t *testing.T) {
+	var e *apm.Error
+	assert.EqualError(t, e, "[EMPTY]")
+
+	e = &apm.Error{}
+	assert.EqualError(t, e, "")
 }
 
 func TestErrorTransactionSampled(t *testing.T) {

--- a/gocontext.go
+++ b/gocontext.go
@@ -80,14 +80,18 @@ func StartSpanOptions(ctx context.Context, name, spanType string, opts SpanOptio
 // from err. The Error.Handled field will be set to true, and a stacktrace
 // set either from err, or from the caller.
 //
-// If there is no span or transaction in the context, CaptureError returns
-// nil. As a convenience, if the provided error is nil, then CaptureError
-// will also return nil.
+// If the provided error is nil, then CaptureError will also return nil;
+// otherwise a non-nil Error will always be returned. If there is no
+// transaction or span in the context, then the returned Error's Send
+// method will have no effect.
 func CaptureError(ctx context.Context, err error) *Error {
 	if err == nil {
 		return nil
 	}
-	var e *Error
+	var e = &Error{
+		cause: err,
+		err:   err.Error(),
+	}
 	if span := SpanFromContext(ctx); span != nil {
 		span.mu.RLock()
 		if !span.ended() {
@@ -103,7 +107,7 @@ func CaptureError(ctx context.Context, err error) *Error {
 		}
 		tx.mu.RUnlock()
 	}
-	if e != nil {
+	if e.ErrorData != nil {
 		e.Handled = true
 	}
 	return e


### PR DESCRIPTION
Fixes elastic/apm-agent-go#391
Had to change apm.captureError behavior a little bit - instead of returning nil, Error with nil ErrorData is returned. Comments are adjusted.

I think Error.sent() name may be adjusted as there are more cases when ErrorData is nil.

Tests for causer and error interfaces added.