### PR TITLE
 Fix body capture to ignore read errors

### DIFF
--- a/internal/apmhttputil/url.go
+++ b/internal/apmhttputil/url.go
@@ -104,5 +104,6 @@ func splitHost(in string) (host, port string) {
 
 func truncateString(s string) string {
 	// At the time of writing, all length limits are 1024.
-	return apmstrings.Truncate(s, 1024)
+	s, _ = apmstrings.Truncate(s, 1024)
+	return s
 }

--- a/internal/apmstrings/truncate.go
+++ b/internal/apmstrings/truncate.go
@@ -17,14 +17,15 @@
 
 package apmstrings
 
-// Truncate returns s truncated at n runes.
-func Truncate(s string, n int) string {
+// Truncate returns s truncated at n runes, and the number
+// of runes in the resulting string (<= n).
+func Truncate(s string, n int) (string, int) {
 	var j int
 	for i := range s {
 		if j == n {
-			return s[:i]
+			return s[:i], n
 		}
 		j++
 	}
-	return s
+	return s, j
 }

--- a/internal/apmstrings/truncate_test.go
+++ b/internal/apmstrings/truncate_test.go
@@ -19,6 +19,7 @@ package apmstrings_test
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 
@@ -29,8 +30,9 @@ func TestTruncate(t *testing.T) {
 	const limit = 2
 	test := func(name, in, expect string) {
 		t.Run(name, func(t *testing.T) {
-			out := apmstrings.Truncate(in, limit)
-			assert.Equal(t, out, expect)
+			out, n := apmstrings.Truncate(in, limit)
+			assert.Equal(t, expect, out)
+			assert.Equal(t, utf8.RuneCountInString(out), n)
 		})
 	}
 	test("empty", "", "")

--- a/utils.go
+++ b/utils.go
@@ -48,6 +48,16 @@ const (
 	envHostname = "ELASTIC_APM_HOSTNAME"
 
 	serviceNameValidClass = "a-zA-Z0-9 _-"
+
+	// At the time of writing, all keyword length limits
+	// are 1024 runes, enforced by JSON Schema.
+	stringLengthLimit = 1024
+
+	// Non-keyword string fields are not limited in length
+	// by JSON Schema, but we still truncate all strings.
+	// Some strings, such as database statement, we explicitly
+	// allow to be longer than others.
+	longStringLengthLimit = 10000
 )
 
 func init() {
@@ -157,18 +167,13 @@ func sanitizeServiceName(name string) string {
 }
 
 func truncateString(s string) string {
-	// At the time of writing, all keyword length
-	// limits are 1024, enforced by JSON Schema.
-	return apmstrings.Truncate(s, 1024)
+	s, _ = apmstrings.Truncate(s, stringLengthLimit)
+	return s
 }
 
 func truncateLongString(s string) string {
-	// Non-keyword string fields are not limited
-	// in length by JSON Schema, but we still
-	// truncate all strings. Some strings, such
-	// as database statement, we explicitly allow
-	// to be longer than others.
-	return apmstrings.Truncate(s, 10000)
+	s, _ = apmstrings.Truncate(s, longStringLengthLimit)
+	return s
 }
 
 func nextGracePeriod(p time.Duration) time.Duration {


### PR DESCRIPTION
Ignore request body read errors when capturing the remaining body. Also, limit the amount we read from the body.

Closes elastic/apm-agent-go#568