### PR TITLE
Add row_query callback to apmgorm

### DIFF
--- a/module/apmgorm/context.go
+++ b/module/apmgorm/context.go
@@ -87,6 +87,10 @@ func registerCallbacks(db *gorm.DB, dsnInfo apmsql.DSNInfo) {
 			spanType:  execSpanType,
 			processor: func() *gorm.CallbackProcessor { return db.Callback().Update() },
 		},
+		"gorm:row_query": {
+			spanType:  querySpanType,
+			processor: func() *gorm.CallbackProcessor { return db.Callback().RowQuery() },
+		},
 	}
 	for name, params := range callbacks {
 		const callbackPrefix = "elasticapm"


### PR DESCRIPTION
The RowQuery callback is used when objects are queried with functions like row, rows, count, etc are executed.