### PR TITLE
module/apmzap: add zap integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - module/apmot: ignore "follows-from" span references (#414)
  - module/apmot: report error log records (#415)
  - Introduce `ELASTIC_APM_CAPTURE_HEADERS` to control HTTP header capture (#418)
+ - module/apmzap: introduce zap log correlation and exception-tracking hook (#426)
 
 ## [v1.1.3](https://github.com/elastic/apm-agent-go/releases/tag/v1.1.3)
 

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -458,7 +458,7 @@ func main() {
 ===== module/apmlogrus
 Package apmlogrus provides a https://github.com/sirupsen/logrus[logrus] Hook
 implementation for sending error messages to Elastic APM, as well as a function
-for adding trace ID fields to errors.
+for adding trace context fields to log records.
 
 [source,go]
 ----
@@ -480,7 +480,40 @@ func handleRequest(w http.ResponseWriter, req *http.Request) {
 	logrus.WithFields(traceContextFields).Debug("handling request")
 
 	// Output:
-	// {"level":"debug","msg":"beep","span.id":"0e134f39535a75c0","time":"1970-01-01T00:00:00Z","trace.id":"67829ae467e896fb2b87ec2de50f6c0e","transaction.id":"67829ae467e896fb"}
+	// {"level":"debug","msg":"handling request","time":"1970-01-01T00:00:00Z","trace.id":"67829ae467e896fb2b87ec2de50f6c0e","transaction.id":"67829ae467e896fb"}
+}
+----
+
+[[builtin-modules-apmzap]]
+===== module/apmzap
+Package apmzap provides a https://godoc.org/go.uber.org/zap/zapcore#Core[go.uber.org/zap/zapcore.Core]
+implementation for sending error messages to Elastic APM, as well as a function
+for adding trace context fields to log records.
+
+[source,go]
+----
+import (
+	"go.uber.org/zap"
+
+	"go.elastic.co/apm/module/apmzap"
+)
+
+// apmzap.Core.WrapCore will wrap the core created by zap.NewExample
+// such that logs are also sent to the apmzap.Core.
+//
+// apmzap.Core will send "error", "panic", and "fatal" level log
+// messages to Elastic APM.
+var logger = zap.NewExample(zap.WrapCore((&apmzap.Core{}).WrapCore))
+
+func handleRequest(w http.ResponseWriter, req *http.Request) {
+	// apmzap.TraceContext extracts the transaction and span (if any)
+	// from the given context, and returns zap.Fields containing the
+	// trace, transaction, and span IDs.
+	traceContextFields := apmzap.TraceContext(req.Context())
+	logger.With(traceContextFields...).Debug("handling request")
+
+	// Output:
+	// {"level":"debug","msg":"handling request","trace.id":"67829ae467e896fb2b87ec2de50f6c0e","transaction.id":"67829ae467e896fb"}
 }
 ----
 

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -188,3 +188,13 @@ https://github.com/sirupsen/logrus/releases/tag/v1.1.0[v1.1.0] and greater.
 
 See <<builtin-modules-apmlogrus, module/apmlogrus>> for more information
 about Logrus integration.
+
+[float]
+==== Zap
+
+We support log correlation and exception tracking with
+https://github.com/uber-go/zap/[Zap],
+https://github.com/uber-go/zap/releases/tag/v1.0.0[v1.0.0] and greater.
+
+See <<builtin-modules-apmzap, module/apmzap>> for more information
+about Zap integration.

--- a/module/apmzap/core.go
+++ b/module/apmzap/core.go
@@ -1,0 +1,188 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.9
+
+package apmzap
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/stacktrace"
+)
+
+const (
+	// DefaultFatalFlushTimeout is the default value for Hook.FatalFlushTimeout.
+	DefaultFatalFlushTimeout = 5 * time.Second
+)
+
+func init() {
+	stacktrace.RegisterLibraryPackage("go.uber.org/zap")
+}
+
+// Core is an implementation of zapcore.Core, reporting log records as
+// errors to the APM Server. If TraceContext is used to add trace IDs
+// to the log records, the errors reported will be associated with them.
+type Core struct {
+	// Tracer is the apm.Tracer to use for reporting errors.
+	// If Tracer is nil, then apm.DefaultTracer will be used.
+	Tracer *apm.Tracer
+
+	// FatalFlushTimeout is the amount of time to wait while
+	// flushing a fatal log message to the APM Server before
+	// the process is exited. If this is 0, then
+	// DefaultFatalFlushTimeout will be used. If the timeout
+	// is a negative value, then no flushing will be performed.
+	FatalFlushTimeout time.Duration
+}
+
+func (c *Core) tracer() *apm.Tracer {
+	tracer := c.Tracer
+	if tracer == nil {
+		tracer = apm.DefaultTracer
+	}
+	return tracer
+}
+
+// WrapCore returns zapcore.NewTee(core, c).
+// WrapCore is suitable for passing to zap.WrapCore.
+func (c *Core) WrapCore(core zapcore.Core) zapcore.Core {
+	return zapcore.NewTee(core, c)
+}
+
+// Sync is a no-op.
+func (*Core) Sync() error {
+	return nil
+}
+
+// Enabled returns true if level is >= zapcore.ErrorLevel.
+func (*Core) Enabled(level zapcore.Level) bool {
+	return level >= zapcore.ErrorLevel
+}
+
+// With returns a new zapcore.Core that decorates c with fields.
+func (c *Core) With(fields []zapcore.Field) zapcore.Core {
+	out := &contextCore{core: c}
+	out.traceContext.fields(fields)
+	return out
+}
+
+// Check checks if the entry should be logged, and adds c to checked if so.
+func (c *Core) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if entry.Level < zapcore.ErrorLevel || !c.tracer().Active() {
+		return checked
+	}
+	return checked.AddCore(entry, c)
+}
+
+// Write reports entry and fields as an error using c.tracer.
+func (c *Core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	core := contextCore{core: c}
+	return core.Write(entry, fields)
+}
+
+type contextCore struct {
+	core         *Core
+	traceContext traceContext
+}
+
+func (c *contextCore) Sync() error {
+	return nil
+}
+
+func (c *contextCore) Enabled(level zapcore.Level) bool {
+	return level >= zapcore.ErrorLevel
+}
+
+func (c *contextCore) With(fields []zapcore.Field) zapcore.Core {
+	newCore := &contextCore{
+		core:         c.core,
+		traceContext: c.traceContext,
+	}
+	newCore.traceContext.fields(fields)
+	return newCore
+}
+
+func (c *contextCore) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if entry.Level < zapcore.ErrorLevel || !c.core.tracer().Active() {
+		return checked
+	}
+	return checked.AddCore(entry, c)
+}
+
+func (c *contextCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	traceContext := c.traceContext
+	traceContext.fields(fields)
+
+	tracer := c.core.tracer()
+	errlog := tracer.NewErrorLog(apm.ErrorLogRecord{
+		Message:    entry.Message,
+		Level:      entry.Level.String(),
+		LoggerName: entry.LoggerName,
+		Error:      traceContext.err,
+	})
+	errlog.Handled = true
+	errlog.Timestamp = entry.Time
+	errlog.SetStacktrace(1)
+	errlog.TraceID = traceContext.traceID
+	errlog.TransactionID = traceContext.transactionID
+	if traceContext.spanID.Validate() == nil {
+		errlog.ParentID = traceContext.spanID
+	} else {
+		errlog.ParentID = traceContext.transactionID
+	}
+	errlog.Send()
+
+	if entry.Level == zapcore.FatalLevel {
+		// Zap will exit the process following a fatal log message, so we flush the tracer.
+		flushTimeout := c.core.FatalFlushTimeout
+		if flushTimeout == 0 {
+			flushTimeout = DefaultFatalFlushTimeout
+		}
+		if flushTimeout >= 0 {
+			ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
+			defer cancel()
+			tracer.Flush(ctx.Done())
+		}
+	}
+	return nil
+}
+
+type traceContext struct {
+	err                   error
+	traceID               apm.TraceID
+	transactionID, spanID apm.SpanID
+}
+
+func (c *traceContext) fields(fields []zapcore.Field) {
+	for _, field := range fields {
+		switch field.Key {
+		case "error":
+			c.err, _ = field.Interface.(error)
+		case FieldKeyTraceID:
+			c.traceID, _ = field.Interface.(apm.TraceID)
+		case FieldKeyTransactionID:
+			c.transactionID, _ = field.Interface.(apm.SpanID)
+		case FieldKeySpanID:
+			c.spanID, _ = field.Interface.(apm.SpanID)
+		}
+	}
+}

--- a/module/apmzap/core_test.go
+++ b/module/apmzap/core_test.go
@@ -1,0 +1,161 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.9
+
+package apmzap_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/module/apmzap"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func TestCore(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	core := &apmzap.Core{Tracer: tracer}
+	logger := zap.New(core).Named("myLogger")
+	logger.Error("¡hola, mundo!")
+
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	assert.Len(t, payloads.Errors, 1)
+
+	err0 := payloads.Errors[0]
+	assert.Equal(t, "¡hola, mundo!", err0.Log.Message)
+	assert.Equal(t, "error", err0.Log.Level)
+	assert.Equal(t, "myLogger", err0.Log.LoggerName)
+	assert.Equal(t, "", err0.Log.ParamMessage)
+	assert.Equal(t, "TestCore", err0.Culprit)
+	assert.NotEmpty(t, err0.Log.Stacktrace)
+	assert.Zero(t, err0.ParentID)
+	assert.Zero(t, err0.TraceID)
+	assert.Zero(t, err0.TransactionID)
+}
+
+func TestCoreTransactionTraceContext(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	core := &apmzap.Core{Tracer: tracer}
+	logger := zap.New(core).Named("myLogger")
+
+	tx := tracer.StartTransaction("name", "type")
+	ctx := apm.ContextWithTransaction(context.Background(), tx)
+	span, ctx := apm.StartSpan(ctx, "name", "type")
+	logger.With(apmzap.TraceContext(ctx)...).Error("¡hola, mundo!")
+	span.End()
+	tx.End()
+
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	assert.Len(t, payloads.Transactions, 1)
+	assert.Len(t, payloads.Spans, 1)
+	assert.Len(t, payloads.Errors, 1)
+
+	err0 := payloads.Errors[0]
+	assert.Equal(t, payloads.Spans[0].ID, err0.ParentID)
+	assert.Equal(t, payloads.Transactions[0].TraceID, err0.TraceID)
+	assert.Equal(t, payloads.Transactions[0].ID, err0.TransactionID)
+}
+
+func TestCoreWithError(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	core := &apmzap.Core{Tracer: tracer}
+	logger := zap.New(core)
+	logger.Error("nope nope nope", zap.Error(makeError()))
+
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	assert.Len(t, payloads.Errors, 1)
+
+	err0 := payloads.Errors[0]
+	assert.Equal(t, "kablamo", err0.Exception.Message)
+	assert.Equal(t, "nope nope nope", err0.Log.Message)
+	assert.Equal(t, "makeError", err0.Culprit)
+	assert.NotEmpty(t, err0.Log.Stacktrace)
+	assert.NotEmpty(t, err0.Exception.Stacktrace)
+	assert.NotEqual(t, err0.Log.Stacktrace, err0.Exception.Stacktrace)
+	assert.Equal(t, "makeError", err0.Exception.Stacktrace[0].Function)
+	assert.Equal(t, "(*contextCore).Write", err0.Log.Stacktrace[0].Function)
+}
+
+func makeError() error {
+	return errors.New("kablamo")
+}
+
+func TestCoreTracerClosed(t *testing.T) {
+	tracer, _ := transporttest.NewRecorderTracer()
+	tracer.Close() // close it straight away, core should return immediately
+
+	core := &apmzap.Core{Tracer: tracer}
+	logger := zap.New(core)
+	logger.Error("boom")
+}
+
+func TestCoreFatal(t *testing.T) {
+	if os.Getenv("_INSIDE_TEST") == "1" {
+		logger := zap.New(&apmzap.Core{})
+		logger.Fatal("fatality!")
+	}
+
+	var recorder transporttest.RecorderTransport
+	mux := http.NewServeMux()
+	mux.HandleFunc("/intake/v2/events", func(w http.ResponseWriter, req *http.Request) {
+		if err := recorder.SendStream(req.Context(), req.Body); err != nil {
+			panic(err)
+		}
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCoreFatal$")
+	cmd.Env = append(os.Environ(),
+		"_INSIDE_TEST=1",
+		"ELASTIC_APM_SERVER_URL="+server.URL,
+		"ELASTIC_APM_LOG_FILE=stderr",
+		"ELASTIC_APM_LOG_LEVEL=debug",
+	)
+	output, err := cmd.CombinedOutput()
+	assert.Error(t, err)
+	defer func() {
+		if t.Failed() {
+			t.Logf("%s", output)
+		}
+	}()
+
+	payloads := recorder.Payloads()
+	require.Len(t, payloads.Errors, 1)
+	assert.Equal(t, "fatality!", payloads.Errors[0].Log.Message)
+	assert.Equal(t, "fatal", payloads.Errors[0].Log.Level)
+}

--- a/module/apmzap/fields.go
+++ b/module/apmzap/fields.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.9
+
+package apmzap
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"go.elastic.co/apm"
+)
+
+const (
+	// FieldKeyTraceID is the field key for the trace ID.
+	FieldKeyTraceID = "trace.id"
+
+	// FieldKeyTransactionID is the field key for the transaction ID.
+	FieldKeyTransactionID = "transaction.id"
+
+	// FieldKeySpanID is the field key for the span ID.
+	FieldKeySpanID = "span.id"
+)
+
+// TraceContext returns zap.Fields containing the trace context
+// of the transaction and span contained in ctx, if any.
+func TraceContext(ctx context.Context) []zapcore.Field {
+	tx := apm.TransactionFromContext(ctx)
+	if tx == nil {
+		return nil
+	}
+	traceContext := tx.TraceContext()
+	fields := []zapcore.Field{
+		zap.Stringer(FieldKeyTraceID, traceContext.Trace),
+		zap.Stringer(FieldKeyTransactionID, traceContext.Span),
+	}
+	if span := apm.SpanFromContext(ctx); span != nil {
+		fields = append(fields, zap.Stringer(FieldKeySpanID, span.TraceContext().Span))
+	}
+	return fields
+}

--- a/module/apmzap/fields_test.go
+++ b/module/apmzap/fields_test.go
@@ -1,0 +1,102 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.9
+
+package apmzap_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/module/apmzap"
+)
+
+func TestTraceContext(t *testing.T) {
+	var buf zaptest.Buffer
+	logger := newLogger(&buf, zap.DebugLevel)
+
+	tx, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		span, ctx := apm.StartSpan(ctx, "name", "type")
+		defer span.End()
+		logger.With(apmzap.TraceContext(ctx)...).Debug("beep")
+		logger.Debug("beep", apmzap.TraceContext(ctx)...)
+	})
+	require.Len(t, spans, 1)
+	lines := buf.Lines()
+	require.Len(t, lines, 2)
+
+	for _, line := range lines {
+		assert.Equal(t, fmt.Sprintf(
+			`{"level":"debug","message":"beep","trace.id":"%x","transaction.id":"%x","span.id":"%x"}`,
+			tx.TraceID[:], tx.ID[:], spans[0].ID[:],
+		), line)
+	}
+}
+
+func TestTraceContextNoSpan(t *testing.T) {
+	var buf zaptest.Buffer
+	logger := newLogger(&buf, zap.DebugLevel)
+
+	tx, _, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		logger.Debug("beep", apmzap.TraceContext(ctx)...)
+	})
+	lines := buf.Lines()
+	require.Len(t, lines, 1)
+
+	assert.Equal(t, fmt.Sprintf(
+		`{"level":"debug","message":"beep","trace.id":"%x","transaction.id":"%x"}`,
+		tx.TraceID[:], tx.ID[:],
+	), lines[0])
+}
+
+func TestTraceContextEmpty(t *testing.T) {
+	var buf zaptest.Buffer
+	logger := newLogger(&buf, zap.DebugLevel)
+
+	// apmzap.TraceContext will return nil if the context does not contain a transaction.
+	ctx := context.Background()
+	logger.Debug("beep", apmzap.TraceContext(ctx)...)
+
+	lines := buf.Lines()
+	require.Len(t, lines, 1)
+	assert.Equal(t, `{"level":"debug","message":"beep"}`, lines[0])
+}
+
+func newLogger(ws zapcore.WriteSyncer, level zapcore.LevelEnabler) *zap.Logger {
+	config := zapcore.EncoderConfig{
+		LevelKey:       "level",
+		NameKey:        "name",
+		CallerKey:      "caller",
+		MessageKey:     "message",
+		StacktraceKey:  "stack",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+	return zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(config), ws, level))
+}

--- a/scripts/Dockerfile-testing
+++ b/scripts/Dockerfile-testing
@@ -39,6 +39,9 @@ RUN go get -v github.com/stretchr/testify/assert
 RUN go get -v github.com/stretchr/testify/require
 RUN go get -v github.com/stretchr/testify/suite
 RUN go get -v go.elastic.co/fastjson
+RUN go get -v go.uber.org/zap
+RUN go get -v go.uber.org/zap/zapcore
+RUN go get -v go.uber.org/zap/zaptest
 RUN go get -v golang.org/x/net/context
 RUN go get -v golang.org/x/net/context/ctxhttp
 RUN go get -v golang.org/x/net/http2


### PR DESCRIPTION
Introduce module/apmzap, which provides a helper
function for trace correlation, and an implementation
of zapcore.Core for sending errors to Elastic APM.

Closes elastic/apm-agent-go#382 