### PR TITLE
apm: allow specifying transaction/span ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - module/apmmongo: introduce instrumentation for the MongoDB Go Driver (#452)
  - Introduce ErrorDetailer interface (#453)
  - module/apmhttp: add CloseIdleConnectons and CancelRequest to RoundTripper (#457)
+ - Allow specifying transaction (span) ID via TransactionOptions/SpanOptions (#463)
 
 ## [v1.2.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.2.0)
 

--- a/module/apmhttp/traceheaders.go
+++ b/module/apmhttp/traceheaders.go
@@ -98,8 +98,14 @@ func ParseTraceparentHeader(h string) (apm.TraceContext, error) {
 		if _, err := hex.Decode(out.Trace[:], []byte(h[:traceIDEnd])); err != nil {
 			return out, errors.Wrapf(err, "error decoding trace-id for version %d", version)
 		}
+		if err := out.Trace.Validate(); err != nil {
+			return out, errors.Wrap(err, "invalid trace-id")
+		}
 		if _, err := hex.Decode(out.Span[:], []byte(h[spanIDStart:spanIDEnd])); err != nil {
 			return out, errors.Wrapf(err, "error decoding span-id for version %d", version)
+		}
+		if err := out.Span.Validate(); err != nil {
+			return out, errors.Wrap(err, "invalid span-id")
 		}
 		var traceOptions [1]byte
 		if _, err := hex.Decode(traceOptions[:], []byte(h[traceOptionsStart:traceOptionsEnd])); err != nil {

--- a/span_test.go
+++ b/span_test.go
@@ -125,3 +125,13 @@ func TestSpanType(t *testing.T) {
 	check(spans[2], "type", "subtype", "action")
 	check(spans[3], "type", "subtype", "action.figure")
 }
+
+func TestTracerStartSpanIDSpecified(t *testing.T) {
+	spanID := apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7}
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		span, _ := apm.StartSpanOptions(ctx, "name", "type", apm.SpanOptions{SpanID: spanID})
+		span.End()
+	})
+	require.Len(t, spans, 1)
+	assert.Equal(t, model.SpanID(spanID), spans[0].ID)
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -59,10 +59,6 @@ func TestStartTransactionInvalidTraceContext(t *testing.T) {
 		// Trace is all zeroes, which is invalid.
 		Span: apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
 	})
-	startTransactionInvalidTraceContext(t, apm.TraceContext{
-		Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-		// Span is all zeroes, which is invalid.
-	})
 }
 
 func startTransactionInvalidTraceContext(t *testing.T, traceContext apm.TraceContext) {
@@ -78,6 +74,36 @@ func startTransactionInvalidTraceContext(t *testing.T, traceContext apm.TraceCon
 	opts := apm.TransactionOptions{TraceContext: traceContext}
 	tx := tracer.StartTransactionOptions("name", "type", opts)
 	assert.True(t, samplerCalled)
+	tx.Discard()
+}
+
+func TestStartTransactionTraceParentSpanIDSpecified(t *testing.T) {
+	startTransactionIDSpecified(t, apm.TraceContext{
+		Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+	})
+}
+
+func TestStartTransactionTraceIDSpecified(t *testing.T) {
+	startTransactionIDSpecified(t, apm.TraceContext{
+		Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	})
+}
+
+func TestStartTransactionIDSpecified(t *testing.T) {
+	startTransactionIDSpecified(t, apm.TraceContext{})
+}
+
+func startTransactionIDSpecified(t *testing.T, traceContext apm.TraceContext) {
+	tracer, _ := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	opts := apm.TransactionOptions{
+		TraceContext:  traceContext,
+		TransactionID: apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+	}
+	tx := tracer.StartTransactionOptions("name", "type", opts)
+	assert.Equal(t, opts.TransactionID, tx.TraceContext().Span)
 	tx.Discard()
 }
 


### PR DESCRIPTION
Add TransactionOptions.TransactionID and SpanOptions.SpanID
to enable callers to specify transaction and span IDs. If those fields
are valid/non-zero, they will be used; otherwise random values will
be generated as usual.

Closes #460 
Closes #461 