### PR TITLE
Introduce `ELASTIC_APM_BREAKDOWN_METRICS` config

### DIFF
--- a/breakdown_test.go
+++ b/breakdown_test.go
@@ -146,9 +146,9 @@ func TestBreakdownMetrics_TransactionDropped(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-func TestBreakdownMetrics_SelfTimeDisabled(t *testing.T) {
-	os.Setenv("ELASTIC_APM_DISABLE_METRICS", "span.self_time")
-	defer os.Unsetenv("ELASTIC_APM_DISABLE_METRICS")
+func TestBreakdownMetrics_Disabled(t *testing.T) {
+	os.Setenv("ELASTIC_APM_BREAKDOWN_METRICS", "false")
+	defer os.Unsetenv("ELASTIC_APM_BREAKDOWN_METRICS")
 
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -395,6 +395,18 @@ Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default.
 Prefixing a pattern with `(?-i)` makes the matching case sensitive.
 
 [float]
+[[config-breakdown-metrics]]
+=== `ELASTIC_APM_BREAKDOWN_METRICS`
+
+[options="header"]
+|============
+| Environment                     | Default
+| `ELASTIC_APM_BREAKDOWN_METRICS` | `true`
+|============
+
+Capture breakdown metrics. Set to `false` to disable.
+
+[float]
 [[config-server-cert]]
 === `ELASTIC_APM_SERVER_CERT`
 

--- a/env.go
+++ b/env.go
@@ -52,6 +52,7 @@ const (
 	envGlobalLabels          = "ELASTIC_APM_GLOBAL_LABELS"
 	envStackTraceLimit       = "ELASTIC_APM_STACK_TRACE_LIMIT"
 	envCentralConfig         = "ELASTIC_APM_CENTRAL_CONFIG"
+	envBreakdownMetrics      = "ELASTIC_APM_BREAKDOWN_METRICS"
 
 	defaultAPIRequestSize        = 750 * configutil.KByte
 	defaultAPIRequestTime        = 10 * time.Second
@@ -255,4 +256,8 @@ func initialStackTraceLimit() (int, error) {
 
 func initialCentralConfigEnabled() (bool, error) {
 	return configutil.ParseBoolEnv(envCentralConfig, true)
+}
+
+func initialBreakdownMetricsEnabled() (bool, error) {
+	return configutil.ParseBoolEnv(envBreakdownMetrics, true)
 }

--- a/transaction.go
+++ b/transaction.go
@@ -100,7 +100,7 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	tx.Context.captureHeaders = t.captureHeaders
 	t.captureHeadersMu.RUnlock()
 
-	tx.breakdownMetricsEnabled = t.breakdownMetrics.flags.transactionBreakdown()
+	tx.breakdownMetricsEnabled = t.breakdownMetrics.enabled
 
 	if root {
 		t.samplerMu.RLock()


### PR DESCRIPTION
Add the ELASTIC_APM_BREAKDOWN_METRICS environment
variable, which can be used to disable breakdown metrics.

Closes elastic/apm-agent-go#597 