### PR TITLE
Implement central config polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Introduce transaction/span breakdown metrics (#564)
  - Optimised HTTP request body capture (#592)
  - Fixed transaction encoding to drop tags (and other context) for non-sampled transactions (#593)
+ - Introduce central config polling (#591)
 
 ## [v1.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.4.0)
 

--- a/apmconfig/doc.go
+++ b/apmconfig/doc.go
@@ -15,19 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transport
-
-import (
-	"context"
-	"io"
-)
-
-// Transport provides an interface for sending streams of encoded model
-// entities to the Elastic APM server, and for querying config. Methods
-// are not required to be safe for concurrent use.
-type Transport interface {
-	// SendStream sends a data stream to the server, returning when the
-	// stream has been closed (Read returns io.EOF) or the HTTP request
-	// terminates.
-	SendStream(context.Context, io.Reader) error
-}
+// Package apmconfig provides an API for watching agent config
+// changes.
+package apmconfig

--- a/apmconfig/watcher.go
+++ b/apmconfig/watcher.go
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmconfig
+
+import (
+	"context"
+)
+
+// Watcher provides an interface for watching config changes.
+type Watcher interface {
+	// WatchConfig subscribes to changes to configuration for the agent,
+	// which must match the given ConfigSelector.
+	//
+	// If the watcher experiences an unexpected error fetching config,
+	// it will surface this in a Change with the Err field set.
+	//
+	// If the provided context is cancelled, or the watcher experiences
+	// a fatal condition, the returned channel will be closed.
+	WatchConfig(context.Context, WatchParams) <-chan Change
+}
+
+// WatchParams holds parameters for watching for config changes.
+type WatchParams struct {
+	// Service holds the name and optionally environment name used
+	// for filtering the config to watch.
+	Service struct {
+		Name        string
+		Environment string
+	}
+}
+
+// Change holds an agent configuration change: an error or the new config attributes.
+type Change struct {
+	// Err holds an error that occurred while querying agent config.
+	Err error
+
+	// Attrs holds the agent's configuration. May be empty.
+	Attrs map[string]string
+}

--- a/apmtest/configwatcher.go
+++ b/apmtest/configwatcher.go
@@ -15,19 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transport
+package apmtest
 
 import (
 	"context"
-	"io"
+
+	"go.elastic.co/apm/apmconfig"
 )
 
-// Transport provides an interface for sending streams of encoded model
-// entities to the Elastic APM server, and for querying config. Methods
-// are not required to be safe for concurrent use.
-type Transport interface {
-	// SendStream sends a data stream to the server, returning when the
-	// stream has been closed (Read returns io.EOF) or the HTTP request
-	// terminates.
-	SendStream(context.Context, io.Reader) error
+// WatchConfigFunc is a function type that implements apmconfig.Watcher.
+type WatchConfigFunc func(context.Context, apmconfig.WatchParams) <-chan apmconfig.Change
+
+// WatchConfig returns f(ctx, params).
+func (f WatchConfigFunc) WatchConfig(ctx context.Context, params apmconfig.WatchParams) <-chan apmconfig.Change {
+	return f(ctx, params)
 }

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -555,3 +555,12 @@ e := apm.DefaultTracer.NewError(err)
 e.SetTransaction(tx)
 e.Send()
 ----
+
+[float]
+[[tracer-config-api]]
+==== Tracer Config
+
+Many configuration attributes can be be updated dynamically via `apm.Tracer` method calls.
+Please refer to the documentation at https://godoc.org/go.elastic.co/apm#Tracer[godoc.org/go.elastic.co/apm#Tracer]
+for details. The configuration methods are primarily prefixed with `Set`, such as
+https://godoc.org/go.elastic.co/apm#Tracer.SetLogger[apm#Tracer.SetLogger].

--- a/env_test.go
+++ b/env_test.go
@@ -149,7 +149,7 @@ func TestTracerTransactionRateEnvInvalid(t *testing.T) {
 	defer os.Unsetenv("ELASTIC_APM_TRANSACTION_SAMPLE_RATE")
 
 	_, err := apm.NewTracer("tracer_testing", "")
-	assert.EqualError(t, err, "invalid ELASTIC_APM_TRANSACTION_SAMPLE_RATE value 2.0: out of range [0,1.0]")
+	assert.EqualError(t, err, "invalid value for ELASTIC_APM_TRANSACTION_SAMPLE_RATE: 2.0 (out of range [0,1.0])")
 }
 
 func testTracerTransactionRateEnv(t *testing.T, envValue string, ratio float64) {

--- a/example_test.go
+++ b/example_test.go
@@ -170,6 +170,10 @@ func (r *recorder) count() int {
 }
 
 func (r *recorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path != "/intake/v2/events" {
+		// Ignore config requests.
+		return
+	}
 	body, err := zlib.NewReader(req.Body)
 	if err != nil {
 		panic(err)

--- a/transport/http.go
+++ b/transport/http.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -31,17 +32,21 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"go.elastic.co/apm/apmconfig"
 	"go.elastic.co/apm/internal/apmversion"
 	"go.elastic.co/apm/internal/configutil"
 )
 
 const (
 	intakePath = "/intake/v2/events"
+	configPath = "/config/v1/agents"
 
 	envSecretToken      = "ELASTIC_APM_SECRET_TOKEN"
 	envServerURLs       = "ELASTIC_APM_SERVER_URLS"
@@ -65,12 +70,14 @@ var (
 type HTTPTransport struct {
 	// Client exposes the http.Client used by the HTTPTransport for
 	// sending requests to the APM Server.
-	Client  *http.Client
-	headers http.Header
+	Client        *http.Client
+	intakeHeaders http.Header
+	configHeaders http.Header
+	shuffleRand   *rand.Rand
 
-	intakeURLs     []*url.URL
-	intakeURLIndex int
-	shuffleRand    *rand.Rand
+	urlIndex   int32
+	intakeURLs []*url.URL
+	configURLs []*url.URL
 }
 
 // NewHTTPTransport returns a new HTTPTransport which can be used for
@@ -145,14 +152,18 @@ func NewHTTPTransport() (*HTTPTransport, error) {
 		},
 	}
 
-	headers := make(http.Header)
-	headers.Set("Content-Type", "application/x-ndjson")
-	headers.Set("Content-Encoding", "deflate")
-	headers.Set("Transfer-Encoding", "chunked")
-	headers.Set("User-Agent", defaultUserAgent())
+	commonHeaders := make(http.Header)
+	commonHeaders.Set("User-Agent", defaultUserAgent())
+
+	intakeHeaders := copyHeaders(commonHeaders)
+	intakeHeaders.Set("Content-Type", "application/x-ndjson")
+	intakeHeaders.Set("Content-Encoding", "deflate")
+	intakeHeaders.Set("Transfer-Encoding", "chunked")
+
 	t := &HTTPTransport{
-		Client:  client,
-		headers: headers,
+		Client:        client,
+		configHeaders: commonHeaders,
+		intakeHeaders: intakeHeaders,
 	}
 	t.SetSecretToken(os.Getenv(envSecretToken))
 	t.SetServerURL(serverURLs...)
@@ -167,8 +178,10 @@ func (t *HTTPTransport) SetServerURL(u ...*url.URL) {
 		panic("SetServerURL expects at least one URL")
 	}
 	intakeURLs := make([]*url.URL, len(u))
+	configURLs := make([]*url.URL, len(u))
 	for i, u := range u {
 		intakeURLs[i] = urlWithPath(u, intakePath)
+		configURLs[i] = urlWithPath(u, configPath)
 	}
 	if n := len(intakeURLs); n > 0 {
 		if t.shuffleRand == nil {
@@ -177,15 +190,17 @@ func (t *HTTPTransport) SetServerURL(u ...*url.URL) {
 		for i := n - 1; i > 0; i-- {
 			j := t.shuffleRand.Intn(i + 1)
 			intakeURLs[i], intakeURLs[j] = intakeURLs[j], intakeURLs[i]
+			configURLs[i], configURLs[j] = configURLs[j], configURLs[i]
 		}
 	}
 	t.intakeURLs = intakeURLs
-	t.intakeURLIndex = 0
+	t.configURLs = configURLs
+	t.urlIndex = 0
 }
 
 // SetUserAgent sets the User-Agent header that will be sent with each request.
 func (t *HTTPTransport) SetUserAgent(ua string) {
-	t.headers.Set("User-Agent", ua)
+	t.setCommonHeader("User-Agent", ua)
 }
 
 // SetSecretToken sets the Authorization header with the given secret token.
@@ -193,31 +208,43 @@ func (t *HTTPTransport) SetUserAgent(ua string) {
 // environment variable, if any.
 func (t *HTTPTransport) SetSecretToken(secretToken string) {
 	if secretToken != "" {
-		t.headers.Set("Authorization", "Bearer "+secretToken)
+		t.setCommonHeader("Authorization", "Bearer "+secretToken)
 	} else {
-		t.headers.Del("Authorization")
+		t.deleteCommonHeader("Authorization")
 	}
+}
+
+func (t *HTTPTransport) setCommonHeader(key, value string) {
+	t.configHeaders.Set(key, value)
+	t.intakeHeaders.Set(key, value)
+}
+
+func (t *HTTPTransport) deleteCommonHeader(key string) {
+	t.configHeaders.Del(key)
+	t.intakeHeaders.Del(key)
 }
 
 // SendStream sends the stream over HTTP. If SendStream returns an error and
 // the transport is configured with more than one APM Server URL, then the
 // following request will be sent to the next URL in the list.
 func (t *HTTPTransport) SendStream(ctx context.Context, r io.Reader) error {
-	intakeURL := t.intakeURLs[t.intakeURLIndex]
-	req := t.newRequest(intakeURL)
+	urlIndex := atomic.LoadInt32(&t.urlIndex)
+	intakeURL := t.intakeURLs[urlIndex]
+	req := t.newRequest("POST", intakeURL)
 	req = requestWithContext(ctx, req)
+	req.Header = t.intakeHeaders
 	req.Body = ioutil.NopCloser(r)
-	if err := t.sendRequest(req); err != nil {
-		t.intakeURLIndex = (t.intakeURLIndex + 1) % len(t.intakeURLs)
+	if err := t.sendStreamRequest(req); err != nil {
+		atomic.StoreInt32(&t.urlIndex, (urlIndex+1)%int32(len(t.intakeURLs)))
 		return err
 	}
 	return nil
 }
 
-func (t *HTTPTransport) sendRequest(req *http.Request) error {
+func (t *HTTPTransport) sendStreamRequest(req *http.Request) error {
 	resp, err := t.Client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "sending request failed")
+		return errors.Wrap(err, "sending event request failed")
 	}
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusAccepted:
@@ -226,18 +253,7 @@ func (t *HTTPTransport) sendRequest(req *http.Request) error {
 	}
 	defer resp.Body.Close()
 
-	// apm-server will return 503 Service Unavailable
-	// if the data cannot be published to Elasticsearch,
-	// but there is no Retry-After header included, so
-	// we treat it as any other internal server error.
-	bodyContents, err := ioutil.ReadAll(resp.Body)
-	if err == nil {
-		resp.Body = ioutil.NopCloser(bytes.NewReader(bodyContents))
-	}
-	result := &HTTPError{
-		Response: resp,
-		Message:  strings.TrimSpace(string(bodyContents)),
-	}
+	result := newHTTPError(resp)
 	if resp.StatusCode == http.StatusNotFound && result.Message == "404 page not found" {
 		// This may be an old (pre-6.5) APM server
 		// that does not support the v2 intake API.
@@ -246,14 +262,127 @@ func (t *HTTPTransport) sendRequest(req *http.Request) error {
 	return result
 }
 
-func (t *HTTPTransport) newRequest(url *url.URL) *http.Request {
+// WatchConfig polls the APM Server for agent config changes, sending
+// them over the returned channel.
+func (t *HTTPTransport) WatchConfig(ctx context.Context, args apmconfig.WatchParams) <-chan apmconfig.Change {
+	// We have an initial delay to allow application initialisation code
+	// to close apm.DefaultTracer, which would cancel watching config.
+	const initialDelay = 1 * time.Second
+
+	changes := make(chan apmconfig.Change)
+	go func() {
+		defer close(changes)
+
+		var etag string
+		var out chan apmconfig.Change
+		var change apmconfig.Change
+		timer := time.NewTimer(initialDelay)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case out <- change:
+				out = nil
+				change = apmconfig.Change{}
+				continue
+			case <-timer.C:
+			}
+
+			urlIndex := atomic.LoadInt32(&t.urlIndex)
+			query := make(url.Values)
+			query.Set("service.name", args.Service.Name)
+			if args.Service.Environment != "" {
+				query.Set("service.environment", args.Service.Environment)
+			}
+			url := *t.configURLs[urlIndex]
+			url.RawQuery = query.Encode()
+
+			req := t.newRequest("GET", &url)
+			req.Header = t.configHeaders
+			if etag != "" {
+				req.Header = copyHeaders(req.Header)
+				req.Header.Set("If-None-Match", strconv.QuoteToASCII(etag))
+			}
+
+			req = requestWithContext(ctx, req)
+			resp := t.configRequest(req)
+			var send bool
+			if resp.err != nil {
+				// The request will have failed if the context has been
+				// cancelled. No need to send a a change in this case.
+				send = ctx.Err() == nil
+			}
+			if !send && resp.attrs != nil {
+				etag = resp.etag
+				send = true
+			}
+			if send {
+				change = apmconfig.Change{Err: resp.err, Attrs: resp.attrs}
+				out = changes
+			}
+			timer.Reset(resp.maxAge)
+		}
+	}()
+	return changes
+}
+
+func (t *HTTPTransport) configRequest(req *http.Request) configResponse {
+	// defaultMaxAge is the default amount of time to wait between
+	// requests. This should only be used when the server does not
+	// respond with a Cache-Control header, or where the header is
+	// malformed.
+	const defaultMaxAge = 5 * time.Minute
+
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		// TODO(axw) this might indicate that the APM Server is unavailable.
+		// In this case, we should allow a change in URL due to SendStream
+		// to cut the defaultMaxAge delay short.
+		return configResponse{
+			err:    errors.Wrap(err, "sending config request failed"),
+			maxAge: defaultMaxAge,
+		}
+	}
+	defer resp.Body.Close()
+
+	var response configResponse
+	if etag, err := strconv.Unquote(resp.Header.Get("Etag")); err == nil {
+		response.etag = etag
+	}
+	cacheControl := parseCacheControl(resp.Header.Get("Cache-Control"))
+	response.maxAge = cacheControl.maxAge
+	if response.maxAge < 0 {
+		response.maxAge = defaultMaxAge
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotModified, http.StatusForbidden, http.StatusNotFound:
+		// 304 (Not Modified) is returned when the config has not changed since the previous query.
+		// 403 (Forbidden) is returned if the server does not have the connection to Kibana enabled.
+		// 404 (Not Found) is returned by old servers that do not implement the config endpoint.
+		return response
+	case http.StatusOK:
+		attrs := make(map[string]string)
+		// TODO(axw) handling EOF shouldn't be necessary, server currently responds with an empty
+		// body when there is no config.
+		if err := json.NewDecoder(resp.Body).Decode(&attrs); err != nil && err != io.EOF {
+			response.err = err
+		} else {
+			response.attrs = attrs
+		}
+		return response
+	}
+	response.err = newHTTPError(resp)
+	return response
+}
+
+func (t *HTTPTransport) newRequest(method string, url *url.URL) *http.Request {
 	req := &http.Request{
-		Method:     "POST",
+		Method:     method,
 		URL:        url,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Header:     t.headers,
 		Host:       url.Host,
 	}
 	return req
@@ -272,6 +401,17 @@ func urlWithPath(url *url.URL, p string) *url.URL {
 type HTTPError struct {
 	Response *http.Response
 	Message  string
+}
+
+func newHTTPError(resp *http.Response) *HTTPError {
+	bodyContents, err := ioutil.ReadAll(resp.Body)
+	if err == nil {
+		resp.Body = ioutil.NopCloser(bytes.NewReader(bodyContents))
+	}
+	return &HTTPError{
+		Response: resp,
+		Message:  strings.TrimSpace(string(bodyContents)),
+	}
 }
 
 func (e *HTTPError) Error() string {
@@ -353,4 +493,41 @@ func verifyPeerCertificate(rawCerts [][]byte, trusted *x509.Certificate) error {
 
 func defaultUserAgent() string {
 	return fmt.Sprintf("elasticapm-go/%s go/%s", apmversion.AgentVersion, runtime.Version())
+}
+
+func copyHeaders(in http.Header) http.Header {
+	out := make(http.Header, len(in))
+	for k, vs := range in {
+		vsCopy := make([]string, len(vs))
+		copy(vsCopy, vs)
+		out[k] = vsCopy
+	}
+	return out
+}
+
+type configResponse struct {
+	err    error
+	attrs  map[string]string
+	etag   string
+	maxAge time.Duration
+}
+
+type cacheControl struct {
+	maxAge time.Duration
+}
+
+func parseCacheControl(s string) cacheControl {
+	fields := strings.SplitN(s, "max-age=", 2)
+	if len(fields) < 2 {
+		return cacheControl{maxAge: -1}
+	}
+	s = fields[1]
+	if i := strings.IndexRune(s, ','); i != -1 {
+		s = s[:i]
+	}
+	maxAge, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return cacheControl{maxAge: -1}
+	}
+	return cacheControl{maxAge: time.Duration(maxAge) * time.Second}
 }


### PR DESCRIPTION
We introduce a new package, apmconfig, which
defines a Watcher interface that can be used
for watching for central config changes.

When creating a new Tracer, it will use its
Transport for watching config if it implements
apmconfig.Watcher. The default HTTP transport
implements that interface.

The default behaviour of watching config can
be disabled by setting the new environment
variable ELASTIC_APM_CENTRAL_CONFIG to "false".

For now only the sampler can be updated via
central config. While there is central sampling
config defined, any locally defined Sampler will
be disregarded, whether it be specified via
environment variable or via SetSampler.

Closes elastic/apm-agent-go#512 