### PR TITLE
transport: update default User-Agent

### DIFF
--- a/internal/apmversion/version.go
+++ b/internal/apmversion/version.go
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmversion
+
+const (
+	// AgentVersion is the Elastic APM Go Agent version.
+	AgentVersion = "1.3.0"
+)

--- a/transport/http.go
+++ b/transport/http.go
@@ -30,12 +30,14 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 
 	"go.elastic.co/apm/internal/apmconfig"
+	"go.elastic.co/apm/internal/apmversion"
 )
 
 const (
@@ -147,6 +149,7 @@ func NewHTTPTransport() (*HTTPTransport, error) {
 	headers.Set("Content-Type", "application/x-ndjson")
 	headers.Set("Content-Encoding", "deflate")
 	headers.Set("Transfer-Encoding", "chunked")
+	headers.Set("User-Agent", defaultUserAgent())
 	t := &HTTPTransport{
 		Client:  client,
 		headers: headers,
@@ -346,4 +349,8 @@ func verifyPeerCertificate(rawCerts [][]byte, trusted *x509.Certificate) error {
 		return errors.New("failed to verify server certificate")
 	}
 	return nil
+}
+
+func defaultUserAgent() string {
+	return fmt.Sprintf("elasticapm-go/%s go/%s", apmversion.AgentVersion, runtime.Version())
 }

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -88,7 +88,7 @@ func TestHTTPTransportUserAgent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, h.requests, 2)
 
-	assert.Regexp(t, "Go-http-client/.*", h.requests[0].UserAgent())
+	assert.Regexp(t, "elasticapm-go/.* go/.*", h.requests[0].UserAgent())
 	assert.Equal(t, "foo", h.requests[1].UserAgent())
 }
 

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/internal/apmversion"
+)
+
+func TestAgentVersion(t *testing.T) {
+	// Ensure apmversion.AgentVersion is kept in sync.
+	//
+	// NOTE We do not want a dependency from apmversion back
+	// to apm, and we want to use a string literal in the
+	// apm package for godoc.
+	assert.Equal(t, apmversion.AgentVersion, apm.AgentVersion)
+}


### PR DESCRIPTION
The default User-Agent sent by the agent is changed to:

`elasticapm-go/$agent_version go/$go_version`

Closes #527 