### PR TITLE
Ignore sql.ErrNoRows

### DIFF
--- a/module/apmgorm/apmgorm_test.go
+++ b/module/apmgorm/apmgorm_test.go
@@ -154,8 +154,8 @@ func TestCaptureErrors(t *testing.T) {
 	t.Run("sqlite3", func(t *testing.T) {
 		db, err := apmgorm.Open("sqlite3", ":memory:")
 		require.NoError(t, err)
-		testCaptureErrors(t, db)
 		defer db.Close()
+		testCaptureErrors(t, db)
 	})
 
 	if os.Getenv("PGHOST") == "" {
@@ -164,8 +164,8 @@ func TestCaptureErrors(t *testing.T) {
 		t.Run("postgres", func(t *testing.T) {
 			db, err := apmgorm.Open("postgres", "user=postgres password=hunter2 dbname=test_db sslmode=disable")
 			require.NoError(t, err)
-			testCaptureErrors(t, db)
 			defer db.Close()
+			testCaptureErrors(t, db)
 		})
 	}
 }

--- a/module/apmgorm/context.go
+++ b/module/apmgorm/context.go
@@ -21,6 +21,7 @@ package apmgorm
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/jinzhu/gorm"
@@ -141,7 +142,7 @@ func newAfterCallback(dsnInfo apmsql.DSNInfo) func(*gorm.Scope) {
 
 		// Capture errors, except for "record not found", which may be expected.
 		for _, err := range scope.DB().GetErrors() {
-			if gorm.IsRecordNotFoundError(err) {
+			if gorm.IsRecordNotFoundError(err) || err == sql.ErrNoRows {
 				continue
 			}
 			if e := apm.CaptureError(ctx, err); e != nil {


### PR DESCRIPTION
There are some cases that gorm can return sql.ErrNoRows when using with postgres and ON CONFLICT DO NOTHING RETURNING *. I think we can safely ignore this error as we're ignoring gorm.ErrRecordNotFound

Also add second argument of redis command trace to understand more clearly about the trace.