### PR TITLE
module/apmhttp: CloseIdleConnections and CancelRequest pass through

### DIFF
--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -121,13 +121,23 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// CloseIdleConnections calls r.r.CloseIdleConnections if it exists.
+// CloseIdleConnections calls r.r.CloseIdleConnections if the method exists.
 func (r *roundTripper) CloseIdleConnections() {
 	type closeIdler interface {
 		CloseIdleConnections()
 	}
 	if r, ok := r.r.(closeIdler); ok {
 		r.CloseIdleConnections()
+	}
+}
+
+// CancelRequest calls r.r.CancelRequest(req) if the method exists.
+func (r *roundTripper) CancelRequest(req *http.Request) {
+	type cancelRequester interface {
+		CancelRequest(*http.Request)
+	}
+	if r, ok := r.r.(cancelRequester); ok {
+		r.CancelRequest(req)
 	}
 }
 

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -121,6 +121,16 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
+// CloseIdleConnections calls r.r.CloseIdleConnections if it exists.
+func (r *roundTripper) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if r, ok := r.r.(closeIdler); ok {
+		r.CloseIdleConnections()
+	}
+}
+
 type responseBody struct {
 	span *apm.Span
 	body io.ReadCloser

--- a/module/apmhttp/client_go112_test.go
+++ b/module/apmhttp/client_go112_test.go
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.12
+
+package apmhttp_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.elastic.co/apm/module/apmhttp"
+)
+
+func TestClientCloseIdleConnections(t *testing.T) {
+	var closed bool
+	transport := &idleConnectionsCloser{
+		RoundTripper: http.DefaultTransport,
+		closeIdleConnections: func() {
+			closed = true
+		},
+	}
+	client := &http.Client{
+		Transport: apmhttp.WrapRoundTripper(transport),
+	}
+	client.CloseIdleConnections()
+	assert.True(t, closed)
+}
+
+type idleConnectionsCloser struct {
+	http.RoundTripper
+	closeIdleConnections func()
+}
+
+func (c *idleConnectionsCloser) CloseIdleConnections() {
+	c.closeIdleConnections()
+}


### PR DESCRIPTION
Add CloseIdleConnections and CancelRequest methods to the RoundTripper type returned by apmhttp.WrapRoundTripper (and internally, WrapClient). These methods simply pass through to the underlying RoundTripper, if it has those methods.

Closes elastic/apm-agent-go#455 