### PR TITLE
CI: coverage improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,7 @@ pipeline {
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
                 testResults: "${BASE_DIR}/build/junit-*.xml")
-              codecov(repo: 'apm-agent-go', basedir: "${BASE_DIR}")
+              codecov(repo: 'apm-agent-go', basedir: "${BASE_DIR}/codecov")
             }
           }
         }

--- a/scripts/jenkins/docker-test.sh
+++ b/scripts/jenkins/docker-test.sh
@@ -11,19 +11,13 @@ go get -v -u github.com/jstemmer/go-junit-report
 go get -v -u github.com/t-yuki/gocover-cobertura
 go get -v -t ./...
 
-export COV_FILE="build/coverage/coverage.cov"
+export COV_FILE="build/codecov/coverage.txt"
 export OUT_FILE="build/test-report.out"
-mkdir -p build/coverage 
+mkdir -p build/coverage build/codecov
 
 ./scripts/docker-compose-testing up -d --build
-./scripts/docker-compose-testing run -T --rm go-agent-tests make coverage GOFLAGS=-v 2> >(tee ${OUT_FILE} 1>&2) > ${COV_FILE}.raw
-
-echo "mode: atomic" > ${COV_FILE}
-grep -v "mode\: atomic" ${COV_FILE}.raw >> ${COV_FILE}
+./scripts/docker-compose-testing run -T --rm go-agent-tests make coverage GOFLAGS=-v 2> >(tee ${OUT_FILE} 1>&2) > ${COV_FILE}
 
 go tool cover -html="${COV_FILE}" -o build/coverage/coverage-apm-agent-go-docker-report.html
 gocover-cobertura < "${COV_FILE}" > build/coverage/coverage-apm-agent-go-docker-report.xml
-
-cat ${OUT_FILE} | go-junit-report > build/junit-apm-agent-go-docker.xml
-
-
+go-junit-report > build/junit-apm-agent-go-docker.xml < ${OUT_FILE}

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -2,10 +2,12 @@
 
 set -e
 
+echo "mode: atomic"
+
 for pkg in $(go list ./...); do
     go test -coverpkg=go.elastic.co/apm/... -coverprofile=profile.out -covermode=atomic $pkg 1>&2
     if [ -f profile.out ]; then
-        cat profile.out
+        grep -v "mode: atomic" profile.out || true
         rm profile.out
     fi
 done


### PR DESCRIPTION
- Update scripts/test_coverage.sh to remove repeat "mode: atomic" lines,
  and drop the code from scripts/jenkins/docker-test.sh which did that.
- Under Jenkins, write the "go test -cover" output to build/codecov
  instead of build/coverage, so that we can prevent the codecov script
  from picking up the Cobertura report.

Hopefully addresses #384 