### PR TITLE
apm: introduce ErrorDetailer interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Rename "metricset.labels" to "metricset.tags" (#438)
  - Introduce `ELASTIC_APM_DISABLE_METRICS` to disable metrics with matching names (#439)
  - module/apmmongo: introduce instrumentation for the MongoDB Go Driver (#452)
+ - Introduce ErrorDetailer interface (#453)
 
 ## [v1.2.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.2.0)
 

--- a/error.go
+++ b/error.go
@@ -568,7 +568,8 @@ var (
 )
 
 // ErrorDetails holds details of an error, which can be altered or
-// extended by registering an ErrorDetailer with RegisterErrorDetailer.
+// extended by registering an ErrorDetailer with RegisterErrorDetailer
+// or RegisterTypeErrorDetailer.
 type ErrorDetails struct {
 	attrs map[string]interface{}
 
@@ -615,6 +616,9 @@ func (d *ErrorDetails) SetAttr(k string, v interface{}) {
 }
 
 // ErrorDetailer defines an interface for altering or extending the ErrorDetails for an error.
+//
+// ErrorDetailers can be registered using the package-level functions RegisterErrorDetailer and
+// RegisterTypeErrorDetailer.
 type ErrorDetailer interface {
 	// ErrorDetails is called to update or alter details for err.
 	ErrorDetails(err error, details *ErrorDetails)

--- a/error_unix.go
+++ b/error_unix.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !windows
+
+package apm
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func errnoName(err syscall.Errno) string {
+	return unix.ErrnoName(err)
+}

--- a/error_windows.go
+++ b/error_windows.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm
+
+import (
+	"syscall"
+)
+
+func errnoName(err syscall.Errno) string {
+	// There's currently no equivalent of unix.ErrnoName for Windows.
+	return ""
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema v1.2.3
 	github.com/stretchr/testify v1.2.2
 	go.elastic.co/fastjson v1.0.0
-	golang.org/x/sys v0.0.0-20190102155601-82a175fd1598 // indirect
+	golang.org/x/sys v0.0.0-20190102155601-82a175fd1598
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 )

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -169,11 +169,11 @@ func (w *modelWriter) buildModelError(out *model.Error, e *ErrorData) {
 		out.Exception = model.Exception{
 			Message: e.exception.message,
 			Code: model.ExceptionCode{
-				String: e.exception.codeString,
-				Number: e.exception.codeNumber,
+				String: e.exception.Code.String,
+				Number: e.exception.Code.Number,
 			},
-			Type:       e.exception.typeName,
-			Module:     e.exception.typePackagePath,
+			Type:       e.exception.Type.Name,
+			Module:     e.exception.Type.PackagePath,
 			Handled:    e.Handled,
 			Stacktrace: w.modelStacktrace[:e.exceptionStacktraceFrames],
 		}

--- a/module/apmmongo/monitor_integration_test.go
+++ b/module/apmmongo/monitor_integration_test.go
@@ -110,5 +110,5 @@ func (suite *IntegrationSuite) TestCommandMonitor() {
 	suite.Require().Len(errs, 1)
 	suite.Equal(tx.ID, errs[0].ParentID)
 	suite.Equal("(UserNotFound) User 'bob@test_db' not found", errs[0].Exception.Message)
-	suite.Equal(model.ExceptionCode{}, errs[0].Exception.Code) // BUG(axw) https://github.com/elastic/apm-agent-go/issues/447
+	suite.Equal(model.ExceptionCode{String: "UserNotFound"}, errs[0].Exception.Code)
 }


### PR DESCRIPTION
Introduce the ErrorDetailer interface, along with
top-level functions RegisterTypeErrorDetailer and
RegisterErrorDetailer. The former register an
ErrorDetailer with a specific error type, and the
latter registers an ErrorDetailer for all errors.

When an error is created with NewError or NewErrorLog,
we pass the error details through these ErrorDetailers,
giving instrumentation modules and application-specific
code an opportunity to extract details from custom
error types.

In module/apmmongo, we register an ErrorDetailer
that extracts details from mongo.CommandErrors.

Closes #447 
Closes #443 