### PR TITLE
module/apmot: follows-from is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  - Add "transaction.sampled" to errors (#410)
  - Enforce license header in source files with go-licenser (#411)
+ - module/apmot: ignore "follows-from" span references (#414)
 
 ## [v1.1.3](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.3)
 


### PR DESCRIPTION
Bring the code in line with the docs, and do not support follows-from.

Fixes #413 