### PR TITLE
module/apmprometheus: remove refs to DefObjectives

### DIFF
--- a/module/apmprometheus/gatherer_test.go
+++ b/module/apmprometheus/gatherer_test.go
@@ -48,7 +48,7 @@ func TestSummary(t *testing.T) {
 	s := prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:       "summary",
 		Help:       "halp",
-		Objectives: prometheus.DefObjectives,
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 	r.MustRegister(s)
 


### PR DESCRIPTION
In https://github.com/prometheus/client_golang/commit/761a2ff07c763475bff727730e823a8f4d501f36 the DefObjectives var was removed, along with other deprecated bits of the API, in preparation for their v1.0.0 release. We were referencing one deprecated bit in a test: DefObjectives. Replace it with explicit quantile objectives.