### PR TITLE
ELASTIC_APM_TRANSACTION_MAX_SPANS=0 disables spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - module/apmgoredis: add Client.RedisClient (#613)
  - Introduce apm.TraceFormatter, for formatting trace IDs (#635)
  - Report error cause(s), add support for errors.Unwrap (#638)
+ - Setting `ELASTIC_APM_TRANSACTION_MAX_SPANS` to 0 now disables all spans (#640)
 
 ## [v1.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.5.0)
 

--- a/span.go
+++ b/span.go
@@ -101,7 +101,7 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 	defer tx.TransactionData.mu.Unlock()
 	if !span.traceContext.Options.Recorded() {
 		span.tracer = nil // span is dropped
-	} else if tx.maxSpans > 0 && tx.spansCreated >= tx.maxSpans {
+	} else if tx.maxSpans >= 0 && tx.spansCreated >= tx.maxSpans {
 		span.tracer = nil // span is dropped
 		tx.spansDropped++
 	} else {

--- a/tracer.go
+++ b/tracer.go
@@ -581,8 +581,10 @@ func (t *Tracer) SetSampler(s Sampler) {
 }
 
 // SetMaxSpans sets the maximum number of spans that will be added
-// to a transaction before dropping spans. If set to a non-positive
-// value, the number of spans is unlimited.
+// to a transaction before dropping spans.
+//
+// Passing in zero will disable all spans, while negative values will
+// permit an unlimited number of spans.
 func (t *Tracer) SetMaxSpans(n int) {
 	t.maxSpansMu.Lock()
 	t.maxSpans = n


### PR DESCRIPTION
Setting ELASTIC_APM_TRANSACTION_MAX_SPANS=0 now disables all spans. Negative values continue to mean that there are an unlimited number of spans.

Closes #639 