### PR TITLE
travis-ci: stop pinning prometheus/procfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,20 +47,6 @@ before_install:
           cd elastic && git checkout release-branch.v6
         );
       fi;
-  - |
-      if (! go run scripts/mingoversion.go 1.11 &>/dev/null); then
-        # NOTE(axw) temporary hack to pin prometheus/procfs
-        # to the version supported by go-sysinfo. This should
-        # be undone once go-sysinfo is updated. Note that we're
-        # using modules for Go 1.11+, so this only applies for
-        # Go 1.10 and older.
-        mkdir -p $GOPATH/src/github.com/prometheus;
-        (
-          cd $GOPATH/src/github.com/prometheus &&
-          git clone https://github.com/prometheus/procfs &&
-          cd procfs && git checkout 65bdadfa96aecebf4dcf888da995a29eab4fc964
-        );
-      fi;
 
 script:
   - make install check


### PR DESCRIPTION
prometheus/procfs reinstated the methods
go-sysinfo relies on, so we can use master
again.