### PR TITLE
module/apmot: remove workaround for ended tx

### DIFF
--- a/module/apmot/context.go
+++ b/module/apmot/context.go
@@ -18,7 +18,6 @@
 package apmot
 
 import (
-	"sync"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -29,13 +28,9 @@ import (
 type spanContext struct {
 	tracer *otTracer // for origin of tx/span
 
-	txSpanContext *spanContext // spanContext for OT span which created tx
-	traceContext  apm.TraceContext
-	transactionID apm.SpanID
-	startTime     time.Time
-
-	mu sync.RWMutex
-	tx *apm.Transaction
+	tx           *apm.Transaction
+	traceContext apm.TraceContext
+	startTime    time.Time
 }
 
 // TraceContext returns the trace context for the transaction or span
@@ -46,9 +41,6 @@ func (s *spanContext) TraceContext() apm.TraceContext {
 
 // Transaction returns the transaction associated with this span context.
 func (s *spanContext) Transaction() *apm.Transaction {
-	if s.txSpanContext != nil {
-		return s.txSpanContext.tx
-	}
 	return s.tx
 }
 
@@ -76,7 +68,6 @@ func parentSpanContext(refs []opentracing.SpanReference) (*spanContext, bool) {
 				tx:           apmSpanContext.Transaction(),
 				traceContext: apmSpanContext.TraceContext(),
 			}
-			spanContext.transactionID = spanContext.tx.TraceContext().Span
 			return spanContext, true
 		}
 	}

--- a/module/apmot/doc.go
+++ b/module/apmot/doc.go
@@ -20,5 +20,5 @@
 // Things not implemented by this tracer:
 //  - binary propagation format
 //  - baggage
-//  - logging
+//  - logging (generally; errors are reported)
 package apmot

--- a/module/apmot/span.go
+++ b/module/apmot/span.go
@@ -100,18 +100,14 @@ func (s *otSpan) FinishWithOptions(opts opentracing.FinishOptions) {
 		s.span.End()
 	} else {
 		s.setTransactionContext()
-		s.ctx.mu.Lock()
-		tx := s.ctx.tx
-		s.ctx.tx = nil
-		s.ctx.mu.Unlock()
 		for _, record := range opts.LogRecords {
 			timestamp := record.Timestamp
 			if timestamp.IsZero() {
 				timestamp = opts.FinishTime
 			}
-			logFields(s.tracer.tracer, tx, nil, timestamp, record.Fields)
+			logFields(s.tracer.tracer, s.ctx.tx, nil, timestamp, record.Fields)
 		}
-		tx.End()
+		s.ctx.tx.End()
 	}
 }
 

--- a/module/apmot/tracer_test.go
+++ b/module/apmot/tracer_test.go
@@ -213,8 +213,8 @@ func TestStartSpanParentFinished(t *testing.T) {
 
 	apmtracer.Flush(nil)
 	payloads := recorder.Payloads()
-	assert.Len(t, payloads.Transactions, 1)
-	assert.Len(t, payloads.Spans, 2)
+	require.Len(t, payloads.Transactions, 1)
+	require.Len(t, payloads.Spans, 2)
 
 	tx := payloads.Transactions[0]
 	assert.Equal(t, tx.ID, payloads.Spans[0].ParentID)


### PR DESCRIPTION
We previously worked around starting spans from
finished/ended transactions by maintaining a
reference to the span context that created the
transaction, and setting its tx property to
nil upon ending it. This was necessary because,
at the time, spans started from ended transactions
would be dropped.

We no longer drop these spans, so we can get rid
of this workaround. Now we just keep a reference
to the transaction within which a span is created,
and always use that.

Closes elastic/apm-agent-go#480 