### PR TITLE
transport: fix watcher test again

### DIFF
--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -365,6 +365,13 @@ func TestHTTPTransportWatchConfig(t *testing.T) {
 				w.WriteHeader(http.StatusTeapot)
 				return
 			}
+		case <-time.After(10 * time.Millisecond):
+			// This is necessary in case the previous config change
+			// wasn't consumed before a new request was made. This
+			// will return to the request loop.
+			w.Header().Set("Cache-Control", "max-age=0")
+			w.WriteHeader(http.StatusNotModified)
+			return
 		case <-req.Context().Done():
 			return
 		}


### PR DESCRIPTION
If a change isn't consumed before the
timer fires again (which will be nearly
instantaneous, since max-age=0), then
the proceeding request will block waiting
before sending another response, causing
a deadlock in the test.