### PR TITLE
scripts/jenkins: fix benchmark script

### DIFF
--- a/scripts/jenkins/bench.sh
+++ b/scripts/jenkins/bench.sh
@@ -6,9 +6,10 @@ echo "Installing ${GO_VERSION} with gimme."
 eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
 
 go get -v -u github.com/jstemmer/go-junit-report
-go get -v -t ./...
 
+export GOFLAGS='-run=NONE -benchmem -bench=.'
 export OUT_FILE="build/bench.out"
 mkdir -p build
-go test -run=NONE -benchmem -bench=. ./... -v 2>&1 | tee ${OUT_FILE}
+
+make install test | tee ${OUT_FILE}
 go-junit-report < ${OUT_FILE} > build/junit-apm-agent-go-bench.xml


### PR DESCRIPTION
When we changed to using Go modules under Jenkins,
benchmarks stopped being run for modules other than
the top-level module due to how "go test ./..." works.

This change switches the benchmarks to using "make test",
passing flags to "go test" via the GOFLAGS environment
variable.