### PR TITLE
ci(jenkins): avoid using the any agent to skip running in the master-worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent none
   environment {
     REPO = 'apm-agent-go'
     BASE_DIR = "src/go.elastic.co/apm"
@@ -210,7 +210,7 @@ pipeline {
     }
   }
   post {
-    cleanup {
+    node('linux && immutable') {
       notifyBuildResult()
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-go'
     BASE_DIR = "src/go.elastic.co/apm"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,7 +210,7 @@ pipeline {
     }
   }
   post {
-    node('linux && immutable') {
+    cleanup {
       notifyBuildResult()
     }
   }


### PR DESCRIPTION
## Highlights
- When working with ephemeral workers the only agent which might be always up is the `master` one, besides the static workers if any. So far, we don't have any after moving to windows ephemeral workers.
- This will help to avoid overloading the master, although might consume another worker which will be active from the very beginning of the pipeline until the very end as the post step happens at the `stages` level.
- This particular change will help to scale up when the build queue is long but will increase a bit the wait time.
- In other words, there are three major concepts regarding the overall time:
  - Waste of time for resources during the build
  - Waste of time for resources in the queue
  - Real build time.
- This particular fix will increase the time for the first one but will reduce the time in the queue.

## Follow-ups
- We might need to work on reducing the waste of time for resources during the build if required but let's say, for now, we can keep it simple with this particular fix.