### PR TITLE
Wrong/Missing information about config variable.

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -363,7 +363,8 @@ a negative value, such as -1, means that all frames will be collected.
 By default, the agent will sample every transaction (e.g. request to your service).
 To reduce overhead and storage requirements, you can set the sample rate to a value
 between `0.0` and `1.0`. We still record overall time and the result for unsampled
-transactions, but no context information, tags, or spans.
+transactions, but no context information like http request, response and body.
+Developer should decide to add or not to add tags to context by using txn.Sample() function.
 
 [float]
 [[config-metrics-interval]]


### PR DESCRIPTION
Tags are still added to context for unsampled txn's.
Developer should check for txn.Sampled() to decide add or not to add to context.