### PR TITLE
apmhostutil: extract CF Garden container IDs

### DIFF
--- a/internal/apmhostutil/container_linux.go
+++ b/internal/apmhostutil/container_linux.go
@@ -48,7 +48,12 @@ var (
 			`(?:^/kubepods\.slice/kubepods-[^/]+\.slice/kubepods-[^/]+-pod([^/]+)\.slice/$)`,
 	)
 
-	containerIDRegexp = regexp.MustCompile("^[[:xdigit:]]{64}$")
+	containerIDRegexp = regexp.MustCompile(
+		"^" +
+			"[[:xdigit:]]{64}|" +
+			"[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4,}" +
+			"$",
+	)
 )
 
 func containerInfo() (*model.Container, error) {

--- a/internal/apmhostutil/container_linux_test.go
+++ b/internal/apmhostutil/container_linux_test.go
@@ -59,6 +59,16 @@ func TestCgroupContainerInfoECS(t *testing.T) {
 	assert.Equal(t, &model.Container{ID: "7e9139716d9e5d762d22f9f877b87d1be8b1449ac912c025a984750c5dbff157"}, container)
 }
 
+func TestCgroupContainerInfoCloudFoundryGarden(t *testing.T) {
+	container, kubernetes, err := readCgroupContainerInfo(strings.NewReader(`
+1:name=systemd:/system.slice/garden.service/garden/70eb4ce5-a065-4401-6990-88ed
+`[1:]))
+
+	assert.NoError(t, err)
+	assert.Nil(t, kubernetes)
+	assert.Equal(t, &model.Container{ID: "70eb4ce5-a065-4401-6990-88ed"}, container)
+}
+
 func TestCgroupContainerInfoNonContainer(t *testing.T) {
 	container, _, err := readCgroupContainerInfo(strings.NewReader(`
 12:devices:/user.slice


### PR DESCRIPTION
As well as supporting contiguous 64 hex digits, also support truncated UUIDs as used by CloudFoundry Garden.

Closes #576 