### PR TITLE
Fix Makefile when running with modules enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 
 .PHONY: check-vet
 check-vet:
-	@for dir in $(shell scripts/moduledirs.sh); do (cd $$dir && go vet ./...); done
+	@for dir in $(shell scripts/moduledirs.sh); do (cd $$dir && go vet ./...) || exit $$?; done
 
 .PHONY: install
 install:
@@ -50,7 +50,7 @@ docker-test:
 
 .PHONY: test
 test:
-	@for dir in $(shell scripts/moduledirs.sh); do (cd $$dir && go test -v -timeout=$(TEST_TIMEOUT) ./...); done
+	@for dir in $(shell scripts/moduledirs.sh); do (cd $$dir && go test -v -timeout=$(TEST_TIMEOUT) ./...) || exit $$?; done
 
 .PHONY: coverage
 coverage:


### PR DESCRIPTION
Fix the for loops in Makefile targets to exit
if any of the iterations fail. This currently
only affects us when modules are enabled, as
otherwise there's just one loop iteration, and
the for loop exits with the last iteration's
result.