### PR TITLE
Update missing pieces to the apmhttp module docs

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -225,6 +225,7 @@ import (
 
 	"golang.org/x/net/context/ctxhttp"
 
+	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmhttp"
 )
 
@@ -234,7 +235,7 @@ func serverHandler(w http.ResponseWriter, req *http.Request) {
 	// Propagate the transaction context contained in req.Context().
 	resp, err := ctxhttp.Get(req.Context(), tracingClient, "http://backend.local/foo")
 	if err != nil {
-		apm.CaptureError(req.Context()).Send()
+		apm.CaptureError(req.Context(), err).Send()
 		http.Error(w, "failed to query backend", 500)
 		return
 	}


### PR DESCRIPTION
The `go.elastic.co/apm` import statement-, and the 2nd argument to `apm.CaptureError` was missing from the apmhttp module. I added those. Works on my machine :)