### PR TITLE
model: fix metric.tags field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.2.0...master)
 
+ - Rename "metricset.labels" to "metricset.tags" (#438)
+
 ## [v1.2.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.2.0)
 
  - Add "transaction.sampled" to errors (#410)

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1067,7 +1067,7 @@ func (v *Metrics) MarshalFastJSON(w *fastjson.Writer) error {
 		firstErr = err
 	}
 	if !v.Labels.isZero() {
-		w.RawString(",\"labels\":")
+		w.RawString(",\"tags\":")
 		if err := v.Labels.MarshalFastJSON(w); err != nil && firstErr == nil {
 			firstErr = err
 		}

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -161,7 +161,7 @@ func TestMarshalMetrics(t *testing.T) {
 	decoded := mustUnmarshalJSON(w)
 	expect := map[string]interface{}{
 		"timestamp": float64(123000000),
-		"labels": map[string]interface{}{
+		"tags": map[string]interface{}{
 			"foo": "bar",
 		},
 		"samples": map[string]interface{}{

--- a/model/model.go
+++ b/model/model.go
@@ -584,7 +584,11 @@ type Metrics struct {
 
 	// Labels holds a set of labels associated with the metrics.
 	// The labels apply uniformly to all metric samples in the set.
-	Labels StringMap `json:"labels,omitempty"`
+	//
+	// NOTE(axw) the schema calls the field "tags", but we use
+	// "labels" for agent-internal consistency. Labels aligns better
+	// with the common schema, anyway.
+	Labels StringMap `json:"tags,omitempty"`
 
 	// Samples holds a map of metric samples, keyed by metric name.
 	Samples map[string]Metric `json:"samples"`


### PR DESCRIPTION
Change model.Metrics.Labels's JSON-encoding
field name to "tags", to align with the
server's schema. We were calling it "labels"
by mistake.

Fixes #437 