### PR TITLE
Introduce DetachedContext function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - module/apmzerolog: introduce zerolog log correlation and exception-tracking writer (#428)
  - module/apmelasticsearch: capture body for \_msearch, template and rollup search (#470)
  - Ended Transactions/Spans may now be used as parents (#478)
+ - Introduce apm.DetachedContext for async/fire-and-forget trace propagation (#481)
 
 ## [v1.2.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.2.0)
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ update-modules:
 .PHONY: docs
 docs:
 ifdef ELASTIC_DOCS
-	$(ELASTIC_DOCS)/build_docs --chunk=1 $(BUILD_DOCS_ARGS) --doc docs/index.asciidoc --out docs/html
+	$(ELASTIC_DOCS)/build_docs --asciidoctor --chunk=1 $(BUILD_DOCS_ARGS) --doc docs/index.asciidoc --out docs/html
 else
 	@echo "\nELASTIC_DOCS is not defined.\n"
 	@exit 1

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -170,6 +170,17 @@ TransactionFromContext returns a transaction previously stored in the context us
 <<apm-context-with-transaction, apm.ContextWithTransaction>>, or nil if the context
 does not contain a transaction.
 
+[float]
+[[apm-detached-context]]
+==== `func DetachedContext(context.Context) context.Context`
+
+DetachedContext returns a new context detached from the lifetime of the input, but
+which still returns the same values as the input.
+
+DetachedContext can be used to maintain trace context required to correlate events,
+but where the operation is "fire-and-forget" and should not be affected by the
+deadline or cancellation of the surrounding context.
+
 // -------------------------------------------------------------------------------------------------
 
 [float]

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -797,6 +797,25 @@ func getList(ctx context.Context) (
 }
 ----
 
+Contexts can have deadlines associated, and can be explicitly canceled. In some cases you may
+wish to propagate the trace context (parent transaction/span) to some code without propagating
+the cancellation. For example, an HTTP request's context will be canceled when the client's
+connection closes. You may want to perform some operation in the request handler without it
+being canceled due to the client connection closing, such as in a fire-and-forget operation.
+To handle scenarios like this, we provide the function <<apm-detached-context, apm.DetachedContext>>.
+
+[source,go]
+----
+func handleRequest(w http.ResponseWriter, req *http.Request) {
+	go fireAndForget(apm.DetachedContext(req.Context()))
+
+	// After handleRequest returns, req.Context() will be canceled,
+	// but the "detached context" passed into fireAndForget will not.
+	// Any spans created by fireAndForget will still be joined to
+	// the handleRequest transaction.
+}
+----
+
 ===== Panic recovery and errors
 
 If you want to recover panics, and report them along with your transaction, you can use the

--- a/gocontext.go
+++ b/gocontext.go
@@ -51,6 +51,26 @@ func TransactionFromContext(ctx context.Context) *Transaction {
 	return value
 }
 
+// DetachedContext returns a new context detached from the lifetime
+// of ctx, but which still returns the values of ctx.
+//
+// DetachedContext can be used to maintain the trace context required
+// to correlate events, but where the operation is "fire-and-forget",
+// and should not be affected by the deadline or cancellation of ctx.
+func DetachedContext(ctx context.Context) context.Context {
+	return &detachedContext{Context: context.Background(), orig: ctx}
+}
+
+type detachedContext struct {
+	context.Context
+	orig context.Context
+}
+
+// Value returns c.orig.Value(key).
+func (c *detachedContext) Value(key interface{}) interface{} {
+	return c.orig.Value(key)
+}
+
 // StartSpan is equivalent to calling StartSpanOptions with a zero SpanOptions struct.
 func StartSpan(ctx context.Context, name, spanType string) (*Span, context.Context) {
 	return StartSpanOptions(ctx, name, spanType, SpanOptions{})


### PR DESCRIPTION
Introduce apm.DetachedContext, which takes a context.Context
and returns a new context.Context which is effectively a
background context, but with access to the values in the
input context.

DetachedContext can be used to maintain the trace context
required to correlate events, but where the operation is
"fire-and-forget", and should not be affected by the deadline
or cancellation of the input context.

Closes #476 