### PR TITLE
internal/sqlscanner: fix for unicode at beginning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - module/apmsql: exposed the QuerySignature function (#515)
  - module/apmgopg: introduce instrumentation for the go-pg/pg ORM (#516)
  - module/apmmongo: set minimum Go version to Go 1.10 (#522)
+ - internal/sqlscanner: bug fix for multi-byte rune handling (#535)
 
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 

--- a/internal/sqlscanner/testdata/tests.json
+++ b/internal/sqlscanner/testdata/tests.json
@@ -208,5 +208,23 @@
 	"text": "3"
       }
     ]
+  },
+  {
+	  "name": "unicode",
+	  "input": "选择 FROM foo",
+	  "tokens": [
+		  {
+			  "kind": "IDENT",
+			  "text": "选择"
+		  },
+		  {
+			  "kind": "FROM",
+			  "text": "FROM"
+		  },
+		  {
+			  "kind": "IDENT",
+			  "text": "foo"
+		  }
+	  ]
   }
 ]


### PR DESCRIPTION
Ensure we use the rune length everywhere, rather than
assuming single byte runes. This fixes a bug where we
would not properly mark the beginning of the first token
if it starts with a multi-byte rune.

Also, add some comments based on https://github.com/elastic/apm-agent-java/pull/633.

Fixes #535