### PR TITLE
module/apmgopg: unexpose QueryHook, add Instrument

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -346,7 +346,7 @@ used, and the context includes a transaction.
 ===== module/apmgopg
 Package apmgopg provides a means of instrumenting http://github.com/go-pg/pg[go-pg] database operations.
 
-To trace `go-pg` statements, simply add the `apmgopg.QueryHook` to the database instance you plan on using and provide
+To trace `go-pg` statements, call `apmgopg.Instrument` with the database instance you plan on using and provide
 a context that contains an apm transaction.
 
 [source,go]
@@ -358,10 +358,10 @@ import (
 )
 
 func main() {
-    db := pg.Connect(&pg.Options{})
-    db.AddQueryHook(&apmgopg.QueryHook{})
+	db := pg.Connect(&pg.Options{})
+	apmgopg.Instrument(db)
 
-    db.WithContext(ctx).Model(...)
+	db.WithContext(ctx).Model(...)
 }
 ----
 

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -136,6 +136,16 @@ See <<builtin-modules-apmgorm, module/apmgorm>> for more information
 about GORM instrumentation.
 
 [float]
+==== go-pg/pg
+
+We support the https://github.com/go-pg/pg[go-pg/pg] PostgreSQL ORM,
+https://github.com/go-pg/pg/releases/tag/v8.0.4[v8.0.4]. Spans will
+be created for each database operation.
+
+See <<builtin-modules-apmgopg, module/apmgopg>> for more information
+about go-pg instrumentation.
+
+[float]
 ==== Cassandra (gocql)
 
 https://gocql.github.io/[GoCQL] does not have a stable API, so we will

--- a/module/apmgopg/hook.go
+++ b/module/apmgopg/hook.go
@@ -20,6 +20,7 @@
 package apmgopg
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-pg/pg"
@@ -35,19 +36,31 @@ func init() {
 
 const elasticApmSpanKey = "go-apm-agent:span"
 
-// QueryHook is an implementation of pg.QueryHook that reports queries as spans to Elastic APM.
-type QueryHook struct{}
+// Instrument modifies db such that operations are hooked and reported as spans
+// to Elastic APM if they occur within the context of a captured transaction.
+//
+// If Instrument cannot instrument db, then an error will be returned.
+func Instrument(db *pg.DB) error {
+	qh := &queryHook{}
+	switch qh := ((interface{})(qh)).(type) {
+	case pg.QueryHook:
+		db.AddQueryHook(qh)
+		return nil
+	}
+	return errors.New("cannot instrument pg.DB, does not implement required interface")
+}
+
+// queryHook is an implementation of pg.QueryHook that reports queries as spans to Elastic APM.
+type queryHook struct{}
 
 // BeforeQuery initiates the span for the database query
-func (qh *QueryHook) BeforeQuery(evt *pg.QueryEvent) {
+func (qh *queryHook) BeforeQuery(evt *pg.QueryEvent) {
 	var (
 		database string
 		user     string
 	)
-
 	if db, ok := evt.DB.(*pg.DB); ok {
 		opts := db.Options()
-
 		user = opts.User
 		database = opts.Database
 	}
@@ -67,17 +80,15 @@ func (qh *QueryHook) BeforeQuery(evt *pg.QueryEvent) {
 		User:     user,
 		Instance: database,
 	})
-
 	evt.Data[elasticApmSpanKey] = span
 }
 
 // AfterQuery ends the initiated span from BeforeQuery
-func (qh *QueryHook) AfterQuery(evt *pg.QueryEvent) {
+func (qh *queryHook) AfterQuery(evt *pg.QueryEvent) {
 	span, ok := evt.Data[elasticApmSpanKey]
 	if !ok {
 		return
 	}
-
 	if s, ok := span.(*apm.Span); ok {
 		s.End()
 	}

--- a/module/apmgopg/hook_test.go
+++ b/module/apmgopg/hook_test.go
@@ -54,9 +54,10 @@ func TestWithContext(t *testing.T) {
 			Password: "hunter2",
 			Database: "test_db",
 		})
-		db.AddQueryHook(&apmgopg.QueryHook{})
+		err := apmgopg.Instrument(db)
+		require.NoError(t, err)
 
-		_, err := db.Exec("SELECT 1")
+		_, err = db.Exec("SELECT 1")
 		require.NoError(t, err)
 
 		db.DropTable(&User{}, &orm.DropTableOptions{})


### PR DESCRIPTION
Unexpose the QueryHook type, and add the Instrument
function. This hides the implementation details so
that we can potentially support go-pg v9.x.x without
introducing a new package.