### PR TITLE
Introduce ELASTIC_APM_CAPTURE_HEADERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Enforce license header in source files with go-licenser (#411)
  - module/apmot: ignore "follows-from" span references (#414)
  - module/apmot: report error log records (#415)
+ - Introduce `ELASTIC_APM_CAPTURE_HEADERS` to control HTTP header capture (#418)
 
 ## [v1.1.3](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.3)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -187,11 +187,27 @@ Prefixing a pattern with `(?-i)` makes the matching case sensitive.
 | `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, authorization, set-cookie` | `sekrits`
 |============
 
-A list of patterns to match the names of HTTP cookies and POST form fields to refact.
+A list of patterns to match the names of HTTP headers, cookies, and POST form fields to redact.
 
 This option supports the wildcard `*`, which matches zero or more characters.
 Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default.
 Prefixing a pattern with `(?-i)` makes the matching case sensitive.
+
+[float]
+[[config-capture-headers]]
+=== `ELASTIC_APM_CAPTURE_HEADERS`
+
+[options="header"]
+|============
+| Environment                   | Default
+| `ELASTIC_APM_CAPTURE_HEADERS` | `true`
+|============
+
+For transactions that are HTTP requests, the Go agent can optionally capture request and response headers.
+
+Possible values: `true`, `false`.
+
+Captured headers are subject to sanitization, per <<config-sanitize-field-names>>.
 
 [float]
 [[config-capture-body]]

--- a/env.go
+++ b/env.go
@@ -36,6 +36,7 @@ const (
 	envMaxSpans              = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
 	envTransactionSampleRate = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
 	envSanitizeFieldNames    = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
+	envCaptureHeaders        = "ELASTIC_APM_CAPTURE_HEADERS"
 	envCaptureBody           = "ELASTIC_APM_CAPTURE_BODY"
 	envServiceName           = "ELASTIC_APM_SERVICE_NAME"
 	envServiceVersion        = "ELASTIC_APM_SERVICE_VERSION"
@@ -53,6 +54,7 @@ const (
 	defaultMetricsBufferSize     = 100 * apmconfig.KByte
 	defaultMetricsInterval       = 30 * time.Second
 	defaultMaxSpans              = 500
+	defaultCaptureHeaders        = true
 	defaultCaptureBody           = CaptureBodyOff
 	defaultSpanFramesMinDuration = 5 * time.Millisecond
 
@@ -163,6 +165,10 @@ func initialSampler() (Sampler, error) {
 
 func initialSanitizedFieldNames() wildcard.Matchers {
 	return apmconfig.ParseWildcardPatternsEnv(envSanitizeFieldNames, defaultSanitizedFieldNames)
+}
+
+func initialCaptureHeaders() (bool, error) {
+	return apmconfig.ParseBoolEnv(envCaptureHeaders, defaultCaptureHeaders)
 }
 
 func initialCaptureBody() (CaptureBodyMode, error) {

--- a/error.go
+++ b/error.go
@@ -137,6 +137,11 @@ func (t *Tracer) newError() *Error {
 		}
 	}
 	e.Timestamp = time.Now()
+
+	t.captureHeadersMu.RLock()
+	e.Context.captureHeaders = t.captureHeaders
+	t.captureHeadersMu.RUnlock()
+
 	return &Error{ErrorData: e}
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -80,6 +80,10 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	tx.spanFramesMinDuration = t.spanFramesMinDuration
 	t.spanFramesMinDurationMu.RUnlock()
 
+	t.captureHeadersMu.RLock()
+	tx.Context.captureHeaders = t.captureHeaders
+	t.captureHeadersMu.RUnlock()
+
 	if root {
 		t.samplerMu.RLock()
 		sampler := t.sampler


### PR DESCRIPTION
Introduce the ELASTIC_APM_CAPTURE_HEADERS config,
which controls whether or not HTTP headers will be captured.
Defaults to true.

Closes #390 