### PR TITLE
apmgrpc: Add WithServerRequestIgnorer Server Option

### DIFF
--- a/module/apmgrpc/ignorer.go
+++ b/module/apmgrpc/ignorer.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.9
+
 package apmgrpc
 
 import (

--- a/module/apmgrpc/ignorer.go
+++ b/module/apmgrpc/ignorer.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmgrpc
+
+import (
+	"regexp"
+	"sync"
+
+	"go.elastic.co/apm/internal/apmconfig"
+	"go.elastic.co/apm/internal/wildcard"
+)
+
+const (
+	envIgnoreURLs = "ELASTIC_APM_IGNORE_URLS"
+)
+
+var (
+	defaultServerRequestIgnorerOnce sync.Once
+	defaultServerRequestIgnorer     RequestIgnorerFunc = IgnoreNone
+)
+
+// DefaultServerRequestIgnorer returns the default RequestIgnorer to use in
+// handlers. If ELASTIC_APM_IGNORE_URLS is set, it will be treated as a
+// comma-separated list of wildcard patterns; requests that match any of the
+// patterns will be ignored.
+func DefaultServerRequestIgnorer() RequestIgnorerFunc {
+	defaultServerRequestIgnorerOnce.Do(func() {
+		matchers := apmconfig.ParseWildcardPatternsEnv(envIgnoreURLs, nil)
+		if len(matchers) != 0 {
+			defaultServerRequestIgnorer = NewWildcardPatternsRequestIgnorer(matchers)
+		}
+	})
+	return defaultServerRequestIgnorer
+}
+
+// NewRegexpRequestIgnorer returns a RequestIgnorerFunc which matches requests'
+// URLs against re. Note that for server requests, typically only Path and
+// possibly RawQuery will be set, so the regular expression should take this
+// into account.
+func NewRegexpRequestIgnorer(re *regexp.Regexp) RequestIgnorerFunc {
+	if re == nil {
+		panic("re == nil")
+	}
+	return func(s *string) bool {
+		return re.MatchString(*s)
+	}
+}
+
+// NewWildcardPatternsRequestIgnorer returns a RequestIgnorerFunc which matches
+// requests' URLs against any of the matchers. Note that for server requests,
+// typically only Path and possibly RawQuery will be set, so the wildcard patterns
+// should take this into account.
+func NewWildcardPatternsRequestIgnorer(matchers wildcard.Matchers) RequestIgnorerFunc {
+	if len(matchers) == 0 {
+		panic("len(matchers) == 0")
+	}
+	return func(s *string) bool {
+		return matchers.MatchAny(*s)
+	}
+}
+
+// IgnoreNone is a RequestIgnorerFunc which ignores no requests.
+func IgnoreNone(*string) bool {
+	return false
+}

--- a/module/apmgrpc/ignorer_test.go
+++ b/module/apmgrpc/ignorer_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.9
+
 package apmgrpc_test
 
 import (

--- a/module/apmgrpc/ignorer_test.go
+++ b/module/apmgrpc/ignorer_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.elastic.co/apm/module/apmgrpc"
 	"google.golang.org/grpc"
+
+	"go.elastic.co/apm/module/apmgrpc"
 )
 
 func TestDefaultServerRequestIgnorer(t *testing.T) {

--- a/module/apmgrpc/ignorer_test.go
+++ b/module/apmgrpc/ignorer_test.go
@@ -55,7 +55,6 @@ func testDefaultServerRequestIgnorer(t *testing.T, ignoreURLs string, r *grpc.Un
 	testName := fmt.Sprintf("%s_%s", ignoreURLs, r.FullMethod)
 	t.Run(testName, func(t *testing.T) {
 		re := regexp.MustCompile(ignoreURLs)
-		_ = err
 		ignorer := apmgrpc.NewRegexpRequestIgnorer(re)
 		assert.Equal(t, expect, ignorer(r))
 	})

--- a/module/apmgrpc/ignorer_test.go
+++ b/module/apmgrpc/ignorer_test.go
@@ -53,7 +53,7 @@ func TestDefaultServerRequestIgnorer(t *testing.T) {
 func testDefaultServerRequestIgnorer(t *testing.T, ignoreURLs string, r *grpc.UnaryServerInfo, expect bool) {
 	testName := fmt.Sprintf("%s_%s", ignoreURLs, r.FullMethod)
 	t.Run(testName, func(t *testing.T) {
-		re, err := regexp.Compile(ignoreURLs)
+		re := regexp.MustCompile(ignoreURLs)
 		_ = err
 		ignorer := apmgrpc.NewRegexpRequestIgnorer(re)
 		assert.Equal(t, expect, ignorer(r))

--- a/module/apmgrpc/ignorer_test.go
+++ b/module/apmgrpc/ignorer_test.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmgrpc_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.elastic.co/apm/module/apmgrpc"
+)
+
+func TestDefaultServerRequestIgnorer(t *testing.T) {
+	s1 := "/helloworld.Greeter/SayHello"
+	s2 := "/bar.Foo/World"
+	s3 := "/foo?bar=baz"
+
+	testDefaultServerRequestIgnorer(t, "", s1, false)
+	testDefaultServerRequestIgnorer(t, "", s2, false)
+	testDefaultServerRequestIgnorer(t, "", s3, false)
+	testDefaultServerRequestIgnorer(t, ",", s1, false) // equivalent to empty
+	
+	testDefaultServerRequestIgnorer(t, s1, s1, true)
+	testDefaultServerRequestIgnorer(t, "*/helloworld*", s1, true)
+	testDefaultServerRequestIgnorer(t, "*/bar*", s2, true)
+	testDefaultServerRequestIgnorer(t, "*/Bar*", s2, true)
+	testDefaultServerRequestIgnorer(t, "*/foo*", s3, true)
+	testDefaultServerRequestIgnorer(t, "*/BAR*", s2, true) // case insensitive by default
+
+	testDefaultServerRequestIgnorer(t, "*/foo?bar=baz", s1, false)
+	testDefaultServerRequestIgnorer(t, "*/foo?bar=baz", s2, false)
+	testDefaultServerRequestIgnorer(t, "*/foo?bar=baz", s3, true)
+}
+
+func testDefaultServerRequestIgnorer(t *testing.T, ignoreURLs string, s string, expect bool) {
+	testName := fmt.Sprintf("%s_%s", ignoreURLs, s)
+	t.Run(testName, func(t *testing.T) {
+		if os.Getenv("_INSIDE_TEST") != "1" {
+			cmd := exec.Command(os.Args[0], "-test.run=^"+regexp.QuoteMeta(t.Name())+"$")
+			cmd.Env = append(os.Environ(), "_INSIDE_TEST=1")
+			cmd.Env = append(cmd.Env, "ELASTIC_APM_IGNORE_URLS="+ignoreURLs)
+			assert.NoError(t, cmd.Run())
+			return
+		}
+		ignorer := apmgrpc.DefaultServerRequestIgnorer()
+		assert.Equal(t, expect, ignorer(&s))
+	})
+}

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -50,6 +50,7 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 	opts := serverOptions{
 		tracer:  apm.DefaultTracer,
 		recover: false,
+		requestIgnorer: DefaultServerRequestIgnorer(),
 	}
 	for _, o := range o {
 		o(&opts)
@@ -60,7 +61,7 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
-		if !opts.tracer.Active() {
+		if !opts.tracer.Active() || opts.requestIgnorer(&info.FullMethod) {
 			return handler(ctx, req)
 		}
 		tx, ctx := startTransaction(ctx, opts.tracer, info.FullMethod)
@@ -121,6 +122,7 @@ func setTransactionResult(tx *apm.Transaction, err error) {
 type serverOptions struct {
 	tracer  *apm.Tracer
 	recover bool
+	requestIgnorer RequestIgnorerFunc
 }
 
 // ServerOption sets options for server-side tracing.
@@ -147,5 +149,21 @@ func WithTracer(t *apm.Tracer) ServerOption {
 func WithRecovery() ServerOption {
 	return func(o *serverOptions) {
 		o.recover = true
+	}
+}
+
+// RequestIgnorerFunc is the type of a function for use in
+// WithServerRequestIgnorer.
+type RequestIgnorerFunc func(*string) bool
+
+// WithServerRequestIgnorer returns a ServerOption which sets r as the
+// function to use to determine whether or not a server request should
+// be ignored. If r is nil, all requests will be reported.
+func WithServerRequestIgnorer(r RequestIgnorerFunc) ServerOption {
+	if r == nil {
+		r = IgnoreNone
+	}
+	return func(o *serverOptions) {
+		o.requestIgnorer = r
 	}
 }

--- a/module/apmgrpc/server_test.go
+++ b/module/apmgrpc/server_test.go
@@ -189,7 +189,7 @@ func TestServerIgnorer(t *testing.T) {
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
-	s, _, addr := newServer(t, tracer, apmgrpc.WithRecovery(), apmgrpc.WithServerRequestIgnorer(func(*string) bool {
+	s, _, addr := newServer(t, tracer, apmgrpc.WithRecovery(), apmgrpc.WithServerRequestIgnorer(func(*grpc.UnaryServerInfo) bool {
 		return true
 	}))
 	defer s.GracefulStop()

--- a/module/apmgrpc/server_test.go
+++ b/module/apmgrpc/server_test.go
@@ -185,6 +185,26 @@ func TestServerRecovery(t *testing.T) {
 	assert.Equal(t, "boom", e.Exception.Message)
 }
 
+func TestServerIgnorer(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	s, _, addr := newServer(t, tracer, apmgrpc.WithRecovery(), apmgrpc.WithServerRequestIgnorer(func(*string) bool {
+		return true
+	}))
+	defer s.GracefulStop()
+
+	conn, client := newClient(t, addr)
+	defer conn.Close()
+
+	resp, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "birita"})
+	require.NoError(t, err)
+	assert.Equal(t, resp, &pb.HelloReply{Message: "hello, birita"})
+
+	tracer.Flush(nil)
+	assert.Empty(t, transport.Payloads())
+}
+
 func newServer(t *testing.T, tracer *apm.Tracer, opts ...apmgrpc.ServerOption) (*grpc.Server, *helloworldServer, net.Addr) {
 	// We always install grpc_recovery first to avoid panics
 	// aborting the test process. We install it before the


### PR DESCRIPTION
Add `func WithServerRequestIgnorer(r RequestIgnorerFunc) ServerOption` for ignoring gRPC methods, as described in #530.