### PR TITLE
Optimise BodyCapturer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Add Context.SetCustom (#581)
  - Add support for extracting UUID-like container IDs (#577)
  - Introduce transaction/span breakdown metrics (#564)
+ - Optimised HTTP request body capture (#592)
 
 ## [v1.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.4.0)
 

--- a/capturebody.go
+++ b/capturebody.go
@@ -20,9 +20,10 @@ package apm
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sync"
+	"unicode/utf8"
 
 	"go.elastic.co/apm/internal/apmstrings"
 	"go.elastic.co/apm/model"
@@ -49,13 +50,21 @@ const (
 	CaptureBodyAll CaptureBodyMode = CaptureBodyErrors | CaptureBodyTransactions
 )
 
+var bodyCapturerPool = sync.Pool{
+	New: func() interface{} {
+		return &BodyCapturer{}
+	},
+}
+
 // CaptureHTTPRequestBody replaces req.Body and returns a possibly nil
 // BodyCapturer which can later be passed to Context.SetHTTPRequestBody
 // for setting the request body in a transaction or error context. If the
 // tracer is not configured to capture HTTP request bodies, then req.Body
 // is left alone and nil is returned.
 //
-// This must be called before the request body is read.
+// This must be called before the request body is read. The BodyCapturer's
+// Discard method should be called after it is no longer needed, in order
+// to recycle its memory.
 func (t *Tracer) CaptureHTTPRequestBody(req *http.Request) *BodyCapturer {
 	if req.Body == nil {
 		return nil
@@ -67,29 +76,59 @@ func (t *Tracer) CaptureHTTPRequestBody(req *http.Request) *BodyCapturer {
 		return nil
 	}
 
-	type readerCloser struct {
-		io.Reader
-		io.Closer
+	bc := bodyCapturerPool.Get().(*BodyCapturer)
+	bc.captureBody = captureBody
+	bc.request = req
+	bc.originalBody = req.Body
+	bc.buffer.Reset()
+	req.Body = bodyCapturerReadCloser{BodyCapturer: bc}
+	return bc
+}
+
+// bodyCapturerReadCloser implements io.ReadCloser using the embedded BodyCapturer.
+type bodyCapturerReadCloser struct {
+	*BodyCapturer
+}
+
+// Close closes the original body.
+func (bc bodyCapturerReadCloser) Close() error {
+	return bc.originalBody.Close()
+}
+
+// Read reads from the original body, copying into bc.buffer.
+func (bc bodyCapturerReadCloser) Read(p []byte) (int, error) {
+	n, err := bc.originalBody.Read(p)
+	if n > 0 {
+		bc.buffer.Write(p[:n])
 	}
-	bc := BodyCapturer{
-		captureBody:  captureBody,
-		request:      req,
-		originalBody: req.Body,
-	}
-	req.Body = &readerCloser{
-		Reader: io.TeeReader(req.Body, &bc.buffer),
-		Closer: req.Body,
-	}
-	return &bc
+	return n, err
 }
 
 // BodyCapturer is returned by Tracer.CaptureHTTPRequestBody to later be
 // passed to Context.SetHTTPRequestBody.
+//
+// Calling Context.SetHTTPRequestBody will reset req.Body to its original
+// value, and invalidates the BodyCapturer.
 type BodyCapturer struct {
-	captureBody  CaptureBodyMode
-	originalBody io.ReadCloser
-	buffer       bytes.Buffer
+	captureBody CaptureBodyMode
+
+	readbuf      [bytes.MinRead]byte
+	buffer       limitedBuffer
 	request      *http.Request
+	originalBody io.ReadCloser
+}
+
+// Discard discards the body capturer: the original request body is
+// replaced, and the body capturer is returned to a pool for reuse.
+// The BodyCapturer must not be used after calling this.
+//
+// Discard has no effect if bc is nil.
+func (bc *BodyCapturer) Discard() {
+	if bc == nil {
+		return
+	}
+	bc.request.Body = bc.originalBody
+	bodyCapturerPool.Put(bc)
 }
 
 func (bc *BodyCapturer) setContext(out *model.RequestBody) bool {
@@ -123,9 +162,39 @@ func (bc *BodyCapturer) setContext(out *model.RequestBody) bool {
 	// Read the remaining body, limiting to the maximum number of bytes
 	// that could make up the truncation limit. We ignore any errors here,
 	// and just return whatever we can.
-	rem := stringLengthLimit - n
-	r := io.LimitReader(bc.originalBody, int64(4*rem))
-	remainder, _ := ioutil.ReadAll(r)
-	out.Raw = truncateString(body + string(remainder))
-	return out.Raw != ""
+	rem := utf8.UTFMax * (stringLengthLimit - n)
+	for {
+		buf := bc.readbuf[:]
+		if rem < bytes.MinRead {
+			buf = buf[:rem]
+		}
+		n, err := bc.originalBody.Read(buf)
+		if n > 0 {
+			bc.buffer.Write(buf[:n])
+			rem -= n
+		}
+		if rem == 0 || err != nil {
+			break
+		}
+	}
+	body, _ = apmstrings.Truncate(bc.buffer.String(), stringLengthLimit)
+	out.Raw = body
+	return body != ""
+}
+
+type limitedBuffer struct {
+	bytes.Buffer
+}
+
+func (b *limitedBuffer) Write(p []byte) (n int, err error) {
+	rem := (stringLengthLimit * utf8.UTFMax) - b.Len()
+	n = len(p)
+	if n > rem {
+		p = p[:rem]
+	}
+	written, err := b.Buffer.Write(p)
+	if err != nil {
+		n = written
+	}
+	return n, err
 }

--- a/capturebody_test.go
+++ b/capturebody_test.go
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/apmtest"
+)
+
+func BenchmarkBodyCapturer(b *testing.B) {
+	tracer := apmtest.NewDiscardTracer()
+	defer tracer.Close()
+	tracer.SetCaptureBody(apm.CaptureBodyAll)
+
+	req, _ := http.NewRequest("GET", "http://testing.invalid", strings.NewReader(strings.Repeat("*", 1024*1024)))
+	tx := tracer.StartTransaction("name", "type")
+
+	for i := 0; i < b.N; i++ {
+		bodyCapturer := tracer.CaptureHTTPRequestBody(req)
+		tx.Context.SetHTTPRequestBody(bodyCapturer)
+		bodyCapturer.Discard()
+	}
+}

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -99,6 +99,7 @@ func (m *middleware) handle(c echo.Context) error {
 		if tx.Sampled() {
 			setContext(&tx.Context, req, resp, body)
 		}
+		body.Discard()
 	}()
 
 	handlerErr = m.handler(c)

--- a/module/apmechov4/middleware.go
+++ b/module/apmechov4/middleware.go
@@ -101,6 +101,7 @@ func (m *middleware) handle(c echo.Context) error {
 		if tx.Sampled() {
 			setContext(&tx.Context, req, resp, body)
 		}
+		body.Discard()
 	}()
 
 	handlerErr = m.handler(c)

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -127,6 +127,7 @@ func (m *middleware) handle(c *gin.Context) {
 			e.Handled = true
 			e.Send()
 		}
+		body.Discard()
 	}()
 	c.Next()
 }

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -83,6 +83,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			h.recovery(w, req, resp, body, tx, v)
 		}
 		SetTransactionContext(tx, req, resp, body)
+		body.Discard()
 	}()
 	h.handler.ServeHTTP(w, req)
 	if resp.StatusCode == 0 {

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -55,6 +55,7 @@ func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 				opts.recovery(w, req, resp, body, tx, v)
 			}
 			apmhttp.SetTransactionContext(tx, req, resp, body)
+			body.Discard()
 		}()
 		h(w, req, p)
 		if resp.StatusCode == 0 {

--- a/module/apmrestful/filter.go
+++ b/module/apmrestful/filter.go
@@ -89,6 +89,7 @@ func (f *filter) filter(req *restful.Request, resp *restful.Response, chain *res
 			e.Send()
 		}
 		apmhttp.SetTransactionContext(tx, req.Request, httpResp, body)
+		body.Discard()
 	}()
 	chain.ProcessFilter(req, resp)
 	if httpResp.StatusCode == 0 {


### PR DESCRIPTION
We optimise apm.BodyCapturer in two ways to reduce its overhead:

- BodyCapturers are now pooled: CaptureHTTPRequestBody will
  acquire from the pool, and the new BodyCapturer.Discard method
  will release back to the pool.
- We no longer use io.TeeReader to read into a bytes.Buffer,
  as that may lead to reading the entire request body into
  memory. Since we truncate the captured body anyway, we now
  copy only a limited amount into a buffer.

Fixes elastic/apm-agent-go#580 