### PR TITLE
Update all HTTP instrumentation modules to group unknown routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.2.0...master)
 
  - Update opentracing-go dependency to v1.1.0
+ - Update HTTP routers to return "<METHOD> unknown route" if route cannot be matched (#)
 
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -140,7 +140,7 @@ import (
 
 func main() {
 	router := mux.NewRouter()
-	router.Use(apmgorilla.Middleware())
+	apmgorilla.Instrument(router)
 	...
 }
 ----

--- a/module/apmbeego/filter.go
+++ b/module/apmbeego/filter.go
@@ -57,7 +57,7 @@ func Middleware(o ...Option) func(http.Handler) http.Handler {
 				req = apmhttp.RequestWithContext(ctx, req)
 			}
 			h.ServeHTTP(w, req)
-		}), apmhttp.WithTracer(opts.tracer))
+		}), apmhttp.WithTracer(opts.tracer), apmhttp.WithServerRequestName(apmhttp.UnknownRouteRequestName))
 	}
 }
 

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
+	"runtime"
 
 	"github.com/labstack/echo"
 
@@ -100,7 +102,37 @@ func (m *middleware) handle(c echo.Context) error {
 	}()
 
 	handlerErr = m.handler(c)
-	if handlerErr == nil && !resp.Committed {
+	if handlerErr != nil {
+		resp.Status = http.StatusInternalServerError
+		if handlerErr, ok := handlerErr.(*echo.HTTPError); ok {
+			resp.Status = handlerErr.Code
+			reqPath := req.URL.RawPath
+			if reqPath == "" {
+				reqPath = req.URL.Path
+			}
+			if c.Path() == reqPath {
+				// When c.Path() matches the request path exactly,
+				// that means either there's no matching route, or
+				// there's an exactly matching route.
+				//
+				// When ErrNotFound or ErrMethodNotAllowed are
+				// returned, it's probably because there's no
+				// matching route, as opposed to the handler
+				// returning them. We can confirm this by looking
+				// for exact-matching routes.
+				var unknownRoute bool
+				switch handlerErr {
+				case echo.ErrNotFound:
+					unknownRoute = isNotFoundHandler(c.Handler())
+				case echo.ErrMethodNotAllowed:
+					unknownRoute = isMethodNotAllowedHandler(c.Handler())
+				}
+				if unknownRoute {
+					tx.Name = apmhttp.UnknownRouteRequestName(req)
+				}
+			}
+		}
+	} else if !resp.Committed {
 		resp.WriteHeader(http.StatusOK)
 	}
 	return handlerErr
@@ -142,5 +174,51 @@ func WithRequestIgnorer(r apmhttp.RequestIgnorerFunc) Option {
 	}
 	return func(o *options) {
 		o.requestIgnorer = r
+	}
+}
+
+func isNotFoundHandler(h echo.HandlerFunc) bool {
+	return isHandler(h, notFoundHandlerIdentity, &echo.NotFoundHandler)
+}
+
+func isMethodNotAllowedHandler(h echo.HandlerFunc) bool {
+	return isHandler(h, methodNotAllowedHandlerIdentity, &echo.MethodNotAllowedHandler)
+}
+
+func isHandler(h echo.HandlerFunc, ident handlerFuncIdentity, handlerVar *func(echo.Context) error) bool {
+	rv := reflect.ValueOf(h)
+	ptr := rv.Pointer()
+	if ptr == ident.rv.Pointer() {
+		return true
+	}
+	// A sufficiently smart compiler could perform whole program optimisation
+	// to determine that echo.NotFoundHandler and/or echo.MethodNotAllowedHandler
+	// are only written to once to a defined function, enabling callers to inline
+	// the assigned function. In this case, the function PC will not match.
+	name := runtime.FuncForPC(ptr).Name()
+	if name == ident.name {
+		return true
+	}
+	// The global variables could have been reassigned since we read
+	// their values during package init.
+	ident = getHandlerFuncIdentity(*handlerVar)
+	return ptr == ident.rv.Pointer() || name == ident.name
+}
+
+var (
+	notFoundHandlerIdentity         = getHandlerFuncIdentity(echo.NotFoundHandler)
+	methodNotAllowedHandlerIdentity = getHandlerFuncIdentity(echo.MethodNotAllowedHandler)
+)
+
+type handlerFuncIdentity struct {
+	rv   reflect.Value
+	name string
+}
+
+func getHandlerFuncIdentity(h func(echo.Context) error) handlerFuncIdentity {
+	rv := reflect.ValueOf(h)
+	return handlerFuncIdentity{
+		rv:   rv,
+		name: runtime.FuncForPC(rv.Pointer()).Name(),
 	}
 }

--- a/module/apmechov4/middleware_test.go
+++ b/module/apmechov4/middleware_test.go
@@ -107,6 +107,44 @@ func TestEchoMiddleware(t *testing.T) {
 	}, transaction.Context)
 }
 
