### PR TITLE
Added WithClientRequestName function

### DIFF
--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -176,3 +176,15 @@ func (b *responseBody) endSpan() {
 
 // ClientOption sets options for tracing client requests.
 type ClientOption func(*roundTripper)
+
+// WithClientRequestName returns a ClientOption which sets r as the function
+// to use to obtain the span name for the given http request.
+func WithClientRequestName(r RequestNameFunc) ClientOption {
+	if r == nil {
+		panic("r == nil")
+	}
+
+	return ClientOption(func(rt *roundTripper) {
+		rt.requestName = r
+	})
+}


### PR DESCRIPTION
I have not found a way to change the default function "ClientRequestName" in the middleware for HTTP client.