### PR TITLE
module/apmmongo: set build constraint of go1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
  - Update opentracing-go dependency to v1.1.0
  - Update HTTP routers to return "<METHOD> unknown route" if route cannot be matched (#486)
  - module/apmchi: introduce instrumentation for go-chi/chi router (#495)
+ - module/apmgoredis: introduce instrumentation for the go-redis/redis client (#505)
+ - module/apmsql: exposed the QuerySignature function (#515)
+ - module/apmgopg: introduce instrumentation for the go-pg/pg ORM (#516)
+ - module/apmmongo: set minimum Go version to Go 1.10 (#522)
 
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 

--- a/internal/tracecontexttest/Dockerfile
+++ b/internal/tracecontexttest/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:latest
 ADD . /go/src/go.elastic.co/apm
 ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
+WORKDIR /go/src/go.elastic.co/apm/internal/tracecontexttest
+RUN go build -o /trace-context-service main.go
 
 EXPOSE 5000/tcp
-WORKDIR /go/src/go.elastic.co/apm/internal/tracecontexttest
 HEALTHCHECK CMD curl -X POST -H "Content-Type: application/json" -d "{}" http://localhost:5000
-CMD go run main.go
+CMD /trace-context-service

--- a/module/apmmongo/monitor.go
+++ b/module/apmmongo/monitor.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.10
+
 package apmmongo
 
 import (

--- a/module/apmmongo/monitor_benchmark_test.go
+++ b/module/apmmongo/monitor_benchmark_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.10
+
 package apmmongo_test
 
 import (

--- a/module/apmmongo/monitor_integration_test.go
+++ b/module/apmmongo/monitor_integration_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.10
+
 package apmmongo_test
 
 import (

--- a/module/apmmongo/monitor_test.go
+++ b/module/apmmongo/monitor_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.10
+
 package apmmongo_test
 
 import (


### PR DESCRIPTION
At least since 1.0.0, which is what we require, go.mongodb.org/mongo-driver has required Go 1.10. They've just made a code change that breaks Go 1.8, so we need to actually start excluding it now.