### PR TITLE
Makefile: stop excluding apmot/internal/harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 TEST_TIMEOUT?=5m
-GO_LICENSER_EXCLUDE=\
-  module/apmot/internal/harness \
-  stacktrace/testdata
+GO_LICENSER_EXCLUDE=stacktrace/testdata
 
 .PHONY: check
 check: precheck check-modules test


### PR DESCRIPTION
We stopped vendoring the OT harness a while ago, so there's no need to exclude it from licensing checks any more.