### PR TITLE
 module/{apmgopg,apmgoredis}: require Go 1.11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ environment:
   PATH: C:\msys64\mingw64\bin;%PATH%
   GOPATH: C:\gopath
   GO111MODULE: on
+  GOPROXY: https://proxy.golang.org
 
 build_script:
 - cmd: go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go:
   - "1.12.x"
 
 env:
-  - GO111MODULE=on
+  - GO111MODULE=on GOPROXY=https://proxy.golang.org
 
 go_import_path: go.elastic.co/apm
 
@@ -29,17 +29,6 @@ before_install:
         go get -v golang.org/x/tools/cmd/goimports;
         go get -v github.com/elastic/go-licenser;
       fi
-  - |
-      if (go run scripts/mingoversion.go 1.9 &>/dev/null); then
-        # Pin go-pg/pg to v8.0.4, the last version before v9
-        # which breaks the QueryEvent/QueryHook interface.
-        mkdir -p $GOPATH/src/github.com/go-pg;
-        (
-          cd $GOPATH/src/github.com/go-pg &&
-          git clone https://github.com/go-pg/pg &&
-          cd pg && git checkout v8.0.4
-        );
-      fi;
   - |
       if (! go run scripts/mingoversion.go 1.9 &>/dev/null); then
         # For Go 1.8.x, pin go-sql-driver to v1.4.1,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-go-codecov'
     GO111MODULE = 'on'
+    GOPROXY = 'https://proxy.golang.org'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/module/apmgopg/doc.go
+++ b/module/apmgopg/doc.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.9
+// +build go1.11
 
 // Package apmgopg provides wrappers for tracing go-pg operations.
 package apmgopg

--- a/module/apmgopg/hook.go
+++ b/module/apmgopg/hook.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.9
+// +build go1.11
 
 package apmgopg
 

--- a/module/apmgopg/hook_test.go
+++ b/module/apmgopg/hook_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.9
+// +build go1.11
 
 package apmgopg_test
 

--- a/module/apmgoredis/client.go
+++ b/module/apmgoredis/client.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.11
+
 package apmgoredis
 
 import (

--- a/module/apmgoredis/client_test.go
+++ b/module/apmgoredis/client_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.11
+
 package apmgoredis_test
 
 import (

--- a/module/apmgoredis/doc.go
+++ b/module/apmgoredis/doc.go
@@ -15,5 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.11
+
 // Package apmgoredis provides helpers for tracing github.com/go-redis/redis client operations as spans.
 package apmgoredis

--- a/module/apmgoredis/integration_test.go
+++ b/module/apmgoredis/integration_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.11
+
 package apmgoredis_test
 
 import (


### PR DESCRIPTION
Set the minimum Go version requirement to 1.11, so
we can require the use of modules. Trying to support
older versions of Go is going to lead to a worse
experience for the majority.

Since these modules have not yet been in a release of
the agent, this is not considered a breaking change.

Since update the minimum version, pinning go-pg for
Go 1.8-1.10 is no longer necessary. Also, use GOPROXY
to speed up builds and (hopefully) avoid intermittent
package lookup errors.