### PR TITLE
remove httprouter import from New example

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -281,11 +281,7 @@ is `*apmhttprouter.Router`, and not `*httprouter.Router`.
 
 [source,go]
 ----
-import (
-	"github.com/julienschmidt/httprouter"
-
-	"go.elastic.co/apm/module/apmhttprouter"
-)
+import "go.elastic.co/apm/module/apmhttprouter"
 
 func main() {
 	router := apmhttprouter.New()


### PR DESCRIPTION
As `apmhttprouter.New()` wraps httprouter, you don't need to import it. And you also get to avoid `imported and not used: "github.com/julienschmidt/httprouter"` :)

On a side note: httprouter did implement retrieving params from context in [this PR](https://github.com/julienschmidt/httprouter/pull/147) so I don't think you need to wrap a `httprouter.Handler` [here](https://github.com/elastic/apm-agent-go/blob/master/module/apmhttprouter/router.go#L76)