### PR TITLE
Breakdown metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased](https://github.com/elastic/apm-agent-go/compare/v1.4.0...master)
 
  - Add Context.SetCustom (#581)
+ - Add support for extracting UUID-like container IDs (#577)
+ - Introduce transaction/span breakdown metrics (#564)
 
 ## [v1.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.4.0)
 

--- a/apmtest/recordlogger.go
+++ b/apmtest/recordlogger.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmtest
+
+import "fmt"
+
+// RecordLogger is an implementation of apm.Logger, recording log entries.
+type RecordLogger struct {
+	Records []LogRecord
+}
+
+// Debugf logs debug messages.
+func (l *RecordLogger) Debugf(format string, args ...interface{}) {
+	l.logf("debug", format, args...)
+}
+
+// Errorf logs error messages.
+func (l *RecordLogger) Errorf(format string, args ...interface{}) {
+	l.logf("error", format, args...)
+}
+
+// Warningf logs error messages.
+func (l *RecordLogger) Warningf(format string, args ...interface{}) {
+	l.logf("warning", format, args...)
+}
+
+func (l *RecordLogger) logf(level string, format string, args ...interface{}) {
+	l.Records = append(l.Records, LogRecord{
+		Level:   level,
+		Format:  format,
+		Message: fmt.Sprintf(format, args...),
+	})
+}
+
+// LogRecord holds the details of a log record.
+type LogRecord struct {
+	// Level is the log level: "debug", "error", or "warning".
+	Level string
+
+	// Format is the log message format, like "Thingy did foo %d times".
+	Format string
+
+	// Message is the formatted message.
+	Message string
+}

--- a/breakdown.go
+++ b/breakdown.go
@@ -1,0 +1,369 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.elastic.co/apm/internal/wildcard"
+	"go.elastic.co/apm/model"
+)
+
+const (
+	// breakdownMetricsLimit is the maximum number of breakdown metric
+	// buckets to accumulate per reporting period. Metrics are broken
+	// down by {transactionType, transactionName, spanType, spanSubtype}
+	// tuples.
+	breakdownMetricsLimit = 1000
+
+	// appSpanType is the special span type associated with transactions,
+	// for reporting transaction self-time.
+	appSpanType = "app"
+
+	// Breakdown metric names.
+	transactionDurationCountMetricName  = "transaction.duration.count"
+	transactionDurationSumMetricName    = "transaction.duration.sum.us"
+	transactionBreakdownCountMetricName = "transaction.breakdown.count"
+	spanSelfTimeCountMetricName         = "span.self_time.count"
+	spanSelfTimeSumMetricName           = "span.self_time.sum.us"
+
+	transactionBreakdownMetricFlag breakdownMetricsFlags = 1 << iota
+)
+
+var (
+	breakdownMetricsLimitWarning = fmt.Sprintf(`
+The limit of %d breakdown metricsets has been reached, no new metricsets will be created.
+Try to name your transactions so that there are less distinct transaction names.`[1:],
+		breakdownMetricsLimit,
+	)
+)
+
+// spanTimingsKey identifies a span type and subtype, for use as the key in
+// spanTimingsMap.
+type spanTimingsKey struct {
+	spanType    string
+	spanSubtype string
+}
+
+// spanTiming records the number of times a {spanType, spanSubtype} pair
+// has occurred (within the context of a transaction group), along with
+// the sum of the span durations.
+type spanTiming struct {
+	duration int64
+	count    uintptr
+}
+
+// spanTimingsMap records span timings for a transaction group.
+type spanTimingsMap map[spanTimingsKey]spanTiming
+
+// add accumulates the timing for a {spanType, spanSubtype} pair.
+func (m spanTimingsMap) add(spanType, spanSubtype string, d time.Duration) {
+	k := spanTimingsKey{spanType: spanType, spanSubtype: spanSubtype}
+	timing := m[k]
+	timing.count++
+	timing.duration += int64(d)
+	m[k] = timing
+}
+
+// reset resets m back to its initial zero state.
+func (m spanTimingsMap) reset() {
+	for k := range m {
+		delete(m, k)
+	}
+}
+
+// breakdownMetrics holds a pair of breakdown metrics maps. The "active" map
+// accumulates new breakdown metrics, and is swapped with the "inactive" map
+// just prior to when metrics gathering begins. When metrics gathering
+// completes, the inactive map will be empty.
+//
+// breakdownMetrics may be written to concurrently by the tracer, and any
+// number of other goroutines when a transaction cannot be enqueued.
+type breakdownMetrics struct {
+	flags breakdownMetricsFlags
+
+	mu               sync.RWMutex
+	active, inactive *breakdownMetricsMap
+}
+
+func newBreakdownMetrics() *breakdownMetrics {
+	return &breakdownMetrics{
+		active:   newBreakdownMetricsMap(),
+		inactive: newBreakdownMetricsMap(),
+	}
+}
+
+type breakdownMetricsMap struct {
+	mu      sync.RWMutex
+	entries int
+	m       map[uint64][]*breakdownMetricsMapEntry
+	space   []breakdownMetricsMapEntry
+}
+
+func newBreakdownMetricsMap() *breakdownMetricsMap {
+	return &breakdownMetricsMap{
+		m:     make(map[uint64][]*breakdownMetricsMapEntry),
+		space: make([]breakdownMetricsMapEntry, breakdownMetricsLimit),
+	}
+}
+
+type breakdownMetricsMapEntry struct {
+	breakdownMetricsKey
+	breakdownTiming
+}
+
+// breakdownMetricsKey identifies a transaction group, and optionally a
+// spanTimingsKey, for recording transaction and span breakdown metrics.
+type breakdownMetricsKey struct {
+	transactionType string
+	transactionName string
+	spanTimingsKey
+}
+
+func (k breakdownMetricsKey) hash() uint64 {
+	h := newFnv1a()
+	h.add(k.transactionType)
+	h.add(k.transactionName)
+	if k.spanType != "" {
+		h.add(k.spanType)
+	}
+	if k.spanSubtype != "" {
+		h.add(k.spanSubtype)
+	}
+	return uint64(h)
+}
+
+// breakdownTiming holds breakdown metrics.
+type breakdownTiming struct {
+	// transaction holds the "transaction.duration" metric values.
+	transaction spanTiming
+
+	// breakdownCount records the number of transactions for which we
+	// have calculated breakdown metrics. If breakdown metrics are
+	// enabled, this will be equal transaction.count.
+	breakdownCount uintptr
+
+	// span holds the "span.self_time" metric values.
+	span spanTiming
+}
+
+func (lhs *breakdownTiming) accumulate(rhs breakdownTiming) {
+	atomic.AddUintptr(&lhs.transaction.count, rhs.transaction.count)
+	atomic.AddInt64(&lhs.transaction.duration, rhs.transaction.duration)
+	atomic.AddUintptr(&lhs.span.count, rhs.span.count)
+	atomic.AddInt64(&lhs.span.duration, rhs.span.duration)
+	atomic.AddUintptr(&lhs.breakdownCount, rhs.breakdownCount)
+}
+
+// recordTransaction records breakdown metrics for td into m.
+//
+// recordTransaction returns true if breakdown metrics were
+// completely recorded, and false if any metrics were not
+// recorded due to the limit being reached.
+func (m *breakdownMetrics) recordTransaction(td *TransactionData) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	k := breakdownMetricsKey{
+		transactionType: td.Type,
+		transactionName: td.Name,
+	}
+	k.spanType = appSpanType
+
+	var breakdownCount int
+	var transactionSpanTiming spanTiming
+	var transactionDuration = spanTiming{count: 1, duration: int64(td.Duration)}
+	if td.breakdownMetricsEnabled {
+		breakdownCount = 1
+		endTime := td.timestamp.Add(td.Duration)
+		transactionSelfTime := td.Duration - td.childrenTimer.finalDuration(endTime)
+		transactionSpanTiming = spanTiming{count: 1, duration: int64(transactionSelfTime)}
+	}
+
+	if !m.active.record(k, breakdownTiming{
+		transaction:    transactionDuration,
+		breakdownCount: uintptr(breakdownCount),
+		span:           transactionSpanTiming,
+	}) {
+		// We couldn't record the transaction's metricset, so we won't
+		// be able to record spans for that transaction either.
+		return false
+	}
+
+	ok := true
+	for sk, timing := range td.spanTimings {
+		k.spanTimingsKey = sk
+		ok = ok && m.active.record(k, breakdownTiming{span: timing})
+	}
+	return ok
+}
+
+// record records a single breakdown metric, identified by k.
+func (m *breakdownMetricsMap) record(k breakdownMetricsKey, bt breakdownTiming) bool {
+	hash := k.hash()
+	m.mu.RLock()
+	entries, ok := m.m[hash]
+	m.mu.RUnlock()
+	var offset int
+	if ok {
+		for offset = range entries {
+			if entries[offset].breakdownMetricsKey == k {
+				// The append may reallocate the entries, but the
+				// entries are pointers into m.activeSpace. Therefore,
+				// entries' timings can safely be atomically incremented
+				// without holding the read lock.
+				entries[offset].breakdownTiming.accumulate(bt)
+				return true
+			}
+		}
+		offset++ // where to start searching with the write lock below
+	}
+
+	m.mu.Lock()
+	entries, ok = m.m[hash]
+	if ok {
+		for i := range entries[offset:] {
+			if entries[offset+i].breakdownMetricsKey == k {
+				m.mu.Unlock()
+				entries[offset+i].breakdownTiming.accumulate(bt)
+				return true
+			}
+		}
+	} else if m.entries >= breakdownMetricsLimit {
+		m.mu.Unlock()
+		return false
+	}
+	entry := &m.space[m.entries]
+	*entry = breakdownMetricsMapEntry{k, bt}
+	m.m[hash] = append(entries, entry)
+	m.entries++
+	m.mu.Unlock()
+	return true
+}
+
+// gather is called by builtinMetricsGatherer to gather breakdown metrics.
+func (m *breakdownMetrics) gather(out *Metrics) {
+	// Hold m.mu only long enough to swap m.active and m.inactive.
+	// This will be blocked by metric updates, but that's OK; only
+	// metrics gathering will be delayed. After swapping we do not
+	// need to hold m.mu, since nothing concurrently accesses
+	// m.inactive while the gatherer is iterating over it.
+	m.mu.Lock()
+	m.active, m.inactive = m.inactive, m.active
+	m.mu.Unlock()
+
+	for hash, entries := range m.inactive.m {
+		for _, entry := range entries {
+			if entry.transaction.count > 0 {
+				out.transactionGroupMetrics = append(out.transactionGroupMetrics, &model.Metrics{
+					Transaction: model.MetricsTransaction{
+						Type: entry.transactionType,
+						Name: entry.transactionName,
+					},
+					Samples: map[string]model.Metric{
+						transactionDurationCountMetricName: {
+							Value: float64(entry.transaction.count),
+						},
+						transactionDurationSumMetricName: {
+							Value: durationMicros(time.Duration(entry.transaction.duration)),
+						},
+						transactionBreakdownCountMetricName: {
+							Value: float64(entry.breakdownCount),
+						},
+					},
+				})
+			}
+			if entry.span.count > 0 {
+				out.transactionGroupMetrics = append(out.transactionGroupMetrics, &model.Metrics{
+					Transaction: model.MetricsTransaction{
+						Type: entry.transactionType,
+						Name: entry.transactionName,
+					},
+					Span: model.MetricsSpan{
+						Type:    entry.spanType,
+						Subtype: entry.spanSubtype,
+					},
+					Samples: map[string]model.Metric{
+						spanSelfTimeCountMetricName: {
+							Value: float64(entry.span.count),
+						},
+						spanSelfTimeSumMetricName: {
+							Value: durationMicros(time.Duration(entry.span.duration)),
+						},
+					},
+				})
+			}
+			entry.breakdownMetricsKey = breakdownMetricsKey{} // release strings
+		}
+		delete(m.inactive.m, hash)
+	}
+	m.inactive.entries = 0
+}
+
+// childrenTimer tracks time spent by children of a transaction or span.
+//
+// childrenTimer is not goroutine-safe.
+type childrenTimer struct {
+	// active holds the number active children.
+	active int
+
+	// start holds the timestamp at which active went from zero to one.
+	start time.Time
+
+	// totalDuration holds the total duration of time periods in which
+	// at least one child was active.
+	totalDuration time.Duration
+}
+
+func (t *childrenTimer) childStarted(start time.Time) {
+	t.active++
+	if t.active == 1 {
+		t.start = start
+	}
+}
+
+func (t *childrenTimer) childEnded(end time.Time) {
+	t.active--
+	if t.active == 0 {
+		t.totalDuration += end.Sub(t.start)
+	}
+}
+
+func (t *childrenTimer) finalDuration(end time.Time) time.Duration {
+	if t.active > 0 {
+		t.active = 0
+		t.totalDuration += end.Sub(t.start)
+	}
+	return t.totalDuration
+}
+
+type breakdownMetricsFlags int
+
+func (f *breakdownMetricsFlags) set(disabledMetrics wildcard.Matchers) {
+	*f = 0
+	if !disabledMetrics.MatchAny("span.self_time") {
+		*f |= transactionBreakdownMetricFlag
+	}
+}
+
+func (f breakdownMetricsFlags) transactionBreakdown() bool {
+	return f&transactionBreakdownMetricFlag != 0
+}

--- a/breakdown_test.go
+++ b/breakdown_test.go
@@ -1,0 +1,535 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/model"
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func TestBreakdownMetrics_NonSampled(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	// Non-sampled transactions and their dropped spans still attribute to breakdown metrics.
+	tracer.SetSampler(apm.NewRatioSampler(0))
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span.Duration = 10 * time.Millisecond // t0 + 20ms
+	span.End()
+	tx.Duration = 30 * time.Millisecond
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 20*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 1, 10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+func TestBreakdownMetrics_SpanDropped(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	// Dropped spans still attribute to breakdown metrics.
+	tracer.SetMaxSpans(1)
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	var spans []*apm.Span
+	for i := 0; i < 2; i++ {
+		span := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+		spans = append(spans, span)
+	}
+	for _, span := range spans {
+		span.Duration = 10 * time.Millisecond // t0 + 20ms
+		span.End()
+	}
+	tx.Duration = 30 * time.Millisecond
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 20*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 2, 20*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+func TestBreakdownMetrics_MetricsLimit(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	var logger apmtest.RecordLogger
+	tracer.SetLogger(&logger)
+
+	for i := 0; i < 3000; i++ {
+		tx := tracer.StartTransaction(fmt.Sprintf("%d", i), "request")
+		tx.End()
+	}
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	// Make sure there's just one warning logged.
+	var warnings []apmtest.LogRecord
+	for _, record := range logger.Records {
+		if record.Level == "warning" {
+			warnings = append(warnings, record)
+		}
+	}
+	require.Len(t, warnings, 1)
+	assert.Regexp(t, "The limit of 1000 breakdown (.|\n)*", warnings[0].Message)
+
+	// There should be 1000 breakdown metrics keys buckets retained
+	// in-memory. Transaction count and duration metrics piggy-back
+	// on the self_time for the "app" bucket, so some of those buckets
+	// may generate multiple metricsets on the wire.
+	metrics := payloadsBreakdownMetrics(transport)
+	assert.Len(t, metrics, 2000)
+}
+
+func TestBreakdownMetrics_TransactionDropped(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	// Send transactions until one gets dropped, so we can check that
+	// the dropped transactions are included in the breakdown.
+	var count int
+	for tracer.Stats().TransactionsDropped == 0 {
+		for i := 0; i < 1000; i++ {
+			tx := tracer.StartTransaction("test", "request")
+			tx.Duration = 10 * time.Millisecond
+			tx.End()
+			count++
+		}
+	}
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", count, time.Duration(count)*10*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", count, time.Duration(count)*10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+func TestBreakdownMetrics_SelfTimeDisabled(t *testing.T) {
+	os.Setenv("ELASTIC_APM_DISABLE_METRICS", "span.self_time")
+	defer os.Unsetenv("ELASTIC_APM_DISABLE_METRICS")
+
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span.Duration = 10 * time.Millisecond // t0 + 20ms
+	span.End()
+	tx.Duration = 30 * time.Millisecond
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	expect := transactionDurationMetrics("test", "request", 1, 30*time.Millisecond)
+	expect.Samples["transaction.breakdown.count"] = model.Metric{}
+	assertBreakdownMetrics(t, []model.Metrics{expect}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████████████████████████    30   30 transaction
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest1(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	tx := tracer.StartTransaction("test", "request")
+	tx.Duration = 30 * time.Millisecond
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 30*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░░░░░░██████████    30   20 transaction
+//  └─────────██████████              10   10 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest2(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span.Duration = 10 * time.Millisecond // t0 + 20ms
+	span.End()
+	tx.Duration = 30 * time.Millisecond // t0 + 30ms
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 20*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 1, 10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░░░░░░██████████    30   20 transaction
+//  └─────────██████████              10   10 app
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest3(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span := tx.StartSpanOptions("whatever", "app", apm.SpanOptions{
+		Start: t0.Add(10 * time.Millisecond),
+	})
+	span.Duration = 10 * time.Millisecond // t0 + 20ms
+	span.End()
+	tx.Duration = 30 * time.Millisecond // t0 + 30ms
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 2, 30*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░░░░░░██████████    30   20 transaction
+//  └─────────██████████              10   10 db.mysql
+//  └─────────██████████              10   10 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest4(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span1 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span2 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span1.Duration = 10 * time.Millisecond // t0 + 20ms
+	span2.Duration = 10 * time.Millisecond // t0 + 20ms
+	span1.End()
+	span2.End()
+	tx.Duration = 30 * time.Millisecond // t0 + 30ms
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 20*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 2, 20*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░░░░░░░░░░░█████    30   15 transaction
+//  └─────────██████████              10   10 db.mysql
+//  └──────────────██████████         10   10 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest5(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span1 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span2 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(15 * time.Millisecond)})
+	span1.Duration = 10 * time.Millisecond // t0 + 20ms
+	span2.Duration = 10 * time.Millisecond // t0 + 25ms
+	span1.End()
+	span2.End()
+	tx.Duration = 30 * time.Millisecond // t0 + 30ms
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 15*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 2, 20*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  █████░░░░░░░░░░░░░░░░░░░░█████    30   15 transaction
+//  └────██████████                   10   10 db.mysql
+//  └──────────────██████████         10   10 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest6(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span1 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(5 * time.Millisecond)})
+	span1.Duration = 10 * time.Millisecond // t0 + 15ms
+	span1.End()
+	span2 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(15 * time.Millisecond)})
+	span2.Duration = 10 * time.Millisecond // t0 + 25ms
+	span2.End()
+	tx.Duration = 30 * time.Millisecond // t0 + 30ms
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 10*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 2, 20*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░█████░░░░░█████    30   15 transaction
+//  └─────────█████                    5    5 db.mysql
+//  └───────────────────█████          5    5 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest7(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span1 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span1.Duration = 5 * time.Millisecond // t0 + 15ms
+	span1.End()
+	span2 := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(20 * time.Millisecond)})
+	span2.Duration = 5 * time.Millisecond // t0 + 25ms
+	span2.End()
+	tx.Duration = 30 * time.Millisecond // t0 + 30ms
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 20*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 2, 10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░░░░░░██████████    30   20 transaction
+//  └─────────█████░░░░░              10    5 app
+//            └────██████████         10   10 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest8(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	ctx := apm.ContextWithTransaction(context.Background(), tx)
+
+	span1, ctx := apm.StartSpanOptions(ctx, "whatever", "app", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	span2, ctx := apm.StartSpanOptions(ctx, "whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(15 * time.Millisecond)})
+	span1.Duration = 10 * time.Millisecond // t0 + 20ms
+	span2.Duration = 10 * time.Millisecond // t0 + 25ms
+	span1.End()
+	span2.End()
+	tx.Duration = 30 * time.Millisecond // t0 + 30ms
+	tx.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		transactionDurationMetrics("test", "request", 1, 30*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 2, 25*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "db", "mysql", 1, 10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░░░░░░              20   20 transaction
+//  └─────────██████████░░░░░░░░░░    20   10 app
+//            └─────────██████████    10   10 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest9(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	ctx := apm.ContextWithTransaction(context.Background(), tx)
+
+	span1, ctx := apm.StartSpanOptions(ctx, "whatever", "app", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	tx.Duration = 20 * time.Millisecond // t0 + 20ms
+	tx.End()
+	span2, ctx := apm.StartSpanOptions(ctx, "whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(20 * time.Millisecond)})
+	span1.Duration = 20 * time.Millisecond // t0 + 30ms
+	span2.Duration = 10 * time.Millisecond // t0 + 30ms
+	span1.End()
+	span2.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		// The db.mysql span should not be included in breakdown,
+		// as it started after the transaction ended. The explicit
+		// "app" span should not be included in the self_time value,
+		// it should only have been used for subtracting from the
+		// transaction's duration.
+		transactionDurationMetrics("test", "request", 1, 20*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████░░░░░░░░░░              20   10 transaction
+//  └─────────████████████████████    20   20 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest10(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	span := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(10 * time.Millisecond)})
+	tx.Duration = 20 * time.Millisecond // t0 + 20ms
+	tx.End()
+	span.Duration = 20 * time.Millisecond // t0 + 30ms
+	span.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		// The db.mysql span should not be included in breakdown,
+		// as it ended after the transaction ended.
+		transactionDurationMetrics("test", "request", 1, 20*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+//                                 total self type
+//  ██████████                        10   10 transaction
+//  └───────────────────██████████    10   10 db.mysql
+//           10        20        30
+func TestBreakdownMetrics_AcceptanceTest11(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	t0 := time.Now()
+	tx := tracer.StartTransactionOptions("test", "request", apm.TransactionOptions{Start: t0})
+	tx.Duration = 10 * time.Millisecond // t0 + 10ms
+	tx.End()
+	span := tx.StartSpanOptions("whatever", "db.mysql", apm.SpanOptions{Start: t0.Add(20 * time.Millisecond)})
+	span.Duration = 10 * time.Millisecond // t0 + 30ms
+	span.End()
+
+	tracer.Flush(nil)
+	tracer.SendMetrics(nil)
+
+	assertBreakdownMetrics(t, []model.Metrics{
+		// The db.mysql span should not be included in breakdown,
+		// as it started and ended after the transaction ended.
+		transactionDurationMetrics("test", "request", 1, 10*time.Millisecond),
+		spanSelfTimeMetrics("test", "request", "app", "", 1, 10*time.Millisecond),
+	}, payloadsBreakdownMetrics(transport))
+}
+
+func transactionDurationMetrics(txName, txType string, count int, sum time.Duration) model.Metrics {
+	return model.Metrics{
+		Transaction: model.MetricsTransaction{
+			Type: txType,
+			Name: txName,
+		},
+		Samples: map[string]model.Metric{
+			"transaction.breakdown.count": {Value: float64(count)},
+			"transaction.duration.count":  {Value: float64(count)},
+			"transaction.duration.sum.us": {Value: sum.Seconds() * 1000000},
+		},
+	}
+}
+
+func spanSelfTimeMetrics(txName, txType, spanType, spanSubtype string, count int, sum time.Duration) model.Metrics {
+	return model.Metrics{
+		Transaction: model.MetricsTransaction{
+			Type: txType,
+			Name: txName,
+		},
+		Span: model.MetricsSpan{
+			Type:    spanType,
+			Subtype: spanSubtype,
+		},
+		Samples: map[string]model.Metric{
+			"span.self_time.count":  {Value: float64(count)},
+			"span.self_time.sum.us": {Value: sum.Seconds() * 1000000},
+		},
+	}
+}
+
+func assertBreakdownMetrics(t *testing.T, expect []model.Metrics, metrics []model.Metrics) {
+	for i := range metrics {
+		metrics[i].Timestamp = model.Time{}
+	}
+	assert.ElementsMatch(t, expect, metrics)
+}
+
+func payloadsBreakdownMetrics(t *transporttest.RecorderTransport) []model.Metrics {
+	p := t.Payloads()
+	ms := make([]model.Metrics, 0, len(p.Metrics))
+	for _, m := range p.Metrics {
+		if m.Transaction.Type == "" {
+			continue
+		}
+		ms = append(ms, m)
+	}
+	return ms
+}

--- a/builtin_metrics.go
+++ b/builtin_metrics.go
@@ -47,6 +47,7 @@ func (g *builtinMetricsGatherer) GatherMetrics(ctx context.Context, m *Metrics) 
 	m.Add("golang.goroutines", nil, float64(runtime.NumGoroutine()))
 	g.gatherSystemMetrics(m)
 	g.gatherMemStatsMetrics(m)
+	g.tracer.breakdownMetrics.gather(m)
 	return nil
 }
 

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -242,3 +242,65 @@ type: float
 
 Fraction of CPU time used by garbage collection.
 --
+
+[float]
+[[metrics-application]]
+=== Application Metrics
+
+*`transaction.duration`*::
++
+--
+type: simple timer
+
+This timer tracks the duration of transactions and allows for the creation of graphs displaying a weighted average.
+
+Fields:
+
+* `sum.us`: The sum of all transaction durations in microseconds since the last report (the delta)
+* `count`: The count of all transactions since the last report (the delta)
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+
+--
+
+*`transaction.breakdown.count`*::
++
+--
+type: long
+
+format: count (delta)
+
+The number of transactions for which breakdown metrics (`span.self_time`) have been created.
+As the Go agent tracks the breakdown for both sampled and non-sampled transactions, this
+metric is equivalent to `transaction.duration.count`
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+
+--
+
+*`span.self_time`*::
++
+--
+type: simple timer
+
+This timer tracks the span self-times and is the basis of the transaction breakdown visualization.
+
+Fields:
+
+* `sum.us`: The sum of all span self-times in microseconds since the last report (the delta)
+* `count`: The count of all span self-times since the last report (the delta)
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+* `span.type`: The type of the span, for example `app`, `template` or `db`
+* `span.subtype`: The sub-type of the span, for example `mysql` (optional)
+
+--

--- a/env.go
+++ b/env.go
@@ -55,7 +55,7 @@ const (
 	defaultAPIRequestSize        = 750 * apmconfig.KByte
 	defaultAPIRequestTime        = 10 * time.Second
 	defaultAPIBufferSize         = 1 * apmconfig.MByte
-	defaultMetricsBufferSize     = 100 * apmconfig.KByte
+	defaultMetricsBufferSize     = 750 * apmconfig.KByte
 	defaultMetricsInterval       = 30 * time.Second
 	defaultMaxSpans              = 500
 	defaultCaptureHeaders        = true

--- a/fnv.go
+++ b/fnv.go
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Based on Go's pkg/hash/fnv.
+//
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package apm
+
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+)
+
+type fnv1a uint64
+
+func newFnv1a() fnv1a {
+	return offset64
+}
+
+func (f *fnv1a) add(s string) {
+	for i := 0; i < len(s); i++ {
+		*f ^= fnv1a(s[i])
+		*f *= prime64
+	}
+}

--- a/fnv_test.go
+++ b/fnv_test.go
@@ -1,0 +1,43 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm
+
+import (
+	"hash/fnv"
+	"testing"
+	"testing/quick"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFnv1a(t *testing.T) {
+	fa := newFnv1a()
+	fb := fnv.New64a()
+	err := quick.CheckEqual(
+		func(s string) uint64 {
+			fa.add(s)
+			return uint64(fa)
+		},
+		func(s string) uint64 {
+			fb.Write([]byte(s))
+			return fb.Sum64()
+		},
+		nil,
+	)
+	assert.NoError(t, err)
+}

--- a/internal/apmlog/logger.go
+++ b/internal/apmlog/logger.go
@@ -119,6 +119,7 @@ func parseLogLevel(s string) (logLevel, error) {
 type Logger interface {
 	Debugf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
 }
 
 type levelLogger struct {
@@ -134,6 +135,11 @@ func (l levelLogger) Debugf(format string, args ...interface{}) {
 // Errorf logs a message with log.Printf, with an ERROR prefix.
 func (l levelLogger) Errorf(format string, args ...interface{}) {
 	l.logf(errorLevel, format, args...)
+}
+
+// Warningf logs a message with log.Printf, with a WARNING prefix.
+func (l levelLogger) Warningf(format string, args ...interface{}) {
+	l.logf(warnLevel, format, args...)
 }
 
 func (l levelLogger) logf(level logLevel, format string, args ...interface{}) {

--- a/internal/apmschema/jsonschema/metricsets/metricset.json
+++ b/internal/apmschema/jsonschema/metricsets/metricset.json
@@ -4,6 +4,10 @@
     "description": "Data captured by an agent representing an event occurring in a monitored service",
     "allOf": [
         { "$ref": "../timestamp_epoch.json"},
+        { "$ref": "../span_type.json" },
+        { "$ref": "../span_subtype.json" },
+        { "$ref": "../transaction_name.json" },
+        { "$ref": "../transaction_type.json" },
         {
             "properties": {
                 "samples": {
@@ -14,6 +18,72 @@
                     "patternProperties": {
                         "^[^*\"]*$": {
                             "$ref": "sample.json"
+                        }
+                    },
+                    "properties": {
+                        "transaction": {
+                            "type": ["object", "null"],
+                            "properties": {
+                                "duration": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                        "count": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "sum": {
+                                            "type": ["object", "null"],
+                                            "properties": {
+                                                "us": {
+                                                    "type": ["number", "null"]
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "breakdown": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                        "count": {
+                                            "type": ["number", "null"]
+                                        }
+                                    }
+                                },
+                                "self_time": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                        "count": {
+                                            "type": ["number", "null"]
+                                        },
+                                        "sum": {
+                                            "type": ["object", "null"],
+                                            "properties": {
+                                                "us": {
+                                                    "type": ["number", "null"]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "span": {
+                            "type": ["object", "null"],
+                            "self_time": {
+                                "type": ["object", "null"],
+                                "properties": {
+                                    "count": {
+                                        "type":  ["number", "null"]
+                                    },
+                                    "sum": {
+                                        "type": ["object", "null"],
+                                        "properties": {
+                                            "us": {
+                                                "type": ["number", "null"]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                     "additionalProperties": false

--- a/internal/apmschema/jsonschema/span_subtype.json
+++ b/internal/apmschema/jsonschema/span_subtype.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/span_subtype.json",
+    "title": "Span Subtype",
+    "type": ["object"],
+    "properties": {
+        "subtype": {
+            "type": ["string", "null"],
+            "description": "A further sub-division of the type (e.g. postgresql, elasticsearch)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/internal/apmschema/jsonschema/span_type.json
+++ b/internal/apmschema/jsonschema/span_type.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/span_type.json",
+    "title": "Span Type",
+    "type": ["object"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/internal/apmschema/jsonschema/spans/span.json
+++ b/internal/apmschema/jsonschema/spans/span.json
@@ -4,6 +4,8 @@
     "description": "An event captured by an agent occurring in a monitored service",
     "allOf": [
         { "$ref": "../timestamp_epoch.json" },
+        { "$ref": "../span_type.json" },
+        { "$ref": "../span_subtype.json" },
         {  
             "properties": {
                 "id": {
@@ -29,11 +31,6 @@
                 "start": {
                     "type": ["number", "null"],
                     "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
-                },
-                "subtype": {
-                    "type": ["string", "null"],
-                    "description": "A further sub-division of the type (e.g. postgresql, elasticsearch)",
-                    "maxLength": 1024
                 },
                 "action": {
                     "type": ["string", "null"],
@@ -150,11 +147,6 @@
                         "$ref": "../stacktrace_frame.json"
                     },
                     "minItems": 0
-                },
-                "type": {
-                    "type": "string",
-                    "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
-                    "maxLength": 1024
                 },
                 "sync": {
                     "type": ["boolean", "null"],

--- a/internal/apmschema/jsonschema/transaction_name.json
+++ b/internal/apmschema/jsonschema/transaction_name.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/transaction_name.json",
+    "title": "Transaction Name",
+    "type": ["object"],
+    "properties": {
+        "name": {
+            "type": ["string","null"],
+            "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
+            "maxLength": 1024
+        }
+    }
+}

--- a/internal/apmschema/jsonschema/transaction_type.json
+++ b/internal/apmschema/jsonschema/transaction_type.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/transaction_type.json",
+    "title": "Transaction Type",
+    "type": ["object"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/internal/apmschema/jsonschema/transactions/transaction.json
+++ b/internal/apmschema/jsonschema/transactions/transaction.json
@@ -4,6 +4,8 @@
     "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
     "allOf": [
         { "$ref": "../timestamp_epoch.json" },
+        { "$ref": "../transaction_name.json" },
+        { "$ref": "../transaction_type.json" },
         {  
             "properties": {
                 "id": {
@@ -44,19 +46,9 @@
                     "type": "number",
                     "description": "How long the transaction took to complete, in ms with 3 decimal points"
                 },
-                "name": {
-                    "type": ["string","null"],
-                    "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
-                    "maxLength": 1024
-                },
                 "result": {
                     "type": ["string", "null"],
                     "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
-                    "maxLength": 1024
-                },
-                "type": {
-                    "type": "string",
-                    "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
                     "maxLength": 1024
                 },
                 "marks": {

--- a/internal/apmschema/update.sh
+++ b/internal/apmschema/update.sh
@@ -17,10 +17,14 @@ FILES=( \
     "process.json" \
     "request.json" \
     "service.json" \
+    "span_subtype.json" \
+    "span_type.json" \
     "stacktrace_frame.json" \
     "system.json" \
     "tags.json" \
     "timestamp_epoch.json" \
+    "transaction_name.json" \
+    "transaction_type.json" \
     "user.json" \
 )
 

--- a/logger.go
+++ b/logger.go
@@ -26,3 +26,29 @@ type Logger interface {
 	// Errorf logs a message at error level.
 	Errorf(format string, args ...interface{})
 }
+
+// WarningLogger extends Logger with a Warningf method.
+//
+// TODO(axw) this will be removed in v2.0.0, and the
+// Warningf method will be added directly to Logger.
+type WarningLogger interface {
+	Logger
+
+	// Warningf logs a message at warning level.
+	Warningf(format string, args ...interface{})
+}
+
+func makeWarningLogger(l Logger) WarningLogger {
+	if wl, ok := l.(WarningLogger); ok {
+		return wl
+	}
+	return debugWarningLogger{Logger: l}
+}
+
+type debugWarningLogger struct {
+	Logger
+}
+
+func (l debugWarningLogger) Warningf(format string, args ...interface{}) {
+	l.Debugf(format, args...)
+}

--- a/metrics.go
+++ b/metrics.go
@@ -33,10 +33,15 @@ type Metrics struct {
 
 	mu      sync.Mutex
 	metrics []*model.Metrics
+
+	// transactionGroupMetrics holds metrics which are scoped to transaction
+	// groups, and are not sorted according to their labels.
+	transactionGroupMetrics []*model.Metrics
 }
 
 func (m *Metrics) reset() {
 	m.metrics = m.metrics[:0]
+	m.transactionGroupMetrics = m.transactionGroupMetrics[:0]
 }
 
 // MetricLabel is a name/value pair for labeling metrics.

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -622,6 +622,14 @@ func (t *ErrorTransaction) isZero() bool {
 	return *t == ErrorTransaction{}
 }
 
+func (t *MetricsTransaction) isZero() bool {
+	return *t == MetricsTransaction{}
+}
+
+func (s *MetricsSpan) isZero() bool {
+	return *s == MetricsSpan{}
+}
+
 func writeHex(w *fastjson.Writer, v []byte) {
 	const hextable = "0123456789abcdef"
 	for _, v := range v {

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1078,14 +1078,80 @@ func (v *Metrics) MarshalFastJSON(w *fastjson.Writer) error {
 	if err := v.Timestamp.MarshalFastJSON(w); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	if !v.Span.isZero() {
+		w.RawString(",\"span\":")
+		if err := v.Span.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if !v.Labels.isZero() {
 		w.RawString(",\"tags\":")
 		if err := v.Labels.MarshalFastJSON(w); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
+	if !v.Transaction.isZero() {
+		w.RawString(",\"transaction\":")
+		if err := v.Transaction.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	w.RawByte('}')
 	return firstErr
+}
+
+func (v *MetricsTransaction) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	first := true
+	if v.Name != "" {
+		const prefix = ",\"name\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Name)
+	}
+	if v.Type != "" {
+		const prefix = ",\"type\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Type)
+	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *MetricsSpan) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	first := true
+	if v.Subtype != "" {
+		const prefix = ",\"subtype\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Subtype)
+	}
+	if v.Type != "" {
+		const prefix = ",\"type\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Type)
+	}
+	w.RawByte('}')
+	return nil
 }
 
 func (v *Metric) MarshalFastJSON(w *fastjson.Writer) error {

--- a/model/model.go
+++ b/model/model.go
@@ -585,6 +585,14 @@ type Metrics struct {
 	// Timestamp holds the time at which the metric samples were taken.
 	Timestamp Time `json:"timestamp"`
 
+	// Transaction optionally holds the name and type of transactions
+	// with which these metrics are associated.
+	Transaction MetricsTransaction `json:"transaction,omitempty"`
+
+	// Span optionally holds the type and subtype of the spans with
+	// which these metrics are associated.
+	Span MetricsSpan `json:"span,omitempty"`
+
 	// Labels holds a set of labels associated with the metrics.
 	// The labels apply uniformly to all metric samples in the set.
 	//
@@ -595,6 +603,18 @@ type Metrics struct {
 
 	// Samples holds a map of metric samples, keyed by metric name.
 	Samples map[string]Metric `json:"samples"`
+}
+
+// MetricsTransaction holds transaction identifiers for metrics.
+type MetricsTransaction struct {
+	Type string `json:"type,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// MetricsSpan holds span identifiers for metrics.
+type MetricsSpan struct {
+	Type    string `json:"type,omitempty"`
+	Subtype string `json:"subtype,omitempty"`
 }
 
 // Metric holds metric values.

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -85,6 +85,13 @@ func (w *modelWriter) writeError(e *ErrorData) {
 // Note that we do not write metrics to the main ring buffer (w.buffer), as
 // periodic metrics would be evicted by transactions/spans in a busy system.
 func (w *modelWriter) writeMetrics(m *Metrics) {
+	for _, m := range m.transactionGroupMetrics {
+		w.json.RawString(`{"metricset":`)
+		m.MarshalFastJSON(&w.json)
+		w.json.RawString("}")
+		w.metricsBuffer.WriteBlock(w.json.Bytes(), metricsBlockTag)
+		w.json.Reset()
+	}
 	for _, m := range m.metrics {
 		w.json.RawString(`{"metricset":`)
 		m.MarshalFastJSON(&w.json)

--- a/span.go
+++ b/span.go
@@ -27,9 +27,11 @@ import (
 	"go.elastic.co/apm/stacktrace"
 )
 
-// droppedSpanDataPool holds *SpanData which are used when the span
-// is created for a nil or non-sampled Transaction, or one whose max
-// spans limit has been reached.
+// droppedSpanDataPool holds *SpanData which are used when the span is created
+// for a nil or non-sampled trace context, without a transaction reference.
+//
+// Spans started with a non-nil transaction, even if it is non-sampled, are
+// always created with the transaction's tracer span pool.
 var droppedSpanDataPool sync.Pool
 
 // StartSpan starts and returns a new Span within the transaction,
@@ -55,14 +57,14 @@ func (tx *Transaction) StartSpan(name, spanType string, parent *Span) *Span {
 // StartSpanOptions starts and returns a new Span within the transaction,
 // with the specified name, type, and options.
 //
-// StartSpan always returns a non-nil Span. Its End method must
-// be called when the span completes.
+// StartSpan always returns a non-nil Span. Its End method must be called
+// when the span completes.
 //
-// If the span type contains two dots, they are assumed to separate
-// the span type, subtype, and action; a single dot separates span
-// type and subtype, and the action will not be set.
+// If the span type contains two dots, they are assumed to separate the
+// span type, subtype, and action; a single dot separates span type and
+// subtype, and the action will not be set.
 func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions) *Span {
-	if tx == nil || !tx.traceContext.Options.Recorded() {
+	if tx == nil {
 		return newDroppedSpan()
 	}
 
@@ -78,18 +80,8 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 	// Prevent tx from being ended while we're starting a span.
 	tx.mu.RLock()
 	defer tx.mu.RUnlock()
-
 	if tx.ended() {
 		return tx.tracer.StartSpan(name, spanType, transactionID, opts)
-	}
-
-	// Guard access to spansCreated, spansDropped, maxSpans, timestamp,
-	// rand, and spanFramesMinDuration.
-	tx.TransactionData.mu.Lock()
-	defer tx.TransactionData.mu.Unlock()
-	if tx.maxSpans > 0 && tx.spansCreated >= tx.maxSpans {
-		tx.spansDropped++
-		return newDroppedSpan()
 	}
 
 	// Calculate the span time relative to the transaction timestamp so
@@ -100,17 +92,40 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 	} else {
 		opts.Start = tx.timestamp.Add(opts.Start.Sub(tx.timestamp))
 	}
-
 	span := tx.tracer.startSpan(name, spanType, transactionID, opts)
-	if opts.SpanID.Validate() == nil {
-		span.traceContext.Span = opts.SpanID
-	} else {
-		binary.LittleEndian.PutUint64(span.traceContext.Span[:], tx.rand.Uint64())
-	}
-	span.stackFramesMinDuration = tx.spanFramesMinDuration
-	span.stackTraceLimit = tx.stackTraceLimit
 	span.tx = tx
-	tx.spansCreated++
+	span.parent = opts.parent
+
+	// Guard access to spansCreated, spansDropped, rand, and childrenTimer.
+	tx.TransactionData.mu.Lock()
+	defer tx.TransactionData.mu.Unlock()
+	if !span.traceContext.Options.Recorded() {
+		span.tracer = nil // span is dropped
+	} else if tx.maxSpans > 0 && tx.spansCreated >= tx.maxSpans {
+		span.tracer = nil // span is dropped
+		tx.spansDropped++
+	} else {
+		if opts.SpanID.Validate() == nil {
+			span.traceContext.Span = opts.SpanID
+		} else {
+			binary.LittleEndian.PutUint64(span.traceContext.Span[:], tx.rand.Uint64())
+		}
+		span.stackFramesMinDuration = tx.spanFramesMinDuration
+		span.stackTraceLimit = tx.stackTraceLimit
+		tx.spansCreated++
+	}
+
+	if tx.breakdownMetricsEnabled {
+		if span.parent != nil {
+			span.parent.mu.Lock()
+			defer span.parent.mu.Unlock()
+			if !span.parent.ended() {
+				span.parent.childrenTimer.childStarted(span.timestamp)
+			}
+		} else {
+			tx.childrenTimer.childStarted(span.timestamp)
+		}
+	}
 	return span
 }
 
@@ -207,6 +222,7 @@ func (t *Tracer) startSpan(name, spanType string, transactionID SpanID, opts Spa
 	return span
 }
 
+// newDropped returns a new Span with a non-nil SpanData.
 func newDroppedSpan() *Span {
 	span, _ := droppedSpanDataPool.Get().(*Span)
 	if span == nil {
@@ -217,8 +233,9 @@ func newDroppedSpan() *Span {
 
 // Span describes an operation within a transaction.
 type Span struct {
-	tracer        *Tracer      // nil if span is dropped
-	tx            *Transaction // nil if span is dropped
+	tracer        *Tracer // nil if span is dropped
+	tx            *Transaction
+	parent        *Span
 	traceContext  TraceContext
 	transactionID SpanID
 
@@ -277,19 +294,58 @@ func (s *Span) End() {
 	if s.ended() {
 		return
 	}
-	if s.dropped() {
-		droppedSpanDataPool.Put(s.SpanData)
-		s.SpanData = nil
-		return
-	}
 	if s.Duration < 0 {
 		s.Duration = time.Since(s.timestamp)
+	}
+	if s.dropped() {
+		if s.tx == nil {
+			droppedSpanDataPool.Put(s.SpanData)
+		} else {
+			s.reportSelfTime()
+			s.reset(s.tx.tracer)
+		}
+		s.SpanData = nil
+		return
 	}
 	if len(s.stacktrace) == 0 && s.Duration >= s.stackFramesMinDuration {
 		s.setStacktrace(1)
 	}
+	if s.tx != nil {
+		s.reportSelfTime()
+	}
 	s.enqueue()
 	s.SpanData = nil
+}
+
+// reportSelfTime reports the span's self-time to its transaction, and informs
+// the parent that it has ended in order for the parent to later calculate its
+// own self-time.
+//
+// This must only be called from Span.End, with s.mu.Lock held for writing and
+// s.Duration set.
+func (s *Span) reportSelfTime() {
+	endTime := s.timestamp.Add(s.Duration)
+
+	// TODO(axw) try to find a way to not lock the transaction when
+	// ending every span. We already lock them when starting spans.
+	s.tx.mu.RLock()
+	defer s.tx.mu.RUnlock()
+	if s.tx.ended() || !s.tx.breakdownMetricsEnabled {
+		return
+	}
+
+	s.tx.TransactionData.mu.Lock()
+	defer s.tx.TransactionData.mu.Unlock()
+	if s.parent != nil {
+		s.parent.mu.Lock()
+		if !s.parent.ended() {
+			s.parent.childrenTimer.childEnded(endTime)
+		}
+		s.parent.mu.Unlock()
+	} else {
+		s.tx.childrenTimer.childEnded(endTime)
+	}
+	s.tx.spanTimings.add(s.Type, s.Subtype, s.Duration-s.childrenTimer.finalDuration(endTime))
 }
 
 func (s *Span) enqueue() {
@@ -319,6 +375,7 @@ type SpanData struct {
 	stackFramesMinDuration time.Duration
 	stackTraceLimit        int
 	timestamp              time.Time
+	childrenTimer          childrenTimer
 
 	// Name holds the span name, initialized with the value passed to StartSpan.
 	Name string

--- a/transaction.go
+++ b/transaction.go
@@ -43,6 +43,7 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 			Context: Context{
 				captureBodyMask: CaptureBodyTransactions,
 			},
+			spanTimings: make(spanTimingsMap),
 		}
 		var seed int64
 		if err := binary.Read(cryptorand.Reader, binary.LittleEndian, &seed); err != nil {
@@ -98,6 +99,8 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	t.captureHeadersMu.RLock()
 	tx.Context.captureHeaders = t.captureHeaders
 	t.captureHeadersMu.RUnlock()
+
+	tx.breakdownMetricsEnabled = t.breakdownMetrics.flags.transactionBreakdown()
 
 	if root {
 		t.samplerMu.RLock()
@@ -241,6 +244,9 @@ func (tx *Transaction) enqueue() {
 	case tx.tracer.events <- event:
 	default:
 		// Enqueuing a transaction should never block.
+		tx.tracer.breakdownMetrics.recordTransaction(tx.TransactionData)
+
+		// TODO(axw) use an atomic operation to increment.
 		tx.tracer.statsMu.Lock()
 		tx.tracer.stats.TransactionsDropped++
 		tx.tracer.statsMu.Unlock()
@@ -280,15 +286,18 @@ type TransactionData struct {
 	// Result holds the transaction result.
 	Result string
 
-	maxSpans              int
-	spanFramesMinDuration time.Duration
-	stackTraceLimit       int
-	timestamp             time.Time
+	maxSpans                int
+	spanFramesMinDuration   time.Duration
+	stackTraceLimit         int
+	breakdownMetricsEnabled bool
+	timestamp               time.Time
 
-	mu           sync.Mutex
-	spansCreated int
-	spansDropped int
-	rand         *rand.Rand // for ID generation
+	mu            sync.Mutex
+	spansCreated  int
+	spansDropped  int
+	childrenTimer childrenTimer
+	spanTimings   spanTimingsMap
+	rand          *rand.Rand // for ID generation
 	// parentSpan holds the transaction's parent ID. It is protected by
 	// mu, since it can be updated by calling EnsureParent.
 	parentSpan SpanID
@@ -298,10 +307,12 @@ type TransactionData struct {
 // into the transaction pool.
 func (td *TransactionData) reset(tracer *Tracer) {
 	*td = TransactionData{
-		Context:  td.Context,
-		Duration: -1,
-		rand:     td.rand,
+		Context:     td.Context,
+		Duration:    -1,
+		rand:        td.rand,
+		spanTimings: td.spanTimings,
 	}
 	td.Context.reset()
+	td.spanTimings.reset()
 	tracer.transactionDataPool.Put(td)
 }

--- a/utils.go
+++ b/utils.go
@@ -196,3 +196,9 @@ func jitterDuration(d time.Duration, rng *rand.Rand, j float64) time.Duration {
 	r := (rng.Float64() * j * 2) - j
 	return d + time.Duration(float64(d)*r)
 }
+
+func durationMicros(d time.Duration) float64 {
+	us := d / time.Microsecond
+	ns := d % time.Microsecond
+	return float64(us) + float64(ns)/1e9
+}


### PR DESCRIPTION
Implementation of agent breakdown metrics (https://github.com/elastic/apm/issues/78)

Checklist/TL;DR version of the design:

- [x] [Calculate self-time of transactions and spans](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.ondan294nbpt)
  - [x] Prerequisite: Spans have a reference to their parent
  - [x] Add a child duration reentrant timer to transactions and spans
- [x] Add [feature flag](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.12wulrccoi9k)
- [x] [Track span self-times on the transaction](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.g5pdtefj3ag)
  - [x] Prerequisite: Spans have a reference to their transaction
  - On span end:
    - [x] track the span self-time on the corresponding transaction
  - On transaction end
    - [x] track all self-times on the metric registry
    - [x] track the transaction's self time with the `span.type` `app`
    - [x] track the transaction's duration on the metrics registry
- [Reporting metrics](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.gkxkryn9w02s)
  - [x] Add support for top-level labels for `transaction.name`, `transaction.type`, `span.type` and `span.subtype`
  - [x] Reset counters for Timers and the `transaction.breakdown.count` counter every time the metrics are reported
- [x] [Acceptance tests](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.7m6qydtkxod4)
- [x] [Evaluate the performance impact](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.68ixudlgfzac)
- [x] [Document metrics](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.68ixudlgfzac)

Closes elastic/apm-agent-go#528 