### PR TITLE
Provide more control over tracer creation

### DIFF
--- a/apmtest/recorder.go
+++ b/apmtest/recorder.go
@@ -18,35 +18,26 @@
 package apmtest
 
 import (
-	"log"
-
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/transport/transporttest"
 )
 
-// DiscardTracer is an apm.Tracer that discards all events.
-//
-// This tracer may be used by multiple tests, and so should
-// not be modified or closed.
-//
-// Importing apmttest will close apm.DefaultTracer, and update
-// it to this value.
-var DiscardTracer *apm.Tracer
-
-// NewDiscardTracer returns a new apm.Tracer that discards all events.
-func NewDiscardTracer() *apm.Tracer {
+// NewRecordingTracer returns a new RecordingTracer, containing a new
+// Tracer using the RecorderTransport stored inside.
+func NewRecordingTracer() *RecordingTracer {
+	var result RecordingTracer
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
-		Transport: transporttest.Discard,
+		Transport: &result.RecorderTransport,
 	})
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
-	return tracer
+	result.Tracer = tracer
+	return &result
 }
 
-func init() {
-	apm.DefaultTracer.Close()
-	tracer := NewDiscardTracer()
-	DiscardTracer = tracer
-	apm.DefaultTracer = DiscardTracer
+// RecordingTracer holds an apm.Tracer and transporttest.RecorderTransport.
+type RecordingTracer struct {
+	*apm.Tracer
+	transporttest.RecorderTransport
 }

--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -30,15 +30,10 @@ import (
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/model"
-	"go.elastic.co/apm/transport/transporttest"
 )
 
 func TestContextStartSpanTransactionEnded(t *testing.T) {
-	tracer, err := apm.NewTracer("tracer_testing", "")
-	assert.NoError(t, err)
-	defer tracer.Close()
-	tracer.Transport = transporttest.Discard
-
+	tracer := apmtest.DiscardTracer
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
@@ -60,11 +55,7 @@ func TestContextStartSpanTransactionEnded(t *testing.T) {
 }
 
 func TestContextStartSpanSpanEnded(t *testing.T) {
-	tracer, err := apm.NewTracer("tracer_testing", "")
-	assert.NoError(t, err)
-	defer tracer.Close()
-	tracer.Transport = transporttest.Discard
-
+	tracer := apmtest.DiscardTracer
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)

--- a/module/apmgin/bench_test.go
+++ b/module/apmgin/bench_test.go
@@ -65,11 +65,6 @@ func benchmarkEngine(b *testing.B, path string, addMiddleware func(*gin.Engine))
 }
 
 func newTracer() *apm.Tracer {
-	tracer, err := apm.NewTracer("apmgin_test", "0.1")
-	if err != nil {
-		panic(err)
-	}
-
 	invalidServerURL, err := url.Parse("http://testing.invalid:8200")
 	if err != nil {
 		panic(err)
@@ -79,7 +74,14 @@ func newTracer() *apm.Tracer {
 		panic(err)
 	}
 	httpTransport.SetServerURL(invalidServerURL)
-	tracer.Transport = httpTransport
+	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
+		ServiceName:    "apmgin_test",
+		ServiceVersion: "0.1",
+		Transport:      httpTransport,
+	})
+	if err != nil {
+		panic(err)
+	}
 	return tracer
 }
 

--- a/module/apmgometrics/gatherer_test.go
+++ b/module/apmgometrics/gatherer_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/model"
 	"go.elastic.co/apm/module/apmgometrics"
