### PR TITLE
Introduce ELASTIC_APM_GLOBAL_LABELS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
  - module/apmgopg: introduce instrumentation for the go-pg/pg ORM (#516)
  - module/apmmongo: set minimum Go version to Go 1.10 (#522)
  - internal/sqlscanner: bug fix for multi-byte rune handling (#535)
+ - module/apmgrpc: added WithServerRequestIgnorer server option (#531)
+ - Introduce `ELASTIC_APM_GLOBAL_LABELS` config (#539)
 
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -161,6 +161,22 @@ Enable or disable the agent. If set to false, then the Go agent does not send
 any data to the Elastic APM server, and instrumentation overhead is minimized.
 
 [float]
+[[config-global-labels]]
+=== `ELASTIC_APM_GLOBAL_LABELS`
+
+[options="header"]
+|============
+| Environment                 | Default | Example
+| `ELASTIC_APM_GLOBAL_LABELS` |         | `dept=engineering,rack=number8`
+|============
+
+Labels added to all events, with the format key=value[,key=value[,...]].
+Any labels set by application via the API will override global labels with the same keys.
+
+This option requires APM Server 7.2 or greater, and will have no effect when using older
+server versions.
+
+[float]
 [[config-ignore-urls]]
 === `ELASTIC_APM_IGNORE_URLS`
 

--- a/testmain_test.go
+++ b/testmain_test.go
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func getSubprocessMetadata(t *testing.T, env ...string) (*model.System, *model.Process, *model.Service) {
+func getSubprocessMetadata(t *testing.T, env ...string) (*model.System, *model.Process, *model.Service, model.StringMap) {
 	cmd := exec.Command(os.Args[0], "-dump-metadata")
 	cmd.Env = append(os.Environ(), env...)
 
@@ -62,6 +62,7 @@ func getSubprocessMetadata(t *testing.T, env ...string) (*model.System, *model.P
 	var system model.System
 	var process model.Process
 	var service model.Service
+	var labels model.StringMap
 
 	output := stdout.String()
 	d := json.NewDecoder(&stdout)
@@ -71,7 +72,8 @@ func getSubprocessMetadata(t *testing.T, env ...string) (*model.System, *model.P
 	}
 	require.NoError(t, d.Decode(&process))
 	require.NoError(t, d.Decode(&service))
-	return &system, &process, &service
+	require.NoError(t, d.Decode(&labels))
+	return &system, &process, &service, labels
 }
 
 func dumpMetadata() {
@@ -82,10 +84,10 @@ func dumpMetadata() {
 
 	tracer.StartTransaction("name", "type").End()
 	tracer.Flush(nil)
-	system, process, service := transport.Metadata()
+	system, process, service, labels := transport.Metadata()
 
 	var w fastjson.Writer
-	for _, m := range []fastjson.Marshaler{&system, &process, &service} {
+	for _, m := range []fastjson.Marshaler{&system, &process, &service, labels} {
 		if err := m.MarshalFastJSON(&w); err != nil {
 			panic(err)
 		}

--- a/tracer.go
+++ b/tracer.go
@@ -854,6 +854,10 @@ func (t *Tracer) jsonRequestMetadata() []byte {
 	t.process.MarshalFastJSON(&json)
 	json.RawString(`,"service":`)
 	service.MarshalFastJSON(&json)
+	if len(globalLabels) > 0 {
+		json.RawString(`,"labels":`)
+		globalLabels.MarshalFastJSON(&json)
+	}
 	json.RawString("}}\n")
 	return json.Bytes()
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -385,7 +385,7 @@ func TestTracerMetadata(t *testing.T) {
 	tracer.Flush(nil)
 
 	// TODO(axw) check other metadata
-	system, _, _ := recorder.Metadata()
+	system, _, _, _ := recorder.Metadata()
 	container, err := apmhostutil.Container()
 	if err != nil {
 		assert.Nil(t, system.Container)
@@ -397,19 +397,19 @@ func TestTracerMetadata(t *testing.T) {
 
 func TestTracerKubernetesMetadata(t *testing.T) {
 	t.Run("no-env", func(t *testing.T) {
-		system, _, _ := getSubprocessMetadata(t)
+		system, _, _, _ := getSubprocessMetadata(t)
 		assert.Nil(t, system.Kubernetes)
 	})
 
 	t.Run("namespace-only", func(t *testing.T) {
-		system, _, _ := getSubprocessMetadata(t, "KUBERNETES_NAMESPACE=myapp")
+		system, _, _, _ := getSubprocessMetadata(t, "KUBERNETES_NAMESPACE=myapp")
 		assert.Equal(t, &model.Kubernetes{
 			Namespace: "myapp",
 		}, system.Kubernetes)
 	})
 
 	t.Run("pod-only", func(t *testing.T) {
-		system, _, _ := getSubprocessMetadata(t, "KUBERNETES_POD_NAME=luna", "KUBERNETES_POD_UID=oneone!11")
+		system, _, _, _ := getSubprocessMetadata(t, "KUBERNETES_POD_NAME=luna", "KUBERNETES_POD_UID=oneone!11")
 		assert.Equal(t, &model.Kubernetes{
 			Pod: &model.KubernetesPod{
 				Name: "luna",
@@ -419,7 +419,7 @@ func TestTracerKubernetesMetadata(t *testing.T) {
 	})
 
 	t.Run("node-only", func(t *testing.T) {
-		system, _, _ := getSubprocessMetadata(t, "KUBERNETES_NODE_NAME=noddy")
+		system, _, _, _ := getSubprocessMetadata(t, "KUBERNETES_NODE_NAME=noddy")
 		assert.Equal(t, &model.Kubernetes{
 			Node: &model.KubernetesNode{
 				Name: "noddy",

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -66,10 +66,10 @@ func (r *RecorderTransport) SendStream(ctx context.Context, stream io.Reader) er
 
 // Metadata returns the metadata recorded by the transport. If metadata is yet to
 // be received, this method will panic.
-func (r *RecorderTransport) Metadata() (model.System, model.Process, model.Service) {
+func (r *RecorderTransport) Metadata() (_ model.System, _ model.Process, _ model.Service, labels model.StringMap) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.metadata.System, r.metadata.Process, r.metadata.Service
+	return r.metadata.System, r.metadata.Process, r.metadata.Service, r.metadata.Labels
 }
 
 // Payloads returns the payloads recorded by SendStream.
@@ -166,7 +166,8 @@ func (p *Payloads) Len() int {
 }
 
 type metadata struct {
-	System  model.System  `json:"system"`
-	Process model.Process `json:"process"`
-	Service model.Service `json:"service"`
+	System  model.System    `json:"system"`
+	Process model.Process   `json:"process"`
+	Service model.Service   `json:"service"`
+	Labels  model.StringMap `json:"labels,omitempty"`
 }


### PR DESCRIPTION
Global labels will be added as a metadata.labels field
encoded at the head of each event stream. APM Server 7.2+
will add these to events.

Closes elastic/apm-agent-go#507 