### PR TITLE
Fix go1.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,17 @@ before_install:
         go get -v golang.org/x/tools/cmd/goimports;
         go get -v github.com/elastic/go-licenser;
       fi
+  - |
+      if (! go run scripts/mingoversion.go 1.9 &>/dev/null); then
+        # For Go 1.8.x, pin go-sql-driver to v1.4.1,
+        # the last release that supports Go 1.8.
+        mkdir -p $GOPATH/src/github.com/go-sql-driver;
+        (
+          cd $GOPATH/src/github.com/go-sql-driver &&
+          git clone https://github.com/go-sql-driver/mysql &&
+          cd mysql && git checkout v1.4.1
+        );
+      fi;
 
 script:
   - make install check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.2.0...master)
 
+ - Update opentracing-go dependency to v1.1.0
+
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 
  - Rename "metricset.labels" to "metricset.tags" (#438)


### PR DESCRIPTION
Pin go-sql-driver to v1.4.1, which is the last release to support Go 1.8. We'll drop Go 1.8 eventually, but only in a major release.