+func TestEchoMiddlewareUnknownRoute(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	e := echo.New()
+	e.Use(apmecho.Middleware(apmecho.WithTracer(tracer)))
+	e.GET("/hello/there", func(c echo.Context) error {
+		return echo.ErrNotFound
+	})
+
+	doRequest(e, "GET", "http://server.testing/hello/there")
+	doRequest(e, "PUT", "http://server.testing/hello/there")
+	doRequest(e, "GET", "http://server.testing/ahoy/thar")
+	doRequest(e, "PUT", "http://server.testing/ahoy/thar")
+
+	// Replace echo.NotFoundHandler so the function pointers
+	// don't match.
+	oldHandler := echo.NotFoundHandler
+	echo.NotFoundHandler = func(echo.Context) error {
+		return echo.ErrNotFound
+	}
+	defer func() { echo.NotFoundHandler = oldHandler }()
+	doRequest(e, "GET", "http://server.testing/ahoy/thar")
+
+	tracer.Flush(nil)
+	transactions := transport.Payloads().Transactions
+	require.Len(t, transactions, 5)
+
+	assert.Equal(t, "GET /hello/there", transactions[0].Name)
+	assert.Equal(t, "PUT unknown route", transactions[1].Name)
+	assert.Equal(t, "GET unknown route", transactions[2].Name)
+	assert.Equal(t, "PUT unknown route", transactions[3].Name)
+	assert.Equal(t, "GET unknown route", transactions[4].Name)
+	for _, tx := range transactions {
+		assert.Equal(t, "HTTP 4xx", tx.Result)
+	}
+}
+
 func TestEchoMiddlewarePanic(t *testing.T) {
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -89,10 +89,12 @@ func (m *middleware) handle(c *gin.Context) {
 		m.routeMap = rm
 	})
 
-	requestName := c.Request.Method
+	var requestName string
 	handlerName := c.HandlerName()
 	if routeInfo, ok := m.routeMap[c.Request.Method][handlerName]; ok {
 		requestName = routeInfo.transactionName
+	} else {
+		requestName = apmhttp.UnknownRouteRequestName(c.Request)
 	}
 	tx, req := apmhttp.StartTransaction(m.tracer, requestName, c.Request)
 	c.Request = req

--- a/module/apmhttp/requestname.go
+++ b/module/apmhttp/requestname.go
@@ -24,6 +24,17 @@ import (
 	"strings"
 )
 
+// UnknownRouteRequestName returns the transaction name for the server request, req,
+// when the route could not be determined.
+func UnknownRouteRequestName(req *http.Request) string {
+	const suffix = " unknown route"
+	var b strings.Builder
+	b.Grow(len(req.Method) + len(suffix))
+	b.WriteString(req.Method)
+	b.WriteString(suffix)
+	return b.String()
+}
+
 // ServerRequestName returns the transaction name for the server request, req.
 func ServerRequestName(req *http.Request) string {
 	var b strings.Builder

--- a/module/apmhttp/requestname_go19.go
+++ b/module/apmhttp/requestname_go19.go
@@ -21,6 +21,12 @@ package apmhttp
 
 import "net/http"
 
+// UnknownRouteRequestName returns the transaction name for the server request, req,
+// when the route could not be determined.
+func UnknownRouteRequestName(req *http.Request) string {
+	return req.Method + " unknown route"
+}
+
 // ServerRequestName returns the transaction name for the server request, req.
 func ServerRequestName(req *http.Request) string {
 	buf := make([]byte, len(req.Method)+len(req.URL.Path)+1)

--- a/module/apmhttprouter/router.go
+++ b/module/apmhttprouter/router.go
@@ -33,9 +33,15 @@ type Router struct {
 
 // New returns a new Router which will instrument all added routes
 // except static content served with ServeFiles.
+//
+// Router.NotFound and Router.MethodNotAllowed will be set, and will
+// report transactions with the name "<METHOD> unknown route".
 func New(o ...Option) *Router {
+	router := httprouter.New()
+	router.NotFound = WrapNotFoundHandler(router.NotFound, o...)
+	router.MethodNotAllowed = WrapMethodNotAllowedHandler(router.MethodNotAllowed, o...)
 	return &Router{
-		Router: httprouter.New(),
+		Router: router,
 		opts:   o,
 	}
 }

--- a/module/apmrestful/filter.go
+++ b/module/apmrestful/filter.go
@@ -56,7 +56,12 @@ func (f *filter) filter(req *restful.Request, resp *restful.Response, chain *res
 		return
 	}
 
-	name := req.Request.Method + " " + massageRoutePath(req.SelectedRoutePath())
+	var name string
+	if routePath := massageRoutePath(req.SelectedRoutePath()); routePath != "" {
+		name = req.Request.Method + " " + massageRoutePath(req.SelectedRoutePath())
+	} else {
+		name = apmhttp.UnknownRouteRequestName(req.Request)
+	}
 	tx, httpRequest := apmhttp.StartTransaction(f.tracer, name, req.Request)
 	defer tx.End()
 	req.Request = httpRequest


### PR DESCRIPTION
Update all HTTP instrumentation modules to group unknown routes. If a route cannot be determined, then the transaction name will be `<METHOD> unknown route`, as in the Node.js agent.

Closes #486 