### PR TITLE
Report error causes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - module/apmhttp: add WithPanicPropagation function (#611)
  - module/apmgoredis: add Client.RedisClient (#613)
  - Introduce apm.TraceFormatter, for formatting trace IDs (#635)
+ - Report error cause(s), add support for errors.Unwrap (#638)
 
 ## [v1.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.5.0)
 

--- a/error_go113_test.go
+++ b/error_go113_test.go
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.13
+
+package apm_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm/transport/transporttest"
+)
+
+func TestErrorCauseUnwrap(t *testing.T) {
+	err := fmt.Errorf("%w", errors.New("cause"))
+
+	tracer, recorder := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+	tracer.NewError(err).Send()
+	tracer.Flush(nil)
+
+	payloads := recorder.Payloads()
+	require.Len(t, payloads.Errors, 1)
+	assert.Equal(t, "TestErrorCauseUnwrap", payloads.Errors[0].Culprit)
+
+	require.Len(t, payloads.Errors[0].Exception.Cause, 1)
+	assert.Equal(t, "cause", payloads.Errors[0].Exception.Cause[0].Message)
+}

--- a/internal/apmschema/jsonschema/errors/error.json
+++ b/internal/apmschema/jsonschema/errors/error.json
@@ -4,7 +4,7 @@
     "description": "An error or a logged error message captured by an agent occurring in a monitored service",
     "allOf": [
         { "$ref": "../timestamp_epoch.json" },
-        {  
+        {
             "properties": {
                 "id": {
                     "type": ["string"],
@@ -12,7 +12,7 @@
                     "maxLength": 1024
                 },
                 "trace_id": {
-                    "description": "Hex encoded 128 random bits ID of the correlated trace. Must be present if transaction_id and parent_id are set.", 
+                    "description": "Hex encoded 128 random bits ID of the correlated trace. Must be present if transaction_id and parent_id are set.",
                     "type": ["string", "null"],
                     "maxLength": 1024
                 },
@@ -22,7 +22,7 @@
                     "maxLength": 1024
                 },
                 "parent_id": {
-                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Must be present if trace_id and transaction_id are set.", 
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Must be present if trace_id and transaction_id are set.",
                     "type": ["string", "null"],
                     "maxLength": 1024
                 },
@@ -84,6 +84,15 @@
                         "handled": {
                             "type": ["boolean", "null"],
                             "description": "Indicator whether the error was caught somewhere in the code or not."
+                        },
+                        "cause": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "type": ["object", "null"],
+                                "description": "Recursive exception object"
+                            },
+                            "minItems": 0,
+                            "description": "Exception tree"
                         }
                     },
                     "anyOf": [

--- a/internal/apmschema/jsonschema/metricsets/metricset.json
+++ b/internal/apmschema/jsonschema/metricsets/metricset.json
@@ -20,72 +20,6 @@
                             "$ref": "sample.json"
                         }
                     },
-                    "properties": {
-                        "transaction": {
-                            "type": ["object", "null"],
-                            "properties": {
-                                "duration": {
-                                    "type": ["object", "null"],
-                                    "properties": {
-                                        "count": {
-                                            "type": ["number", "null"]
-                                        },
-                                        "sum": {
-                                            "type": ["object", "null"],
-                                            "properties": {
-                                                "us": {
-                                                    "type": ["number", "null"]
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "breakdown": {
-                                    "type": ["object", "null"],
-                                    "properties": {
-                                        "count": {
-                                            "type": ["number", "null"]
-                                        }
-                                    }
-                                },
-                                "self_time": {
-                                    "type": ["object", "null"],
-                                    "properties": {
-                                        "count": {
-                                            "type": ["number", "null"]
-                                        },
-                                        "sum": {
-                                            "type": ["object", "null"],
-                                            "properties": {
-                                                "us": {
-                                                    "type": ["number", "null"]
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "span": {
-                            "type": ["object", "null"],
-                            "self_time": {
-                                "type": ["object", "null"],
-                                "properties": {
-                                    "count": {
-                                        "type":  ["number", "null"]
-                                    },
-                                    "sum": {
-                                        "type": ["object", "null"],
-                                        "properties": {
-                                            "us": {
-                                                "type": ["number", "null"]
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
                     "additionalProperties": false
                 },
                 "tags": {
@@ -93,7 +27,6 @@
                 }
             },
             "required": ["samples"]
-        },
-        {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}}
+        }
     ]
 }

--- a/internal/apmschema/jsonschema/spans/span.json
+++ b/internal/apmschema/jsonschema/spans/span.json
@@ -6,7 +6,7 @@
         { "$ref": "../timestamp_epoch.json" },
         { "$ref": "../span_type.json" },
         { "$ref": "../span_subtype.json" },
-        {  
+        {
             "properties": {
                 "id": {
                     "description": "Hex encoded 64 random bits ID of the span.",
@@ -15,16 +15,16 @@
                 },
                 "transaction_id": {
                     "type": ["string", "null"],
-                    "description": "Hex encoded 64 random bits ID of the correlated transaction.", 
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction.",
                     "maxLength": 1024
                 },
                 "trace_id": {
-                    "description": "Hex encoded 128 random bits ID of the correlated trace.", 
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.",
                     "type": "string",
                     "maxLength": 1024
                 },
                 "parent_id": {
-                    "description": "Hex encoded 64 random bits ID of the parent transaction or span.", 
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span.",
                     "type": "string",
                     "maxLength": 1024
                 },
@@ -48,6 +48,11 @@
                                 "instance": {
                                     "type": ["string", "null"],
                                     "description": "Database instance name"
+                                },
+                                "link": {
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024,
+                                    "description": "Database link"
                                 },
                                 "statement": {
                                     "type": ["string", "null"],

--- a/internal/apmschema/jsonschema/system.json
+++ b/internal/apmschema/jsonschema/system.json
@@ -9,7 +9,17 @@
             "maxLength": 1024
         },
         "hostname": {
-            "description": "Hostname of the system the agent is running on.",
+            "description": "Deprecated. Hostname of the system the agent is running on. Will be ignored if kubernetes information is set.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "detected_hostname": {
+            "description": "Hostname of the host the monitored service is running on. It normally contains what the hostname command returns on the host machine. Will be ignored if kubernetes information is set, otherwise should always be set.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "configured_hostname": {
+            "description": "Name of the host the monitored service is running on. It should only be set when configured by the user. If empty, will be set to detected_hostname or derived from kubernetes information if provided.",
             "type": ["string", "null"],
             "maxLength": 1024
         },

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -771,6 +771,19 @@ func (v *Exception) MarshalFastJSON(w *fastjson.Writer) error {
 		}
 		w.RawByte('}')
 	}
+	if v.Cause != nil {
+		w.RawString(",\"cause\":")
+		w.RawByte('[')
+		for i, v := range v.Cause {
+			if i != 0 {
+				w.RawByte(',')
+			}
+			if err := v.MarshalFastJSON(w); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		w.RawByte(']')
+	}
 	if !v.Code.isZero() {
 		w.RawString(",\"code\":")
 		if err := v.Code.MarshalFastJSON(w); err != nil && firstErr == nil {

--- a/model/model.go
+++ b/model/model.go
@@ -396,6 +396,9 @@ type Exception struct {
 
 	// Handled indicates whether or not the error was caught and handled.
 	Handled bool `json:"handled"`
+
+	// Cause holds the causes of this error.
+	Cause []Exception `json:"cause,omitempty"`
 }
 
 // ExceptionCode represents an exception code as either a number or a string.

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -168,30 +168,58 @@ func (w *modelWriter) buildModelError(out *model.Error, e *ErrorData) {
 		}
 	}
 
+	// Create model stacktrace frames, and set the context.
 	w.modelStacktrace = w.modelStacktrace[:0]
-	if len(e.stacktrace) != 0 {
-		w.modelStacktrace = appendModelStacktraceFrames(w.modelStacktrace, e.stacktrace)
-		w.setStacktraceContext(w.modelStacktrace)
+	var appendModelErrorStacktraceFrames func(exception *exceptionData)
+	appendModelErrorStacktraceFrames = func(exception *exceptionData) {
+		if len(exception.stacktrace) != 0 {
+			w.modelStacktrace = appendModelStacktraceFrames(w.modelStacktrace, exception.stacktrace)
+		}
+		for _, cause := range exception.cause {
+			appendModelErrorStacktraceFrames(&cause)
+		}
 	}
+	appendModelErrorStacktraceFrames(&e.exception)
+	if len(e.logStacktrace) != 0 {
+		w.modelStacktrace = appendModelStacktraceFrames(w.modelStacktrace, e.logStacktrace)
+	}
+	w.setStacktraceContext(w.modelStacktrace)
 
+	var modelStacktraceOffset int
 	if e.exception.message != "" {
-		out.Exception = model.Exception{
-			Message: e.exception.message,
-			Code: model.ExceptionCode{
-				String: e.exception.Code.String,
-				Number: e.exception.Code.Number,
-			},
-			Type:       e.exception.Type.Name,
-			Module:     e.exception.Type.PackagePath,
-			Handled:    e.Handled,
-			Stacktrace: w.modelStacktrace[:e.exceptionStacktraceFrames],
+		var buildException func(exception *exceptionData) model.Exception
+		culprit := e.Culprit
+		buildException = func(exception *exceptionData) model.Exception {
+			out := model.Exception{
+				Message: exception.message,
+				Code: model.ExceptionCode{
+					String: exception.Code.String,
+					Number: exception.Code.Number,
+				},
+				Type:    exception.Type.Name,
+				Module:  exception.Type.PackagePath,
+				Handled: e.Handled,
+			}
+			if n := len(exception.stacktrace); n != 0 {
+				out.Stacktrace = w.modelStacktrace[modelStacktraceOffset : modelStacktraceOffset+n]
+				modelStacktraceOffset += n
+			}
+			if len(exception.attrs) != 0 {
+				out.Attributes = exception.attrs
+			}
+			if n := len(exception.cause); n > 0 {
+				out.Cause = make([]model.Exception, n)
+				for i := range exception.cause {
+					out.Cause[i] = buildException(&exception.cause[i])
+				}
+			}
+			if culprit == "" {
+				culprit = stacktraceCulprit(out.Stacktrace)
+			}
+			return out
 		}
-		if len(e.exception.attrs) != 0 {
-			out.Exception.Attributes = e.exception.attrs
-		}
-		if out.Culprit == "" {
-			out.Culprit = stacktraceCulprit(out.Exception.Stacktrace)
-		}
+		out.Exception = buildException(&e.exception)
+		out.Culprit = culprit
 	}
 	if e.log.Message != "" {
 		out.Log = model.Log{
@@ -199,10 +227,13 @@ func (w *modelWriter) buildModelError(out *model.Error, e *ErrorData) {
 			Level:        e.log.Level,
 			LoggerName:   e.log.LoggerName,
 			ParamMessage: e.log.MessageFormat,
-			Stacktrace:   w.modelStacktrace[e.exceptionStacktraceFrames:],
 		}
-		if out.Culprit == "" {
-			out.Culprit = stacktraceCulprit(out.Log.Stacktrace)
+		if n := len(e.logStacktrace); n != 0 {
+			out.Log.Stacktrace = w.modelStacktrace[modelStacktraceOffset : modelStacktraceOffset+n]
+			modelStacktraceOffset += n
+			if out.Culprit == "" {
+				out.Culprit = stacktraceCulprit(out.Log.Stacktrace)
+			}
 		}
 	}
 	out.Culprit = truncateString(out.Culprit)

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -15,6 +15,13 @@ if (! go run scripts/mingoversion.go 1.10 &>/dev/null); then
     git clone https://github.com/gin-gonic/gin &&
     cd gin && git checkout v1.3.0
   );
+  # Ping gocql to the latest commit that supports Go 1.9.
+  mkdir -p "${GOPATH}/src/github.com/gocql";
+  (
+    cd "${GOPATH}/src/github.com/gocql" &&
+    git clone https://github.com/gocql/gocql &&
+    cd gocql && git checkout 16cf9ea1b3e2
+  );
 fi
 
 if (! go run scripts/mingoversion.go 1.9 &>/dev/null); then

--- a/validation_test.go
+++ b/validation_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/pkg/errors"
 	"github.com/santhosh-tekuri/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -252,6 +253,17 @@ func TestValidateErrorException(t *testing.T) {
 			}).Send()
 		})
 	})
+	t.Run("chained", func(t *testing.T) {
+		validatePayloads(t, func(tracer *apm.Tracer) {
+			tracer.NewError(&testError{
+				message: "e1",
+				cause: &testError{
+					message: "e2",
+					cause:   errors.New("hullo"),
+				},
+			}).Send()
+		})
+	})
 }
 
 func TestValidateErrorLog(t *testing.T) {
@@ -430,6 +442,7 @@ type testError struct {
 	message string
 	code    string
 	type_   string
+	cause   error
 }
 
 func (e *testError) Error() string {
@@ -442,4 +455,8 @@ func (e *testError) Code() string {
 
 func (e *testError) Type() string {
 	return e.type_
+}
+
+func (e *testError) Cause() error {
+	return e.cause
 }


### PR DESCRIPTION
We will now report complete error trees in
error.exception: the top-most exception is
the provided error, and any cause/wrapped
error will be reported in an array of causes
to the server.

We will only report at most 50 errors in a tree,
and we break cycles by just ignoring references
to previously seen errors.

The error culprit will now be calculated by
traversing the tree depth-first, returning
the first non-library frame's function name.
This will resolve issues such as #632, where
an error with a complete stack trace is
wrapped by one with only a limited stack trace.

Closes #423 