### PR TITLE
apm: fix data race accessing Tracer.active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.1.1...master)
+## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.1.2...master)
+
+## [v1.1.2](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.2)
+
+ - Fix data race between Tracer.Active and Tracer.loop (#406)
 
 ## [v1.1.1](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.1)
 

--- a/env_test.go
+++ b/env_test.go
@@ -270,7 +270,7 @@ func TestTracerSpanFramesMinDurationEnvInvalid(t *testing.T) {
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_SPAN_FRAMES_MIN_DURATION: invalid duration aeon")
 }
 
-func TestTracerActive(t *testing.T) {
+func TestTracerActiveEnv(t *testing.T) {
 	os.Setenv("ELASTIC_APM_ACTIVE", "false")
 	defer os.Unsetenv("ELASTIC_APM_ACTIVE")
 
@@ -285,7 +285,7 @@ func TestTracerActive(t *testing.T) {
 	assert.Zero(t, transport.Payloads())
 }
 
-func TestTracerActiveInvalid(t *testing.T) {
+func TestTracerActiveEnvInvalid(t *testing.T) {
 	os.Setenv("ELASTIC_APM_ACTIVE", "yep")
 	defer os.Unsetenv("ELASTIC_APM_ACTIVE")
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -411,6 +411,21 @@ func TestTracerKubernetesMetadata(t *testing.T) {
 	})
 }
 
+func TestTracerActive(t *testing.T) {
+	tracer, _ := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+	assert.True(t, tracer.Active())
+
+	// Kick off calls to tracer.Active concurrently
+	// with the tracer.Close, to test that we ensure
+	// there are no data races.
+	go func() {
+		for i := 0; i < 100; i++ {
+			tracer.Active()
+		}
+	}()
+}
+
 type blockedTransport struct {
 	transport.Transport
 	unblocked chan struct{}

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package apm
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "1.1.1"
+	AgentVersion = "1.1.2"
 )


### PR DESCRIPTION
When Tracer.loop exits, it sets Tracer.active
to false, which races with reads by the method
Tracer.Active. We fix this by changing the
Tracer.active field from a bool to int32, and
using atomic ops.

Fixes #404 