### PR TITLE
module/apmzerolog: add Writer.MinLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Introduce apm.TraceFormatter, for formatting trace IDs (#635)
  - Report error cause(s), add support for errors.Unwrap (#638)
  - Setting `ELASTIC_APM_TRANSACTION_MAX_SPANS` to 0 now disables all spans (#640)
+ - module/apmzerolog: add Writer.MinLevel (#641)
 
 ## [v1.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.5.0)
 

--- a/module/apmzerolog/writer_test.go
+++ b/module/apmzerolog/writer_test.go
@@ -116,6 +116,22 @@ func TestWriterNonError(t *testing.T) {
 	assert.Empty(t, payloads.Errors)
 }
 
+func TestWriterMinLevel(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	writer := &apmzerolog.Writer{
+		Tracer:   tracer,
+		MinLevel: zerolog.FatalLevel,
+	}
+	logger := zerolog.New(writer)
+	logger.Error().Msg("oy vey!")
+
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	assert.Empty(t, payloads.Errors)
+}
+
 func TestWriterWithError(t *testing.T) {
 	// Use our own ErrorStackMarshaler implementation,
 	// which records a fully qualified function name.


### PR DESCRIPTION
Add Writer.MinLevel, which controls the minimum
level of logs to send as errors to Elastic APM.
MinLevel must be >= zerolog.ErrorLevel, otherwise
zerolog.ErrorLevel will be used as the minimum.

Closes #636 