### PR TITLE
 module/apmelasticsearch: capture more request bodies

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -520,8 +520,9 @@ func handleRequest(w http.ResponseWriter, req *http.Request) {
 [[builtin-modules-apmelasticsearch]]
 ===== module/apmelasticsearch
 Package apmelasticsearch provides a means of instrumenting the HTTP transport
-of Elasticsearch clients, such as https://github.com/olivere/elastic[olivere/elastic],
-so that Elasticsearch requests are reported as spans within the current transaction.
+of Elasticsearch clients, such as https://github.com/elastic/go-elasticsearch[go-elasticsearch]
+and https://github.com/olivere/elastic[olivere/elastic], so that Elasticsearch
+requests are reported as spans within the current transaction.
 
 To create spans for an Elasticsearch request, you should wrap the client's HTTP
 transport using the `WrapRoundTripper` function, and then associate the request


### PR DESCRIPTION
Capture the request body for more search requests.
Previously we would capture the body only for requests
where the path ended with "/_search". We will now
match the following suffixes:

 - "/_search"
 - "/_msearch"
 - "/_search/template"
 - "/_msearch/template"
 - "/_rollup_search"