### PR TITLE
docs: minor rewording for ELASTIC_APM_ACTIVE

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -157,7 +157,7 @@ introduced with the 6.4 release.
 | `ELASTIC_APM_ACTIVE` | true    | `false`
 |============
 
-Enable or disable the tracer. If set to false, then the Go agent does not send
+Enable or disable the agent. If set to false, then the Go agent does not send
 any data to the Elastic APM server, and instrumentation overhead is minimized.
 
 [float]


### PR DESCRIPTION
s/tracer/agent/ in ELASTIC_APM_ACTIVE config description,
to make it clearer that the agent is entirely de/activated.

Closes #412 