### PR TITLE
module/apmelasticsearch: require go 1.10 for tests

### DIFF
--- a/module/apmelasticsearch/internal/integration/doc.go
+++ b/module/apmelasticsearch/internal/integration/doc.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.10
+
 // Package integration holds integration tests for apmelasticsearch.
 //
 // This exists as a separate module to avoid adding unnecessary

--- a/module/apmelasticsearch/internal/integration/olivere_integration_test.go
+++ b/module/apmelasticsearch/internal/integration/olivere_integration_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build go1.10
+
 package integration_test
 
 import (


### PR DESCRIPTION
Require Go 1.10+ for integration tests, as we do for the instrumentation itself.