### PR TITLE
Move internal/apmconfig to internal/configutil

### DIFF
--- a/env.go
+++ b/env.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"go.elastic.co/apm/internal/apmconfig"
+	"go.elastic.co/apm/internal/configutil"
 	"go.elastic.co/apm/internal/wildcard"
 	"go.elastic.co/apm/model"
 )
@@ -52,10 +52,10 @@ const (
 	envGlobalLabels          = "ELASTIC_APM_GLOBAL_LABELS"
 	envStackTraceLimit       = "ELASTIC_APM_STACK_TRACE_LIMIT"
 
-	defaultAPIRequestSize        = 750 * apmconfig.KByte
+	defaultAPIRequestSize        = 750 * configutil.KByte
 	defaultAPIRequestTime        = 10 * time.Second
-	defaultAPIBufferSize         = 1 * apmconfig.MByte
-	defaultMetricsBufferSize     = 750 * apmconfig.KByte
+	defaultAPIBufferSize         = 1 * configutil.MByte
+	defaultMetricsBufferSize     = 750 * configutil.KByte
 	defaultMetricsInterval       = 30 * time.Second
 	defaultMaxSpans              = 500
 	defaultCaptureHeaders        = true
@@ -63,16 +63,16 @@ const (
 	defaultSpanFramesMinDuration = 5 * time.Millisecond
 	defaultStackTraceLimit       = 50
 
-	minAPIBufferSize     = 10 * apmconfig.KByte
-	maxAPIBufferSize     = 100 * apmconfig.MByte
-	minAPIRequestSize    = 1 * apmconfig.KByte
-	maxAPIRequestSize    = 5 * apmconfig.MByte
-	minMetricsBufferSize = 10 * apmconfig.KByte
-	maxMetricsBufferSize = 100 * apmconfig.MByte
+	minAPIBufferSize     = 10 * configutil.KByte
+	maxAPIBufferSize     = 100 * configutil.MByte
+	minAPIRequestSize    = 1 * configutil.KByte
+	maxAPIRequestSize    = 5 * configutil.MByte
+	minMetricsBufferSize = 10 * configutil.KByte
+	maxMetricsBufferSize = 100 * configutil.MByte
 )
 
 var (
-	defaultSanitizedFieldNames = apmconfig.ParseWildcardPatterns(strings.Join([]string{
+	defaultSanitizedFieldNames = configutil.ParseWildcardPatterns(strings.Join([]string{
 		"password",
 		"passwd",
 		"pwd",
@@ -88,7 +88,7 @@ var (
 
 	globalLabels = func() model.StringMap {
 		var labels model.StringMap
-		for _, kv := range apmconfig.ParseListEnv(envGlobalLabels, ",", nil) {
+		for _, kv := range configutil.ParseListEnv(envGlobalLabels, ",", nil) {
 			i := strings.IndexRune(kv, '=')
 			if i > 0 {
 				k, v := strings.TrimSpace(kv[:i]), strings.TrimSpace(kv[i+1:])
@@ -103,15 +103,15 @@ var (
 )
 
 func initialRequestDuration() (time.Duration, error) {
-	return apmconfig.ParseDurationEnv(envAPIRequestTime, defaultAPIRequestTime)
+	return configutil.ParseDurationEnv(envAPIRequestTime, defaultAPIRequestTime)
 }
 
 func initialMetricsInterval() (time.Duration, error) {
-	return apmconfig.ParseDurationEnv(envMetricsInterval, defaultMetricsInterval)
+	return configutil.ParseDurationEnv(envMetricsInterval, defaultMetricsInterval)
 }
 
 func initialMetricsBufferSize() (int, error) {
-	size, err := apmconfig.ParseSizeEnv(envMetricsBufferSize, defaultMetricsBufferSize)
+	size, err := configutil.ParseSizeEnv(envMetricsBufferSize, defaultMetricsBufferSize)
 	if err != nil {
 		return 0, err
 	}
@@ -125,7 +125,7 @@ func initialMetricsBufferSize() (int, error) {
 }
 
 func initialAPIBufferSize() (int, error) {
-	size, err := apmconfig.ParseSizeEnv(envAPIBufferSize, defaultAPIBufferSize)
+	size, err := configutil.ParseSizeEnv(envAPIBufferSize, defaultAPIBufferSize)
 	if err != nil {
 		return 0, err
 	}
@@ -139,7 +139,7 @@ func initialAPIBufferSize() (int, error) {
 }
 
 func initialAPIRequestSize() (int, error) {
-	size, err := apmconfig.ParseSizeEnv(envAPIRequestSize, defaultAPIRequestSize)
+	size, err := configutil.ParseSizeEnv(envAPIRequestSize, defaultAPIRequestSize)
 	if err != nil {
 		return 0, err
 	}
@@ -184,11 +184,11 @@ func initialSampler() (Sampler, error) {
 }
 
 func initialSanitizedFieldNames() wildcard.Matchers {
-	return apmconfig.ParseWildcardPatternsEnv(envSanitizeFieldNames, defaultSanitizedFieldNames)
+	return configutil.ParseWildcardPatternsEnv(envSanitizeFieldNames, defaultSanitizedFieldNames)
 }
 
 func initialCaptureHeaders() (bool, error) {
-	return apmconfig.ParseBoolEnv(envCaptureHeaders, defaultCaptureHeaders)
+	return configutil.ParseBoolEnv(envCaptureHeaders, defaultCaptureHeaders)
 }
 
 func initialCaptureBody() (CaptureBodyMode, error) {
@@ -224,15 +224,15 @@ func initialService() (name, version, environment string) {
 }
 
 func initialSpanFramesMinDuration() (time.Duration, error) {
-	return apmconfig.ParseDurationEnv(envSpanFramesMinDuration, defaultSpanFramesMinDuration)
+	return configutil.ParseDurationEnv(envSpanFramesMinDuration, defaultSpanFramesMinDuration)
 }
 
 func initialActive() (bool, error) {
-	return apmconfig.ParseBoolEnv(envActive, true)
+	return configutil.ParseBoolEnv(envActive, true)
 }
 
 func initialDisabledMetrics() wildcard.Matchers {
-	return apmconfig.ParseWildcardPatternsEnv(envDisableMetrics, nil)
+	return configutil.ParseWildcardPatternsEnv(envDisableMetrics, nil)
 }
 
 func initialStackTraceLimit() (int, error) {

--- a/internal/configutil/duration.go
+++ b/internal/configutil/duration.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmconfig
+package configutil
 
 import (
 	"fmt"

--- a/internal/configutil/env.go
+++ b/internal/configutil/env.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmconfig
+package configutil
 
 import (
 	"os"

--- a/internal/configutil/env_test.go
+++ b/internal/configutil/env_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmconfig_test
+package configutil_test
 
 import (
 	"os"
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"go.elastic.co/apm/internal/apmconfig"
+	"go.elastic.co/apm/internal/configutil"
 	"go.elastic.co/apm/internal/wildcard"
 )
 
@@ -33,39 +33,39 @@ func TestParseDurationEnv(t *testing.T) {
 	os.Unsetenv(envKey)
 	defer os.Unsetenv(envKey)
 
-	d, err := apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	d, err := configutil.ParseDurationEnv(envKey, 42*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 42*time.Second, d)
 
 	os.Setenv(envKey, "5s")
-	d, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	d, err = configutil.ParseDurationEnv(envKey, 42*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 5*time.Second, d)
 
 	os.Setenv(envKey, "5ms")
-	d, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	d, err = configutil.ParseDurationEnv(envKey, 42*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, 5*time.Millisecond, d)
 
 	os.Setenv(envKey, "5m")
-	d, err = apmconfig.ParseDurationEnv(envKey, 42*time.Minute)
+	d, err = configutil.ParseDurationEnv(envKey, 42*time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, 5*time.Minute, d)
 
 	os.Setenv(envKey, "5 h")
-	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	_, err = configutil.ParseDurationEnv(envKey, 42*time.Second)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: invalid character ' ' in duration 5 h")
 
 	os.Setenv(envKey, "5h")
-	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	_, err = configutil.ParseDurationEnv(envKey, 42*time.Second)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: invalid unit in duration 5h (allowed units: ms, s, m)")
 
 	os.Setenv(envKey, "5")
-	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	_, err = configutil.ParseDurationEnv(envKey, 42*time.Second)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: missing unit in duration 5 (allowed units: ms, s, m)")
 
 	os.Setenv(envKey, "blah")
-	_, err = apmconfig.ParseDurationEnv(envKey, 42*time.Second)
+	_, err = configutil.ParseDurationEnv(envKey, 42*time.Second)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_DURATION: invalid duration blah")
 }
 
@@ -74,49 +74,49 @@ func TestParseSizeEnv(t *testing.T) {
 	os.Unsetenv(envKey)
 	defer os.Unsetenv(envKey)
 
-	d, err := apmconfig.ParseSizeEnv(envKey, 42*apmconfig.KByte)
+	d, err := configutil.ParseSizeEnv(envKey, 42*configutil.KByte)
 	assert.NoError(t, err)
-	assert.Equal(t, 42*apmconfig.KByte, d)
+	assert.Equal(t, 42*configutil.KByte, d)
 
 	os.Setenv(envKey, "5b")
-	d, err = apmconfig.ParseSizeEnv(envKey, 42*apmconfig.KByte)
+	d, err = configutil.ParseSizeEnv(envKey, 42*configutil.KByte)
 	assert.NoError(t, err)
-	assert.Equal(t, 5*apmconfig.Byte, d)
+	assert.Equal(t, 5*configutil.Byte, d)
 
 	os.Setenv(envKey, "5kb")
-	d, err = apmconfig.ParseSizeEnv(envKey, 42*apmconfig.KByte)
+	d, err = configutil.ParseSizeEnv(envKey, 42*configutil.KByte)
 	assert.NoError(t, err)
-	assert.Equal(t, 5*apmconfig.KByte, d)
+	assert.Equal(t, 5*configutil.KByte, d)
 
 	os.Setenv(envKey, "5mb")
-	d, err = apmconfig.ParseSizeEnv(envKey, 42*apmconfig.KByte)
+	d, err = configutil.ParseSizeEnv(envKey, 42*configutil.KByte)
 	assert.NoError(t, err)
-	assert.Equal(t, 5*apmconfig.MByte, d)
+	assert.Equal(t, 5*configutil.MByte, d)
 
 	os.Setenv(envKey, "5gb")
-	d, err = apmconfig.ParseSizeEnv(envKey, 42*apmconfig.KByte)
+	d, err = configutil.ParseSizeEnv(envKey, 42*configutil.KByte)
 	assert.NoError(t, err)
-	assert.Equal(t, 5*apmconfig.GByte, d)
+	assert.Equal(t, 5*configutil.GByte, d)
 
 	os.Setenv(envKey, "5GB")
-	d, err = apmconfig.ParseSizeEnv(envKey, 42*apmconfig.KByte)
+	d, err = configutil.ParseSizeEnv(envKey, 42*configutil.KByte)
 	assert.NoError(t, err)
-	assert.Equal(t, 5*apmconfig.GByte, d)
+	assert.Equal(t, 5*configutil.GByte, d)
 
 	os.Setenv(envKey, "5 mb")
-	_, err = apmconfig.ParseSizeEnv(envKey, 0)
+	_, err = configutil.ParseSizeEnv(envKey, 0)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_SIZE: invalid character ' ' in size 5 mb")
 
 	os.Setenv(envKey, "5tb")
-	_, err = apmconfig.ParseSizeEnv(envKey, 0)
+	_, err = configutil.ParseSizeEnv(envKey, 0)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_SIZE: invalid unit in size 5tb (allowed units: B, KB, MB, GB)")
 
 	os.Setenv(envKey, "5")
-	_, err = apmconfig.ParseSizeEnv(envKey, 0)
+	_, err = configutil.ParseSizeEnv(envKey, 0)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_SIZE: missing unit in size 5 (allowed units: B, KB, MB, GB)")
 
 	os.Setenv(envKey, "blah")
-	_, err = apmconfig.ParseSizeEnv(envKey, 0)
+	_, err = configutil.ParseSizeEnv(envKey, 0)
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_TEST_SIZE: invalid size blah")
 }
 
@@ -125,22 +125,22 @@ func TestParseBoolEnv(t *testing.T) {
 	os.Unsetenv(envKey)
 	defer os.Unsetenv(envKey)
 
-	b, err := apmconfig.ParseBoolEnv(envKey, true)
+	b, err := configutil.ParseBoolEnv(envKey, true)
 	assert.NoError(t, err)
 	assert.True(t, b)
 
 	os.Setenv(envKey, "true")
-	b, err = apmconfig.ParseBoolEnv(envKey, false)
+	b, err = configutil.ParseBoolEnv(envKey, false)
 	assert.NoError(t, err)
 	assert.True(t, b)
 
 	os.Setenv(envKey, "false")
-	b, err = apmconfig.ParseBoolEnv(envKey, true)
+	b, err = configutil.ParseBoolEnv(envKey, true)
 	assert.NoError(t, err)
 	assert.False(t, b)
 
 	os.Setenv(envKey, "falsk")
-	_, err = apmconfig.ParseBoolEnv(envKey, true)
+	_, err = configutil.ParseBoolEnv(envKey, true)
 	assert.EqualError(t, err, `failed to parse ELASTIC_APM_TEST_BOOL: strconv.ParseBool: parsing "falsk": invalid syntax`)
 }
 
@@ -151,31 +151,31 @@ func TestParseListEnv(t *testing.T) {
 
 	defaultList := []string{"foo", "bar"}
 
-	list := apmconfig.ParseListEnv(envKey, ",", defaultList)
+	list := configutil.ParseListEnv(envKey, ",", defaultList)
 	assert.Equal(t, defaultList, list)
 
 	os.Setenv(envKey, "a")
-	list = apmconfig.ParseListEnv(envKey, ",", defaultList)
+	list = configutil.ParseListEnv(envKey, ",", defaultList)
 	assert.Equal(t, []string{"a"}, list)
 
 	os.Setenv(envKey, "a,b")
-	list = apmconfig.ParseListEnv(envKey, ",", defaultList)
+	list = configutil.ParseListEnv(envKey, ",", defaultList)
 	assert.Equal(t, []string{"a", "b"}, list)
 
 	os.Setenv(envKey, ",a , b,")
-	list = apmconfig.ParseListEnv(envKey, ",", defaultList)
+	list = configutil.ParseListEnv(envKey, ",", defaultList)
 	assert.Equal(t, []string{"a", "b"}, list)
 
 	os.Setenv(envKey, ",")
-	list = apmconfig.ParseListEnv(envKey, ",", defaultList)
+	list = configutil.ParseListEnv(envKey, ",", defaultList)
 	assert.Len(t, list, 0)
 
 	os.Setenv(envKey, "a| b")
-	list = apmconfig.ParseListEnv(envKey, "|", defaultList)
+	list = configutil.ParseListEnv(envKey, "|", defaultList)
 	assert.Equal(t, []string{"a", "b"}, list)
 
 	os.Setenv(envKey, "a b")
-	list = apmconfig.ParseListEnv(envKey, ",", defaultList)
+	list = configutil.ParseListEnv(envKey, ",", defaultList)
 	assert.Equal(t, []string{"a b"}, list)
 }
 
@@ -193,20 +193,20 @@ func TestParseWildcardPatternsEnv(t *testing.T) {
 	}
 	defaultMatchers := newMatchers("default")
 
-	matchers := apmconfig.ParseWildcardPatternsEnv(envKey, defaultMatchers)
+	matchers := configutil.ParseWildcardPatternsEnv(envKey, defaultMatchers)
 	assert.Equal(t, defaultMatchers, matchers)
 
 	os.Setenv(envKey, "foo, bar")
 	expected := newMatchers("foo", "bar")
-	matchers = apmconfig.ParseWildcardPatternsEnv(envKey, defaultMatchers)
+	matchers = configutil.ParseWildcardPatternsEnv(envKey, defaultMatchers)
 	assert.Equal(t, expected, matchers)
 
 	os.Setenv(envKey, "foo, (?-i)bar")
 	expected[1] = wildcard.NewMatcher("bar", wildcard.CaseSensitive)
-	matchers = apmconfig.ParseWildcardPatternsEnv(envKey, defaultMatchers)
+	matchers = configutil.ParseWildcardPatternsEnv(envKey, defaultMatchers)
 	assert.Equal(t, expected, matchers)
 
 	os.Setenv(envKey, "(?i)foo, (?-i)bar")
-	matchers = apmconfig.ParseWildcardPatternsEnv(envKey, defaultMatchers)
+	matchers = configutil.ParseWildcardPatternsEnv(envKey, defaultMatchers)
 	assert.Equal(t, expected, matchers)
 }

--- a/internal/configutil/list.go
+++ b/internal/configutil/list.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmconfig
+package configutil
 
 import "strings"
 

--- a/internal/configutil/size.go
+++ b/internal/configutil/size.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmconfig
+package configutil
 
 import (
 	"fmt"

--- a/internal/configutil/wildcards.go
+++ b/internal/configutil/wildcards.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmconfig
+package configutil
 
 import (
 	"strings"

--- a/module/apmhttp/ignorer.go
+++ b/module/apmhttp/ignorer.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"sync"
 
-	"go.elastic.co/apm/internal/apmconfig"
+	"go.elastic.co/apm/internal/configutil"
 	"go.elastic.co/apm/internal/wildcard"
 )
 
@@ -41,7 +41,7 @@ var (
 // patterns will be ignored.
 func DefaultServerRequestIgnorer() RequestIgnorerFunc {
 	defaultServerRequestIgnorerOnce.Do(func() {
-		matchers := apmconfig.ParseWildcardPatternsEnv(envIgnoreURLs, nil)
+		matchers := configutil.ParseWildcardPatternsEnv(envIgnoreURLs, nil)
 		if len(matchers) != 0 {
 			defaultServerRequestIgnorer = NewWildcardPatternsRequestIgnorer(matchers)
 		}

--- a/tracer.go
+++ b/tracer.go
@@ -28,8 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.elastic.co/apm/internal/apmconfig"
 	"go.elastic.co/apm/internal/apmlog"
+	"go.elastic.co/apm/internal/configutil"
 	"go.elastic.co/apm/internal/iochan"
 	"go.elastic.co/apm/internal/ringbuffer"
 	"go.elastic.co/apm/internal/wildcard"
@@ -467,7 +467,7 @@ func (t *Tracer) SetSanitizedFieldNames(patterns ...string) error {
 	if len(patterns) != 0 {
 		matchers = make(wildcard.Matchers, len(patterns))
 		for i, p := range patterns {
-			matchers[i] = apmconfig.ParseWildcardPattern(p)
+			matchers[i] = configutil.ParseWildcardPattern(p)
 		}
 	}
 	t.sendConfigCommand(func(cfg *tracerConfig) {

--- a/transport/http.go
+++ b/transport/http.go
@@ -36,8 +36,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"go.elastic.co/apm/internal/apmconfig"
 	"go.elastic.co/apm/internal/apmversion"
+	"go.elastic.co/apm/internal/configutil"
 )
 
 const (
@@ -99,12 +99,12 @@ type HTTPTransport struct {
 //   certificates.
 //
 func NewHTTPTransport() (*HTTPTransport, error) {
-	verifyServerCert, err := apmconfig.ParseBoolEnv(envVerifyServerCert, true)
+	verifyServerCert, err := configutil.ParseBoolEnv(envVerifyServerCert, true)
 	if err != nil {
 		return nil, err
 	}
 
-	serverTimeout, err := apmconfig.ParseDurationEnv(envServerTimeout, defaultServerTimeout)
+	serverTimeout, err := configutil.ParseDurationEnv(envServerTimeout, defaultServerTimeout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In preparation for introducing a top-level apmconfig package.