### PR TITLE
Pin go-pg/pg to v8.0.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ deploy: off
 environment:
   PATH: C:\msys64\mingw64\bin;%PATH%
   GOPATH: C:\gopath
+  GO111MODULE: on
 
 build_script:
 - cmd: go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,17 @@ before_install:
         go get -v github.com/elastic/go-licenser;
       fi
   - |
+      if (go run scripts/mingoversion.go 1.9 &>/dev/null); then
+        # Pin go-pg/pg to v8.0.4, the last version before v9
+        # which breaks the QueryEvent/QueryHook interface.
+        mkdir -p $GOPATH/src/github.com/go-pg;
+        (
+          cd $GOPATH/src/github.com/go-pg &&
+          git clone https://github.com/go-pg/pg &&
+          cd pg && git checkout v8.0.4
+        );
+      fi;
+  - |
       if (! go run scripts/mingoversion.go 1.9 &>/dev/null); then
         # For Go 1.8.x, pin go-sql-driver to v1.4.1,
         # the last release that supports Go 1.8.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ go:
   - "1.11.x"
   - "1.12.x"
 
+env:
+  - GO111MODULE=on
+
 go_import_path: go.elastic.co/apm
 
 dist: xenial
@@ -53,6 +56,20 @@ before_install:
           cd $GOPATH/src/github.com/olivere &&
           git clone https://github.com/olivere/elastic &&
           cd elastic && git checkout release-branch.v6
+        );
+      fi;
+  - |
+      if (! go run scripts/mingoversion.go 1.11 &>/dev/null); then
+        # NOTE(axw) temporary hack to pin prometheus/procfs
+        # to the version supported by go-sysinfo. This should
+        # be undone once go-sysinfo is updated. Note that we're
+        # using modules for Go 1.11+, so this only applies for
+        # Go 1.10 and older.
+        mkdir -p $GOPATH/src/github.com/prometheus;
+        (
+          cd $GOPATH/src/github.com/prometheus &&
+          git clone https://github.com/prometheus/procfs &&
+          cd procfs && git checkout 65bdadfa96aecebf4dcf888da995a29eab4fc964
         );
       fi;
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,10 +5,11 @@
 pipeline {
   agent any
   environment {
-    BASE_DIR="src/go.elastic.co/apm"
+    BASE_DIR = "src/go.elastic.co/apm"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-go-codecov'
+    GO111MODULE = 'on'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/scripts/jenkins/docker-test.sh
+++ b/scripts/jenkins/docker-test.sh
@@ -18,6 +18,5 @@ mkdir -p build/coverage
 ./scripts/docker-compose-testing up -d --build
 ./scripts/docker-compose-testing run -T --rm go-agent-tests make coverage GOFLAGS=-v 2> >(tee ${OUT_FILE} 1>&2) > ${COV_FILE}
 
-go tool cover -html="${COV_FILE}" -o build/coverage/coverage-apm-agent-go-docker-report.html
 gocover-cobertura < "${COV_FILE}" > build/coverage/coverage-apm-agent-go-docker-report.xml
 go-junit-report > build/junit-apm-agent-go-docker.xml < ${OUT_FILE}


### PR DESCRIPTION
go-pg/pg has some breaking changes which will require
a major version bump (of pg) to v9. For now we'll pin
to v8.0.4, but since we haven't yet released the agent
with apmgopg, it's possible we'll end up setting v9 as
the minimum version.

Fixes #541