### PR TITLE
 Improve test reliability

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   parameters {
-    string(name: 'GO_VERSION', defaultValue: "1.10.3", description: "Go version to use.")
+    string(name: 'GO_VERSION', defaultValue: "1.11.4", description: "Go version to use.")
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
     booleanParam(name: 'docker_test_ci', defaultValue: true, description: 'Enable run docker tests')


### PR DESCRIPTION
TestTracerRequestSize now sets a much higher request time,
and allows for greater delays. This will allow for slower
environments while ensuring the request time isn't the
cause for request completion.

TestTracerRequestTimeEnv now just sends a single event,
ensuring the request size is not the cause, and also allows
for greater delays.

Also, update Go to 1.11.4 under Jenkins.