### PR TITLE
Problem on Linux if APM Go agent is installed without -u flag

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -17,7 +17,7 @@ Install the Elastic APM Go agent package using `go get`:
 
 [source,bash]
 ----
-go get go.elastic.co/apm
+go get -u go.elastic.co/apm
 ----
 
 ==== Requirements


### PR DESCRIPTION
Actual version of module `github.com/elastic/go-sysinfo` seems to have some trouble if I add APM module by only `go get go.elastic.co/apm`

```
# github.com/elastic/go-sysinfo/providers/linux
$HOME/go/pkg/mod/github.com/elastic/go-sysinfo@v0.0.0-20190103140604-e68552284485/providers/linux/host_linux.go:45:20: cannot convert filepath.Join(hostFS, procfs.DefaultMountPoint) (type string) to type procfs.FS
$HOME/go/pkg/mod/github.com/elastic/go-sysinfo@v0.0.0-20190103140604-e68552284485/providers/linux/host_linux.go:64:42: h.procFS.Path undefined (type procfs.FS has no field or method Path)
$HOME/go/pkg/mod/github.com/elastic/go-sysinfo@v0.0.0-20190103140604-e68552284485/providers/linux/process_linux.go:40:10: s.procFS.Path undefined (type procfs.FS has no field or method Path)
$HOME/go/pkg/mod/github.com/elastic/go-sysinfo@v0.0.0-20190103140604-e68552284485/providers/linux/process_linux.go:74:13: p.fs.Path undefined (type procfs.FS has no field or method Path)
```

This problem disappear if I use `-u` flags because it updates `github.com/elastic/go-sysinfo` to version `v1.0.1`