### PR TITLE
Promote TraceContext to non-pooled types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - Allow specifying transaction (span) ID via TransactionOptions/SpanOptions (#463)
  - module/apmzerolog: introduce zerolog log correlation and exception-tracking writer (#428)
  - module/apmelasticsearch: capture body for \_msearch, template and rollup search (#470)
+ - Ended Transactions/Spans may now be used as parents (#478)
 
 ## [v1.2.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.2.0)
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -90,7 +90,8 @@ transaction := apm.DefaultTracer.StartTransactionOptions("GET /", "request", opt
 ==== `func (*Transaction) End()`
 
 End enqueues the transaction for sending to the Elastic APM server.
-The Transaction must not be modified after this.
+The Transaction must not be modified after this, but it may still
+be used for starting spans.
 
 The transaction's duration will be calculated as the amount of time
 elapsed since the transaction was started until this call. To override
@@ -242,7 +243,8 @@ span, ctx := apm.StartSpan(ctx, "SELECT FROM foo", "db.mysql.query")
 [[span-end]]
 ==== `func (*Span) End()`
 
-End marks the span as complete. The Span must not be modified after this.
+End marks the span as complete. The Span must not be modified after this,
+but may still be used as the parent of a span.
 
 The span's duration will be calculated as the amount of time elapsed
 since the span was started until this call. To override this behaviour,
@@ -253,8 +255,8 @@ the span's Duration field may be set before calling End.
 ==== `func (*Span) Dropped() bool`
 
 Dropped indicates whether or not the span is dropped, meaning it will not be reported to
-the APM server. Spans are dropped when the created with a nil, ended, or non-sampled
-transaction, or one whose max spans limit has been reached.
+the APM server. Spans are dropped when the created with a nil, or non-sampled transaction,
+or one whose max spans limit has been reached.
 
 [float]
 [[span-tracecontext]]

--- a/span.go
+++ b/span.go
@@ -62,42 +62,36 @@ func (tx *Transaction) StartSpan(name, spanType string, parent *Span) *Span {
 // the span type, subtype, and action; a single dot separates span
 // type and subtype, and the action will not be set.
 func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions) *Span {
-	if tx == nil {
+	if tx == nil || !tx.traceContext.Options.Recorded() {
 		return newDroppedSpan()
 	}
 
-	haveParent := opts.Parent != TraceContext{}
-	if !haveParent && opts.parent != nil {
-		opts.parent.mu.RLock()
-		if opts.parent.ended() {
-			opts.parent.mu.RUnlock()
-			return newDroppedSpan()
+	if opts.Parent == (TraceContext{}) {
+		if opts.parent != nil {
+			opts.Parent = opts.parent.TraceContext()
+		} else {
+			opts.Parent = tx.traceContext
 		}
-		opts.Parent = opts.parent.TraceContext()
-		opts.parent.mu.RUnlock()
-		haveParent = true
 	}
+	transactionID := tx.traceContext.Span
 
 	// Prevent tx from being ended while we're starting a span.
 	tx.mu.RLock()
 	defer tx.mu.RUnlock()
 
-	if tx.ended() || !tx.traceContext.Options.Recorded() {
-		return newDroppedSpan()
+	if tx.ended() {
+		return tx.tracer.StartSpan(name, spanType, transactionID, opts)
 	}
 
-	// Guard access to spansCreated, spansDropped, and rand.
+	// Guard access to spansCreated, spansDropped, maxSpans, timestamp,
+	// rand, and spanFramesMinDuration.
 	tx.TransactionData.mu.Lock()
 	defer tx.TransactionData.mu.Unlock()
-
 	if tx.maxSpans > 0 && tx.spansCreated >= tx.maxSpans {
 		tx.spansDropped++
 		return newDroppedSpan()
 	}
-	transactionID := tx.traceContext.Span
-	if !haveParent {
-		opts.Parent = tx.traceContext
-	}
+
 	// Calculate the span time relative to the transaction timestamp so
 	// that wall-clock adjustments occurring after the transaction start
 	// don't affect the span timestamp.
@@ -106,6 +100,7 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 	} else {
 		opts.Start = tx.timestamp.Add(opts.Start.Sub(tx.timestamp))
 	}
+
 	span := tx.tracer.startSpan(name, spanType, transactionID, opts)
 	if opts.SpanID.Validate() == nil {
 		span.traceContext.Span = opts.SpanID
@@ -113,6 +108,7 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 		binary.LittleEndian.PutUint64(span.traceContext.Span[:], tx.rand.Uint64())
 	}
 	span.stackFramesMinDuration = tx.spanFramesMinDuration
+	span.tx = tx
 	tx.spansCreated++
 	return span
 }
@@ -185,12 +181,9 @@ type SpanOptions struct {
 func (t *Tracer) startSpan(name, spanType string, transactionID SpanID, opts SpanOptions) *Span {
 	sd, _ := t.spanDataPool.Get().(*SpanData)
 	if sd == nil {
-		sd = &SpanData{
-			tracer:   t,
-			Duration: -1,
-		}
+		sd = &SpanData{Duration: -1}
 	}
-	span := &Span{SpanData: sd}
+	span := &Span{tracer: t, SpanData: sd}
 	span.Name = name
 	span.traceContext = opts.Parent
 	span.parentID = opts.Parent.Span
@@ -217,6 +210,11 @@ func newDroppedSpan() *Span {
 
 // Span describes an operation within a transaction.
 type Span struct {
+	tracer        *Tracer      // nil if span is dropped
+	tx            *Transaction // nil if span is dropped
+	traceContext  TraceContext
+	transactionID SpanID
+
 	mu sync.RWMutex
 
 	// SpanData holds the span data. This field is set to nil when
@@ -229,11 +227,6 @@ func (s *Span) TraceContext() TraceContext {
 	if s == nil {
 		return TraceContext{}
 	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if s.ended() {
-		return TraceContext{}
-	}
 	return s.traceContext
 }
 
@@ -241,12 +234,12 @@ func (s *Span) TraceContext() TraceContext {
 // skipping the first skip number of frames,
 // excluding the SetStacktrace function.
 func (s *Span) SetStacktrace(skip int) {
-	if s == nil {
+	if s == nil || s.dropped() {
 		return
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.ended() || s.dropped() {
+	if s.ended() {
 		return
 	}
 	s.SpanData.setStacktrace(skip + 1)
@@ -260,13 +253,11 @@ func (s *Span) SetStacktrace(skip int) {
 // Dropped may be used to avoid any expensive computation required to set
 // the span's context.
 func (s *Span) Dropped() bool {
-	if s == nil {
-		return true
-	}
-	s.mu.RLock()
-	dropped := s.ended() || s.dropped()
-	s.mu.RUnlock()
-	return dropped
+	return s == nil || s.dropped()
+}
+
+func (s *Span) dropped() bool {
+	return s.tracer == nil
 }
 
 // End marks the s as being complete; s must not be used after this.
@@ -276,8 +267,12 @@ func (s *Span) Dropped() bool {
 func (s *Span) End() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.ended() || s.dropped() {
+	if s.ended() {
+		return
+	}
+	if s.dropped() {
 		droppedSpanDataPool.Put(s.SpanData)
+		s.SpanData = nil
 		return
 	}
 	if s.Duration < 0 {
@@ -286,8 +281,23 @@ func (s *Span) End() {
 	if len(s.stacktrace) == 0 && s.Duration >= s.stackFramesMinDuration {
 		s.setStacktrace(1)
 	}
-	s.SpanData.enqueue()
+	s.enqueue()
 	s.SpanData = nil
+}
+
+func (s *Span) enqueue() {
+	event := tracerEvent{eventType: spanEvent}
+	event.span.Span = s
+	event.span.SpanData = s.SpanData
+	select {
+	case s.tracer.events <- event:
+	default:
+		// Enqueuing a span should never block.
+		s.tracer.statsMu.Lock()
+		s.tracer.stats.SpansDropped++
+		s.tracer.statsMu.Unlock()
+		s.reset(s.tracer)
+	}
 }
 
 func (s *Span) ended() bool {
@@ -298,10 +308,7 @@ func (s *Span) ended() bool {
 // When a span is ended or discarded, its SpanData field will be set
 // to nil.
 type SpanData struct {
-	tracer                 *Tracer // nil if span is dropped
-	traceContext           TraceContext
 	parentID               SpanID
-	transactionID          SpanID
 	stackFramesMinDuration time.Duration
 	timestamp              time.Time
 
@@ -336,29 +343,12 @@ func (s *SpanData) setStacktrace(skip int) {
 	s.stacktrace = stacktrace.AppendStacktrace(s.stacktrace[:0], skip+1, -1)
 }
 
-func (s *SpanData) dropped() bool {
-	return s.tracer == nil
-}
-
-func (s *SpanData) enqueue() {
-	select {
-	case s.tracer.spans <- s:
-	default:
-		// Enqueuing a span should never block.
-		s.tracer.statsMu.Lock()
-		s.tracer.stats.SpansDropped++
-		s.tracer.statsMu.Unlock()
-		s.reset()
-	}
-}
-
-func (s *SpanData) reset() {
+func (s *SpanData) reset(tracer *Tracer) {
 	*s = SpanData{
-		tracer:     s.tracer,
 		Context:    s.Context,
 		Duration:   -1,
 		stacktrace: s.stacktrace[:0],
 	}
 	s.Context.reset()
-	s.tracer.spanDataPool.Put(s)
+	tracer.spanDataPool.Put(s)
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -123,6 +123,12 @@ func TestTransactionEnsureParent(t *testing.T) {
 	assert.Equal(t, parentSpan, parentSpan2)
 
 	tx.End()
+
+	// For an ended transaction, EnsureParent will return a zero value
+	// even if the transaction had a parent at the time it was ended.
+	parentSpan3 := tx.EnsureParent()
+	assert.Zero(t, parentSpan3)
+
 	tracer.Flush(nil)
 	payloads := transport.Payloads()
 	require.Len(t, payloads.Transactions, 1)


### PR DESCRIPTION
Move TraceContext from TransactionData to
Transaction, and SpanData to Span. This
enables an ended transaction or span to
be used as the parent of a span. This is
particularly important to enable
fire-and-forget type patterns, where a
goroutine is spawned that may start a span
after the parent ends.

Transactions, spans, and errors are now
all sent to the tracer goroutine through
a single "chan tracerEvent" channel.

This change incurs a minor (~10%/~50 bytes)
increase in the number of bytes allocated
per transaction. There is no change in number
of allocs, and no significant impact on time
per operation.

Partially addresses #475 