### PR TITLE
fix: set GOSUMDB off

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-go-codecov'
     GO111MODULE = 'on'
     GOPROXY = 'https://proxy.golang.org'
+    GOSUMDB = 'off'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
   }


### PR DESCRIPTION
Disable a new feature on `go 1.13` that it is failing in the CI

closses https://github.com/elastic/apm-agent-go/issues/630