### PR TITLE
tracecontexttest: build service binary

### DIFF
--- a/internal/tracecontexttest/Dockerfile
+++ b/internal/tracecontexttest/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:latest
 ADD . /go/src/go.elastic.co/apm
 ENV GO111MODULE=on
-
-EXPOSE 5000/tcp
 WORKDIR /go/src/go.elastic.co/apm/internal/tracecontexttest
+RUN go build -o /trace-context-service main.go
+
+FROM gcr.io/distroless/base
+COPY --from=0 /trace-context-service /
+EXPOSE 5000/tcp
 HEALTHCHECK CMD curl -X POST -H "Content-Type: application/json" -d "{}" http://localhost:5000
-CMD go run main.go
+CMD /trace-context-service


### PR DESCRIPTION
Build the service first, rather than as the CMD, so building doesn't hold up starting the service.