### PR TITLE
Module/apmhttp/client with request name option

### DIFF
--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -180,6 +180,10 @@ type ClientOption func(*roundTripper)
 // WithClientRequestName returns a ClientOption which sets r as the function
 // to use to obtain the transaction name for the given http request.
 func WithClientRequestName(r RequestNameFunc) ClientOption {
+	if r == nil {
+		panic("r == nil")
+	}
+
 	return ClientOption(func(rt *roundTripper) {
 		rt.requestName = r
 	})

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -178,7 +178,7 @@ func (b *responseBody) endSpan() {
 type ClientOption func(*roundTripper)
 
 // WithClientRequestName returns a ClientOption which sets r as the function
-// to use to obtain the transaction name for the given http request.
+// to use to obtain the span name for the given http request.
 func WithClientRequestName(r RequestNameFunc) ClientOption {
 	if r == nil {
 		panic("r == nil")

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -176,3 +176,11 @@ func (b *responseBody) endSpan() {
 
 // ClientOption sets options for tracing client requests.
 type ClientOption func(*roundTripper)
+
+// WithClientRequestName returns a ClientOption which sets r as the function
+// to use to obtain the transaction name for the given http request.
+func WithClientRequestName(r RequestNameFunc) ClientOption {
+	return ClientOption(func(rt *roundTripper) {
+		rt.requestName = r
+	})
+}


### PR DESCRIPTION
I have not found a way to change the default function "request name" in the middleware for HTTP client.