### PR TITLE
Add row_query callback to apmgorm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.2.0...master)
+## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.3.0...master)
 
  - Update opentracing-go dependency to v1.1.0
  - Update HTTP routers to return "<METHOD> unknown route" if route cannot be matched (#486)
@@ -12,6 +12,7 @@
  - internal/sqlscanner: bug fix for multi-byte rune handling (#535)
  - module/apmgrpc: added WithServerRequestIgnorer server option (#531)
  - Introduce `ELASTIC_APM_GLOBAL_LABELS` config (#539)
+ - module/apmgorm: register `row_query` callbacks (#532)
 
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 

--- a/module/apmgorm/apmgorm_test.go
+++ b/module/apmgorm/apmgorm_test.go
@@ -85,6 +85,9 @@ func testWithContext(t *testing.T, dsnInfo apmsql.DSNInfo, dialect string, args 
 		db.Create(&Product{Code: "L1212", Price: 1000})
 
 		var product Product
+		var count int
+		assert.NoError(t, db.Model(&product).Count(&count).Error)
+		assert.Equal(t, 1, count)
 		assert.NoError(t, db.First(&product, "code = ?", "L1212").Error)
 		assert.NoError(t, db.Model(&product).Update("Price", 2000).Error)
 		assert.NoError(t, db.Delete(&product).Error)            // soft
@@ -105,6 +108,7 @@ func testWithContext(t *testing.T, dsnInfo apmsql.DSNInfo, dialect string, args 
 	}
 	assert.Equal(t, []string{
 		"INSERT INTO products",
+		"SELECT FROM products", // count
 		"SELECT FROM products",
 		"UPDATE products",
 		"UPDATE products", // soft delete

--- a/module/apmgorm/context.go
+++ b/module/apmgorm/context.go
@@ -87,6 +87,10 @@ func registerCallbacks(db *gorm.DB, dsnInfo apmsql.DSNInfo) {
 			spanType:  execSpanType,
 			processor: func() *gorm.CallbackProcessor { return db.Callback().Update() },
 		},
+		"gorm:row_query": {
+			spanType:  querySpanType,
+			processor: func() *gorm.CallbackProcessor { return db.Callback().RowQuery() },
+		},
 	}
 	for name, params := range callbacks {
 		const callbackPrefix = "elasticapm"


### PR DESCRIPTION
The RowQuery callback is used when objects are queried with functions like row, rows, count, etc are executed.

Supersedes https://github.com/elastic/apm-agent-go/pull/532.