### PR TITLE
Disable agent.* metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.1.2...master)
 
+ - Remove the `agent.*` metrics (#407)
+
 ## [v1.1.2](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.2)
 
  - Fix data race between Tracer.Active and Tracer.loop (#406)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -78,14 +78,6 @@ func TestTracerMetricsBuiltin(t *testing.T) {
 		"system.process.cpu.total.norm.pct",
 		"system.process.memory.size",
 		"system.process.memory.rss.bytes",
-
-		"agent.send_errors",
-		"agent.spans.sent",
-		"agent.spans.dropped",
-		"agent.transactions.sent",
-		"agent.transactions.dropped",
-		"agent.errors.sent",
-		"agent.errors.dropped",
 	}
 	sort.Strings(expected)
 	for name := range builtinMetrics.Samples {


### PR DESCRIPTION
Disable the `agent.*` metrics, as they were ill-defined.
We will reinstate these metrics, or some alternatives,
at a later date after design and discussion with other
agent developers.

Closes elastic/apm-agent-go#396 