### PR TITLE
fix apmhttp code example when wrapping a function

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -222,7 +222,7 @@ func serverHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func main() {
-	http.ListenAndServe(":8080", apmhttp.Wrap(serverHandler))
+	http.ListenAndServe(":8080", apmhttp.Wrap(http.HandlerFunc(serverHandler)))
 }
 ----
 


### PR DESCRIPTION
`apmhttp.Wrap` function receive a `http.Handler` type and in this example was receiving a function. Changing the example to use the `http.HandlerFunc` function which will return a `http.Handler` type.