### PR TITLE
 apm: add support for github.com/pkg/errors@master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.1.2...master)
+## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.1.3...master)
+
+## [v1.1.3](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.3)
 
  - Remove the `agent.*` metrics (#407)
+ - Add support for new github.com/pkg/errors.Frame type (#409)
 
 ## [v1.1.2](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.2)
 

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package apm
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "1.1.2"
+	AgentVersion = "1.1.3"
 )


### PR DESCRIPTION
github.com/pkg/errors has broken backwards compatibility
on master, which will become 0.9.0. Until we can get rid
of support for the older version (which, undoubtedly, many
people are using), we will support both by using reflection.

Bump version to v1.1.3.

Fixes #408