### PR TITLE
Introduce ELASTIC_APM_STACK_TRACE_LIMIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - module/apmgrpc: added WithServerRequestIgnorer server option (#531)
  - Introduce `ELASTIC_APM_GLOBAL_LABELS` config (#539)
  - module/apmgorm: register `row_query` callbacks (#532)
+ - Introduce `ELASTIC_APM_STACK_TRACE_LIMIT` config (#559)
 
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -333,6 +333,22 @@ place in your code that causes the span, collecting this stack trace does have
 some processing and storage overhead.
 
 [float]
+[[config-stack-trace-limit]]
+=== `ELASTIC_APM_STACK_TRACE_LIMIT`
+
+[options="header"]
+|============
+| Environment                     | Default
+| `ELASTIC_APM_STACK_TRACE_LIMIT` | `50`
+|============
+
+Limits the number of frames captured for each stack trace.
+
+Setting the limit to 0 will disable stack trace collection, while any positive
+integer value will be used as the maximum number of frames to collect. Setting
+a negative value, such as -1, means that all frames will be collected.
+
+[float]
 [[config-transaction-sample-rate]]
 === `ELASTIC_APM_TRANSACTION_SAMPLE_RATE`
 

--- a/env.go
+++ b/env.go
@@ -50,6 +50,7 @@ const (
 	envMetricsBufferSize     = "ELASTIC_APM_METRICS_BUFFER_SIZE"
 	envDisableMetrics        = "ELASTIC_APM_DISABLE_METRICS"
 	envGlobalLabels          = "ELASTIC_APM_GLOBAL_LABELS"
+	envStackTraceLimit       = "ELASTIC_APM_STACK_TRACE_LIMIT"
 
 	defaultAPIRequestSize        = 750 * apmconfig.KByte
 	defaultAPIRequestTime        = 10 * time.Second
@@ -60,6 +61,7 @@ const (
 	defaultCaptureHeaders        = true
 	defaultCaptureBody           = CaptureBodyOff
 	defaultSpanFramesMinDuration = 5 * time.Millisecond
+	defaultStackTraceLimit       = 50
 
 	minAPIBufferSize     = 10 * apmconfig.KByte
 	maxAPIBufferSize     = 100 * apmconfig.MByte
@@ -231,4 +233,16 @@ func initialActive() (bool, error) {
 
 func initialDisabledMetrics() wildcard.Matchers {
 	return apmconfig.ParseWildcardPatternsEnv(envDisableMetrics, nil)
+}
+
+func initialStackTraceLimit() (int, error) {
+	value := os.Getenv(envStackTraceLimit)
+	if value == "" {
+		return defaultStackTraceLimit, nil
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to parse %s", envStackTraceLimit)
+	}
+	return limit, nil
 }

--- a/internal/pkgerrorsutil/pkgerrors.go
+++ b/internal/pkgerrorsutil/pkgerrors.go
@@ -35,7 +35,7 @@ var (
 )
 
 // AppendStacktrace appends stack frames to out, based on stackTrace.
-func AppendStacktrace(stackTrace errors.StackTrace, out *[]stacktrace.Frame) {
+func AppendStacktrace(stackTrace errors.StackTrace, out *[]stacktrace.Frame, limit int) {
 	// github.com/pkg/errors 0.8.x and earlier represent
 	// stack frames as uintptr; 0.9.0 and later represent
 	// them as runtime.Frames.
@@ -47,8 +47,11 @@ func AppendStacktrace(stackTrace errors.StackTrace, out *[]stacktrace.Frame) {
 		for i, frame := range stackTrace {
 			pc[i] = *(*uintptr)(unsafe.Pointer(&frame))
 		}
-		*out = stacktrace.AppendCallerFrames(*out, pc, -1)
+		*out = stacktrace.AppendCallerFrames(*out, pc, limit)
 	} else if errorsStackTraceFrame {
+		if limit >= 0 && len(stackTrace) > limit {
+			stackTrace = stackTrace[:limit]
+		}
 		for _, frame := range stackTrace {
 			rf := (*runtime.Frame)(unsafe.Pointer(&frame))
 			*out = append(*out, stacktrace.RuntimeFrame(*rf))

--- a/module/apmzerolog/stack.go
+++ b/module/apmzerolog/stack.go
@@ -43,7 +43,7 @@ func MarshalErrorStack(err error) interface{} {
 	}
 
 	var frames []stacktrace.Frame
-	pkgerrorsutil.AppendStacktrace(stackTracer.StackTrace(), &frames)
+	pkgerrorsutil.AppendStacktrace(stackTracer.StackTrace(), &frames, -1)
 	if len(frames) == 0 {
 		return nil
 	}

--- a/stacktrace/stacktrace_test.go
+++ b/stacktrace/stacktrace_test.go
@@ -111,3 +111,24 @@ func assertFunction(t *testing.T, got, expect string) {
 		t.Errorf("got function %q, expected %q", got, expect)
 	}
 }
+
+func BenchmarkAppendStacktraceUnlimited(b *testing.B) {
+	var frames []stacktrace.Frame
+	for i := 0; i < b.N; i++ {
+		frames = stacktrace.AppendStacktrace(frames[:0], 0, -1)
+	}
+}
+
+func BenchmarkAppendStacktrace10(b *testing.B) {
+	var frames []stacktrace.Frame
+	for i := 0; i < b.N; i++ {
+		frames = stacktrace.AppendStacktrace(frames[:0], 0, 10)
+	}
+}
+
+func BenchmarkAppendStacktrace50(b *testing.B) {
+	var frames []stacktrace.Frame
+	for i := 0; i < b.N; i++ {
+		frames = stacktrace.AppendStacktrace(frames[:0], 0, 50)
+	}
+}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -122,7 +122,7 @@ func TestTracerErrors(t *testing.T) {
 	assert.Equal(t, "zing", exception.Message)
 	assert.Equal(t, "errors", exception.Module)
 	assert.Equal(t, "errorString", exception.Type)
-	assert.NotEmpty(t, stacktrace)
+	require.NotEmpty(t, stacktrace)
 	assert.Equal(t, "TestTracerErrors", stacktrace[0].Function)
 }
 
@@ -237,7 +237,7 @@ func TestSpanStackTrace(t *testing.T) {
 	tracer.Flush(nil)
 
 	spans := r.Payloads().Spans
-	assert.Len(t, spans, 3)
+	require.Len(t, spans, 3)
 
 	// Span 0 took only 9ms, so we don't set its stacktrace.
 	assert.Nil(t, spans[0].Stacktrace)

--- a/transaction.go
+++ b/transaction.go
@@ -91,6 +91,10 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	tx.spanFramesMinDuration = t.spanFramesMinDuration
 	t.spanFramesMinDurationMu.RUnlock()
 
+	t.stackTraceLimitMu.RLock()
+	tx.stackTraceLimit = t.stackTraceLimit
+	t.stackTraceLimitMu.RUnlock()
+
 	t.captureHeadersMu.RLock()
 	tx.Context.captureHeaders = t.captureHeaders
 	t.captureHeadersMu.RUnlock()
@@ -278,6 +282,7 @@ type TransactionData struct {
 
 	maxSpans              int
 	spanFramesMinDuration time.Duration
+	stackTraceLimit       int
 	timestamp             time.Time
 
 	mu           sync.Mutex


### PR DESCRIPTION
We introduce a new configurable limit for the
number of stack frames to capture, defaulting
to 50.

stacktrace.AppendStacktrace has been improved
for a limit of N > 10, don't allocate space for
N callers up front; that would be wasteful if
there are mostly fewer. Instead, allocate space
for 10 and work our way up, like we do when there
is no specified limit.

Closes elastic/apm-agent-go#526 