### PR TITLE
 module/apmgrpc: fix trace propagation vs. sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Optimised HTTP request body capture (#592)
  - Fixed transaction encoding to drop tags (and other context) for non-sampled transactions (#593)
  - Introduce central config polling (#591)
+ - Fixed apmgrpc client interceptor, propagating trace context for non-sampled transactions (#602)
 
 ## [v1.4.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.4.0)
 

--- a/apmtest/withtransaction.go
+++ b/apmtest/withtransaction.go
@@ -19,11 +19,9 @@ package apmtest
 
 import (
 	"context"
-	"fmt"
 
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/model"
-	"go.elastic.co/apm/transport/transporttest"
 )
 
 // WithTransaction is equivalent to calling WithTransactionOptions with a zero TransactionOptions.
@@ -35,18 +33,7 @@ func WithTransaction(f func(ctx context.Context)) (model.Transaction, []model.Sp
 // and transaction options, flushes the transaction to a test server, and returns
 // the decoded transaction and any associated spans and errors.
 func WithTransactionOptions(opts apm.TransactionOptions, f func(ctx context.Context)) (model.Transaction, []model.Span, []model.Error) {
-	tracer, transport := transporttest.NewRecorderTracer()
+	tracer := NewRecordingTracer()
 	defer tracer.Close()
-
-	tx := tracer.StartTransactionOptions("name", "type", opts)
-	ctx := apm.ContextWithTransaction(context.Background(), tx)
-	f(ctx)
-
-	tx.End()
-	tracer.Flush(nil)
-	payloads := transport.Payloads()
-	if n := len(payloads.Transactions); n != 1 {
-		panic(fmt.Errorf("expected 1 transaction, got %d", n))
-	}
-	return payloads.Transactions[0], payloads.Spans, payloads.Errors
+	return tracer.WithTransactionOptions(opts, f)
 }


### PR DESCRIPTION
Fix a bug in the client interceptor which would break
trace propagation when facing dropped spans or non-sampled
transactions. In these cases we should propagate the
transaction's trace context, rather than sending nothing
in the outgoing metadata which would restart tracing.

Fixes #601 