### PR TITLE
Truncate error.culprit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
  - Introduce `ELASTIC_APM_GLOBAL_LABELS` config (#539)
  - module/apmgorm: register `row_query` callbacks (#532)
  - Introduce `ELASTIC_APM_STACK_TRACE_LIMIT` config (#559)
+ - Include agent name/version and Go version in User-Agent (#560)
+ - Truncate `error.culprit` at 1024 chars (#561)
 
 ## [v1.3.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.3.0)
 

--- a/internal/apmschema/jsonschema/context.json
+++ b/internal/apmschema/jsonschema/context.json
@@ -22,9 +22,12 @@
                 "headers": {
                     "description": "A mapping of HTTP headers of the response object",
                     "type": ["object", "null"],
-                    "properties": {
-                        "content-type": {
-                            "type": ["string", "null"]
+                    "patternProperties": {
+                        "[.*]*$": {
+                            "type": ["string", "array", "null"],
+                            "items": {
+                                "type": ["string"]
+                            }
                         }
                     }
                 },
@@ -44,7 +47,26 @@
             "$ref": "tags.json"
         },
         "user": {
+            "description": "Describes the correlated user for this event. If user data are provided here, all user related information from metadata is ignored, otherwise the metadata's user information will be stored with the event.",
             "$ref": "user.json"
+        },
+        "page": {
+            "description": "",
+            "type": ["object", "null"],
+            "properties": {
+                "referer": {
+                    "description": "RUM specific field that stores the URL of the page that 'linked' to the current page.",
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "description": "RUM specific field that stores the URL of the current page",
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "service": {
+            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+            "$ref": "service.json"
         }
     }
 }

--- a/internal/apmschema/jsonschema/errors/error.json
+++ b/internal/apmschema/jsonschema/errors/error.json
@@ -46,7 +46,8 @@
                 },
                 "culprit": {
                     "description": "Function call which was the primary perpetrator of this event.",
-                    "type": ["string", "null"]
+                    "type": ["string", "null"],
+                    "maxLength": 1024
                 },
                 "exception": {
                     "description": "Information about the originally thrown error.",
@@ -129,11 +130,11 @@
             "allOf": [
                 { "required": ["id"] },
                 { "if": {"required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}},
-                  "then": { "required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}} },
+                    "then": { "required": ["trace_id", "parent_id"], "properties": {"trace_id": { "type": "string" }, "parent_id": {"type": "string"}}}},
                 { "if": {"required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}},
-                  "then": { "required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}} },
+                    "then": { "required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}} },
                 { "if": {"required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}},
-                  "then": { "required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}} }
+                    "then": { "required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}} }
             ],
             "anyOf": [
                 { "required": ["exception"], "properties": {"exception": { "type": "object" }} },

--- a/internal/apmschema/jsonschema/metadata.json
+++ b/internal/apmschema/jsonschema/metadata.json
@@ -5,7 +5,19 @@
     "type": ["object"],
     "properties": {
         "service": {
-            "$ref": "service.json"
+            "$ref": "service.json",
+            "type": "object",
+            "required": ["name", "agent"],
+            "properties.name.type": "string",
+            "properties.agent.type": "string",
+            "properties.agent.required": ["name", "version"],
+            "properties.agent.properties.name.type": "string",
+            "properties.agent.properties.version.type": "string",
+            "properties.runtime.required": ["name", "version"],
+            "properties.runtime.properties.name.type": "string",
+            "properties.runtime.properties.version.type": "string",
+            "properties.language.required": ["name"],
+            "properties.language.properties.name.type": "string"
         },
         "process": {
             "$ref": "process.json"
@@ -14,7 +26,11 @@
             "$ref": "system.json"
         },
         "user": {
+            "description": "Describes the authenticated User for a request.",
             "$ref": "user.json"
+        },
+        "labels": {
+            "$ref": "tags.json"
         }
     },
     "required": ["service"]

--- a/internal/apmschema/jsonschema/request.json
+++ b/internal/apmschema/jsonschema/request.json
@@ -16,16 +16,12 @@
         "headers": {
             "description": "Should include any headers sent by the requester. Cookies will be taken by headers if supplied.",
             "type": ["object", "null"],
-            "properties": {
-                "content-type": {
-                    "type": ["string", "null"]
-                },
-                "cookie": {
-                    "description": "Cookies sent with the request. It is expected to have values delimited by semicolons.",
-                    "type": ["string", "null"]
-                },
-                "user-agent": {
-                    "type": ["string", "null"]
+            "patternProperties": {
+                "[.*]*$": {
+                    "type": ["string", "array", "null"],
+                    "items": {
+                        "type": ["string"]
+                    }
                 }
             }
         },
@@ -76,7 +72,7 @@
                     "maxLength": 1024
                 },
                 "port": {
-                    "type": ["string", "null"],
+                    "type": ["string", "integer","null"],
                     "description": "The port of the request, e.g. '443'",
                     "maxLength": 1024
                 },

--- a/internal/apmschema/jsonschema/service.json
+++ b/internal/apmschema/jsonschema/service.json
@@ -1,24 +1,28 @@
 {
     "$id": "doc/spec/service.json",
     "title": "Service",
-    "type": "object",
+    "type": ["object", "null"],
     "properties": {
         "agent": {
             "description": "Name and version of the Elastic APM agent",
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
                 "name": {
                     "description": "Name of the Elastic APM agent, e.g. \"Python\"",
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 1024
                 },
                 "version": {
                     "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
-                    "type": "string",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "ephemeral_id": {
+                    "description": "Free format ID used for metrics correlation by some agents",
+                    "type": ["string", "null"],
                     "maxLength": 1024
                 }
-            },
-            "required": ["name", "version"]
+            }
         },
         "framework": {
             "description": "Name and version of the web framework used",
@@ -39,19 +43,18 @@
             "type": ["object", "null"],
             "properties": {
                 "name": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 1024
                 },
                 "version": {
                     "type": ["string", "null"],
                     "maxLength": 1024
                 }
-            },
-            "required": ["name"]
+            }
         },
         "name": {
             "description": "Immutable name of the service emitting this event",
-            "type": "string",
+            "type": ["string", "null"],
             "pattern": "^[a-zA-Z0-9 _-]+$",
             "maxLength": 1024
         },
@@ -65,21 +68,19 @@
             "type": ["object", "null"],
             "properties": {
                 "name": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 1024
                 },
                 "version": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 1024
                 }
-            },
-            "required": ["name", "version"]
+            }
         },
         "version": {
             "description": "Version of the service emitting this event",
             "type": ["string", "null"],
             "maxLength": 1024
         }
-    },
-    "required": ["agent", "name"]
+    }
 }

--- a/internal/apmschema/jsonschema/spans/span.json
+++ b/internal/apmschema/jsonschema/spans/span.json
@@ -12,7 +12,7 @@
                     "maxLength": 1024
                 },
                 "transaction_id": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "description": "Hex encoded 64 random bits ID of the correlated transaction.", 
                     "maxLength": 1024
                 },
@@ -87,6 +87,50 @@
                         },
                         "tags": {
                             "$ref": "../tags.json"
+                        },
+                        "service": {
+                            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+                            "properties": {
+                                "agent": {
+                                    "description": "Name and version of the Elastic APM agent",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "version": {
+                                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "ephemeral_id": {
+                                            "description": "Free format ID used for metrics correlation by some agents",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "description": "Immutable name of the service emitting this event",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                                    "maxLength": 1024
+                                }
+                            }
                         }
                     }
                 },
@@ -117,7 +161,7 @@
                     "description": "Indicates whether the span was executed synchronously or asynchronously."
                 }
             },
-            "required": ["duration", "name", "type", "id", "transaction_id", "trace_id", "parent_id"]
+            "required": ["duration", "name", "type", "id","trace_id", "parent_id"]
         },
         { "anyOf":[
                 {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}},

--- a/internal/apmschema/jsonschema/stacktrace_frame.json
+++ b/internal/apmschema/jsonschema/stacktrace_frame.json
@@ -30,7 +30,7 @@
         },
         "lineno": {
             "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
-            "type": "integer"
+            "type": ["integer", "null"]
         },
         "module": {
             "description": "The module to which frame belongs to",
@@ -58,5 +58,5 @@
             "properties": {}
         }
     },
-    "required": ["filename", "lineno"]
+    "required": ["filename"]
 }

--- a/internal/apmschema/jsonschema/system.json
+++ b/internal/apmschema/jsonschema/system.json
@@ -17,6 +17,48 @@
             "description": "Name of the system platform the agent is running on.",
             "type": ["string", "null"],
             "maxLength": 1024
+        },
+        "container": {
+            "properties": {
+                "id" : {
+                    "description": "Container ID",
+                    "type": ["string"],
+                    "maxLength": 1024
+                }
+            },
+            "required": ["id"]
+        },
+        "kubernetes": {
+            "properties": {
+                "namespace": {
+                    "description": "Kubernetes namespace",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "pod":{
+                    "properties": {
+                        "name": {
+                            "description": "Kubernetes pod name",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "uid": {
+                            "description": "Kubernetes pod uid",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "node":{
+                    "properties": {
+                        "name": {
+                            "description": "Kubernetes node name",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/internal/apmschema/jsonschema/user.json
+++ b/internal/apmschema/jsonschema/user.json
@@ -1,7 +1,6 @@
 {
     "$id": "docs/spec/user.json",
     "title": "User",
-    "description": "Describes the authenticated User for a request.",
     "type": ["object", "null"],
     "properties": {
         "id": {

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -195,6 +195,7 @@ func (w *modelWriter) buildModelError(out *model.Error, e *ErrorData) {
 			out.Culprit = stacktraceCulprit(out.Log.Stacktrace)
 		}
 	}
+	out.Culprit = truncateString(out.Culprit)
 }
 
 func stacktraceCulprit(frames []model.StacktraceFrame) string {

--- a/validation_test.go
+++ b/validation_test.go
@@ -215,6 +215,13 @@ func TestValidateErrorException(t *testing.T) {
 			}).Send()
 		})
 	})
+	t.Run("culprit", func(t *testing.T) {
+		validatePayloads(t, func(tracer *apm.Tracer) {
+			e := tracer.NewError(&testError{message: "foo"})
+			e.Culprit = strings.Repeat("x", 1025)
+			e.Send()
+		})
+	})
 	t.Run("code", func(t *testing.T) {
 		validatePayloads(t, func(tracer *apm.Tracer) {
 			tracer.NewError(&testError{


### PR DESCRIPTION
Ensure `error.culprit` is truncated at 1024 chars.

Fixes elastic/apm-agent-go#508