### PR TITLE
Introduce ELASTIC_APM_DISABLE_METRICS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.2.0...master)
 
  - Rename "metricset.labels" to "metricset.tags" (#438)
+ - Introduce `ELASTIC_APM_DISABLE_METRICS` to disable metrics with matching names (#439)
 
 ## [v1.2.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.2.0)
 

--- a/env.go
+++ b/env.go
@@ -47,6 +47,7 @@ const (
 	envAPIRequestTime        = "ELASTIC_APM_API_REQUEST_TIME"
 	envAPIBufferSize         = "ELASTIC_APM_API_BUFFER_SIZE"
 	envMetricsBufferSize     = "ELASTIC_APM_METRICS_BUFFER_SIZE"
+	envDisableMetrics        = "ELASTIC_APM_DISABLE_METRICS"
 
 	defaultAPIRequestSize        = 750 * apmconfig.KByte
 	defaultAPIRequestTime        = 10 * time.Second
@@ -209,4 +210,8 @@ func initialSpanFramesMinDuration() (time.Duration, error) {
 
 func initialActive() (bool, error) {
 	return apmconfig.ParseBoolEnv(envActive, true)
+}
+
+func initialDisabledMetrics() wildcard.Matchers {
+	return apmconfig.ParseWildcardPatternsEnv(envDisableMetrics, nil)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -23,11 +23,14 @@ import (
 	"strings"
 	"sync"
 
+	"go.elastic.co/apm/internal/wildcard"
 	"go.elastic.co/apm/model"
 )
 
 // Metrics holds a set of metrics.
 type Metrics struct {
+	disabled wildcard.Matchers
+
 	mu      sync.Mutex
 	metrics []*model.Metrics
 }
@@ -72,6 +75,9 @@ func (m *Metrics) Add(name string, labels []MetricLabel, value float64) {
 }
 
 func (m *Metrics) addMetric(name string, labels []MetricLabel, metric model.Metric) {
+	if m.disabled.MatchAny(name) {
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 


### PR DESCRIPTION
Introduce the config ELASTIC_APM_DISABLE_METRICS,
which disables metrics whose names match any of a list of
wildcard patterns. Currently there is no method to change this
dynamically, but the matching is done in a way to permit this
in the future.

Closes elastic/apm-agent-go#435 