### PR TITLE
Don't send context for non-sampled transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Add support for extracting UUID-like container IDs (#577)
  - Introduce transaction/span breakdown metrics (#564)
  - Optimised HTTP request body capture (#592)
+ - Fixed transaction encoding to drop tags (and other context) for non-sampled transactions (#593)
 
 ## [v1.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.4.0)
 


### PR DESCRIPTION
Fix transaction encoding to drop any accumulated
context for non-sampled transactions.

We've been relying on instrumentation to not
set context for non-sampled transactions. If
some instrumentation (e.g. custom code) sets
context, it still shouldn't be sent to the
server for non-sampled transactions.

Closes #583 