### PR TITLE
module/apmmongo: bump 1.0.0-rc1, new import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
  - Rename "metricset.labels" to "metricset.tags" (#438)
  - Introduce `ELASTIC_APM_DISABLE_METRICS` to disable metrics with matching names (#439)
- - module/apmmongo: introduce instrumentation for mongo-go-driver (#452)
+ - module/apmmongo: introduce instrumentation for the MongoDB Go Driver (#452)
 
 ## [v1.2.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.2.0)
 

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -565,8 +565,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/mongodb/mongo-go-driver/mongo"
-	"github.com/mongodb/mongo-go-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"go.elastic.co/apm/module/apmmongo"
 )

--- a/module/apmmongo/go.mod
+++ b/module/apmmongo/go.mod
@@ -3,12 +3,12 @@ module go.elastic.co/apm/module/apmmongo
 require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/snappy v0.0.0-20190218232222-2a8bb927dd31 // indirect
-	github.com/mongodb/mongo-go-driver v0.3.1-0.20190220184843-9ff076f5844d
 	github.com/stretchr/testify v1.3.0
 	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.elastic.co/apm v1.2.0
+	go.mongodb.org/mongo-driver v1.0.0-rc1
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/text v0.3.0 // indirect

--- a/module/apmmongo/go.sum
+++ b/module/apmmongo/go.sum
@@ -19,8 +19,6 @@ github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mongodb/mongo-go-driver v0.3.1-0.20190220184843-9ff076f5844d h1:tQg2nO95Gtkm9SMCIHymWN8mP1kSdTfp1LUkCAWIq0w=
-github.com/mongodb/mongo-go-driver v0.3.1-0.20190220184843-9ff076f5844d/go.mod h1:NK/HWDIIZkaYsnYa0hmtP443T5ELr0KDecmIioVuuyU=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -41,6 +39,8 @@ github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 go.elastic.co/fastjson v1.0.0 h1:ooXV/ABvf+tBul26jcVViPT3sBir0PvXgibYB1IQQzg=
 go.elastic.co/fastjson v1.0.0/go.mod h1:PmeUOMMtLHQr9ZS9J9owrAVg0FkaZDRZJEFTTGHtchs=
+go.mongodb.org/mongo-driver v1.0.0-rc1 h1:Y9CfPSIKyLMS9MkrjBF+Nmo1SoEgPuyhiyVP3wd1oxY=
+go.mongodb.org/mongo-driver v1.0.0-rc1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=

--- a/module/apmmongo/monitor.go
+++ b/module/apmmongo/monitor.go
@@ -22,10 +22,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/bson/bsoncodec"
-	"github.com/mongodb/mongo-go-driver/bson/bsonrw"
-	"github.com/mongodb/mongo-go-driver/event"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/event"
 
 	"go.elastic.co/apm"
 )

--- a/module/apmmongo/monitor_benchmark_test.go
+++ b/module/apmmongo/monitor_benchmark_test.go
@@ -21,9 +21,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/event"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
 
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmmongo"

--- a/module/apmmongo/monitor_integration_test.go
+++ b/module/apmmongo/monitor_integration_test.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/mongo"
-	"github.com/mongodb/mongo-go-driver/mongo/options"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/apmtest"

--- a/module/apmmongo/monitor_test.go
+++ b/module/apmmongo/monitor_test.go
@@ -22,10 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/event"
 
 	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/model"


### PR DESCRIPTION
Bump up the dependency to 1.0.0-rc1, using the new base import path "go.mongodb.org/mongo-driver".

(The apmmongo module is marked experimental because the MongoDB Go Driver has not yet had a stable release, and things may break along the way. Case in point.)