-	"go.elastic.co/apm/transport/transporttest"
 )
 
 func TestGatherer(t *testing.T) {
@@ -88,11 +88,11 @@ func TestHistogram(t *testing.T) {
 }
 
 func gatherMetrics(g apm.MetricsGatherer) []model.Metrics {
-	tracer, transport := transporttest.NewRecorderTracer()
+	tracer := apmtest.NewRecordingTracer()
 	defer tracer.Close()
 	tracer.RegisterMetricsGatherer(g)
 	tracer.SendMetrics(nil)
-	metrics := transport.Payloads().Metrics
+	metrics := tracer.Payloads().Metrics
 	for i := range metrics {
 		metrics[i].Timestamp = model.Time{}
 	}

--- a/module/apmhttp/handler_bench_test.go
+++ b/module/apmhttp/handler_bench_test.go
@@ -69,11 +69,6 @@ func benchmarkHandler(b *testing.B, path string, wrapHandler func(http.Handler) 
 }
 
 func newTracer() *apm.Tracer {
-	tracer, err := apm.NewTracer("apmhttp_test", "0.1")
-	if err != nil {
-		panic(err)
-	}
-
 	invalidServerURL, err := url.Parse("http://testing.invalid:8200")
 	if err != nil {
 		panic(err)
@@ -84,7 +79,15 @@ func newTracer() *apm.Tracer {
 		panic(err)
 	}
 	httpTransport.SetServerURL(invalidServerURL)
-	tracer.Transport = httpTransport
+
+	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
+		ServiceName:    "apmhttp_test",
+		ServiceVersion: "0.1",
+		Transport:      httpTransport,
+	})
+	if err != nil {
+		panic(err)
+	}
 	return tracer
 }
 

--- a/module/apmlogrus/hook_test.go
+++ b/module/apmlogrus/hook_test.go
@@ -123,8 +123,9 @@ func makeError() error {
 
 func TestHookFatal(t *testing.T) {
 	if os.Getenv("_INSIDE_TEST") == "1" {
+		tracer, _ := apm.NewTracer("", "")
 		logger := logrus.New()
-		logger.AddHook(&apmlogrus.Hook{})
+		logger.AddHook(&apmlogrus.Hook{Tracer: tracer})
 		logger.Fatal("fatality!")
 	}
 

--- a/module/apmmongo/monitor_benchmark_test.go
+++ b/module/apmmongo/monitor_benchmark_test.go
@@ -23,24 +23,21 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/event"
 
 	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/module/apmmongo"
-	"go.elastic.co/apm/transport/transporttest"
 )
 
 func BenchmarkCommandMonitor(b *testing.B) {
 	cm := apmmongo.CommandMonitor()
 	command := mustRawBSON(bson.D{{Key: "find", Value: "collection"}})
 
-	tracer, err := apm.NewTracer("", "")
-	require.NoError(b, err)
+	tracer := apmtest.NewDiscardTracer()
 	tracer.SetMaxSpans(b.N)
 	defer tracer.Close()
-	tracer.Transport = transporttest.Discard
 
 	tx := tracer.StartTransaction("name", "type")
 	defer tx.End()

--- a/module/apmot/harness_test.go
+++ b/module/apmot/harness_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/module/apmhttp"
-	"go.elastic.co/apm/transport/transporttest"
 )
 
 func TestHarness(t *testing.T) {
@@ -51,13 +51,8 @@ func TestHarness(t *testing.T) {
 	}()
 
 	newTracer := func() (opentracing.Tracer, func()) {
-		apmtracer, err := apm.NewTracer("transporttest", "")
-		if err != nil {
-			panic(err)
-		}
-		apmtracer.Transport = transporttest.Discard
-		tracer := New(WithTracer(apmtracer))
-		return tracer, apmtracer.Close
+		tracer := New(WithTracer(apmtest.DiscardTracer))
+		return tracer, func() {}
 	}
 
 	var done bool

--- a/module/apmprometheus/gatherer_test.go
+++ b/module/apmprometheus/gatherer_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/model"
 	"go.elastic.co/apm/module/apmprometheus"
-	"go.elastic.co/apm/transport/transporttest"
 )
 
 func TestGoCollector(t *testing.T) {
@@ -135,11 +135,11 @@ func TestLabels(t *testing.T) {
 }
 
 func gatherMetrics(g apm.MetricsGatherer) []model.Metrics {
-	tracer, transport := transporttest.NewRecorderTracer()
+	tracer := apmtest.NewRecordingTracer()
 	defer tracer.Close()
 	tracer.RegisterMetricsGatherer(g)
 	tracer.SendMetrics(nil)
-	metrics := transport.Payloads().Metrics
+	metrics := tracer.Payloads().Metrics
 	for i := range metrics {
 		metrics[i].Timestamp = model.Time{}
 	}

--- a/module/apmsql/apmsql_bench_test.go
+++ b/module/apmsql/apmsql_bench_test.go
@@ -54,9 +54,13 @@ func BenchmarkStmtQueryContext(b *testing.B) {
 		httpTransport, err := transport.NewHTTPTransport()
 		require.NoError(b, err)
 		httpTransport.SetServerURL(invalidServerURL)
-		tracer, err := apm.NewTracer("apmhttp_test", "0.1")
+
+		tracer, err := apm.NewTracerOptions(apm.TracerOptions{
+			ServiceName:    "apmhttp_test",
+			ServiceVersion: "0.1",
+			Transport:      httpTransport,
+		})
 		require.NoError(b, err)
-		tracer.Transport = httpTransport
 		defer tracer.Close()
 
 		tracer.SetMaxSpans(b.N)

--- a/module/apmsql/sqlite3/parser_test.go
+++ b/module/apmsql/sqlite3/parser_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	_ "go.elastic.co/apm/apmtest" // disable default tracer
 	"go.elastic.co/apm/module/apmsql"
 	apmsqlite3 "go.elastic.co/apm/module/apmsql/sqlite3"
 )

--- a/module/apmzap/core_test.go
+++ b/module/apmzap/core_test.go
@@ -125,7 +125,8 @@ func TestCoreTracerClosed(t *testing.T) {
 
 func TestCoreFatal(t *testing.T) {
 	if os.Getenv("_INSIDE_TEST") == "1" {
-		logger := zap.New(&apmzap.Core{})
+		tracer, _ := apm.NewTracer("", "")
+		logger := zap.New(&apmzap.Core{Tracer: tracer})
 		logger.Fatal("fatality!")
 	}
 

--- a/module/apmzerolog/writer_test.go
+++ b/module/apmzerolog/writer_test.go
@@ -198,7 +198,8 @@ func TestWriterTracerClosed(t *testing.T) {
 
 func TestWriterFatal(t *testing.T) {
 	if os.Getenv("_INSIDE_TEST") == "1" {
-		logger := zerolog.New(&apmzerolog.Writer{})
+		tracer, _ := apm.NewTracer("", "")
+		logger := zerolog.New(&apmzerolog.Writer{Tracer: tracer})
 		logger.Fatal().Msg("fatality!")
 	}
 

--- a/testmain_test.go
+++ b/testmain_test.go
@@ -28,9 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/apm/model"
-	"go.elastic.co/apm/transport/transporttest"
 	"go.elastic.co/fastjson"
 )
 
@@ -77,14 +76,12 @@ func getSubprocessMetadata(t *testing.T, env ...string) (*model.System, *model.P
 }
 
 func dumpMetadata() {
-	var transport transporttest.RecorderTransport
-	tracer, _ := apm.NewTracer("", "")
+	tracer := apmtest.NewRecordingTracer()
 	defer tracer.Close()
-	tracer.Transport = &transport
 
 	tracer.StartTransaction("name", "type").End()
 	tracer.Flush(nil)
-	system, process, service, labels := transport.Metadata()
+	system, process, service, labels := tracer.Metadata()
 
 	var w fastjson.Writer
 	for _, m := range []fastjson.Marshaler{&system, &process, &service, labels} {

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -33,13 +33,17 @@ import (
 
 // NewRecorderTracer returns a new apm.Tracer and
 // RecorderTransport, which is set as the tracer's transport.
+//
+// DEPRECATED. Use apmtest.NewRecordingTracer instead.
 func NewRecorderTracer() (*apm.Tracer, *RecorderTransport) {
 	var transport RecorderTransport
-	tracer, err := apm.NewTracer("transporttest", "")
+	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
+		ServiceName: "transporttest",
+		Transport:   &transport,
+	})
 	if err != nil {
 		panic(err)
 	}
-	tracer.Transport = &transport
 	return tracer, &transport
 }
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -324,14 +324,14 @@ func validatePayloadMetadata(t *testing.T, f func(tracer *apm.Tracer)) {
 }
 
 func validatePayloads(t *testing.T, f func(tracer *apm.Tracer)) {
-	tracer, _ := apm.NewTracer("tracer_testing", "")
+	tracer, _ := apm.NewTracerOptions(apm.TracerOptions{
+		ServiceName:        "x",
+		ServiceVersion:     "y",
+		ServiceEnvironment: "z",
+		Transport:          &validatingTransport{t: t},
+	})
 	defer tracer.Close()
-	tracer.Service.Name = "x"
-	tracer.Service.Version = "x"
-	tracer.Service.Environment = "x"
-	tracer.Transport = &validatingTransport{
-		t: t,
-	}
+
 	f(tracer)
 	tracer.Flush(nil)
 }


### PR DESCRIPTION
Introduce NewTracerOptions and TracerOptions, providing
a means of specifying the initial tracer configuration
(currently just a limited subset).

We now use NewTracerOptions to start a Tracer with an
initial non-default Transport in all of the tests,
rather than starting with the default and switching
after the fact.

Importing apmtest will now update apm.DefaultTracer to
DiscardTracer, calling the initial value's Close method
first.

We also introduce apmtest.NewRecordingTracer and
deprecate direct use of transporttest.RecorderTransport
in tests. This is in order to encourage tests to use
apmtest, updating the default tracer as described above.