### PR TITLE
module/apmhttp: fix TestClientCancelRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  - Setting `ELASTIC_APM_TRANSACTION_MAX_SPANS` to 0 now disables all spans (#640)
  - module/apmzerolog: add Writer.MinLevel (#641)
  - Introduce SetLabel and deprecate SetTag (#642)
+ - Support central config for `ELASTIC_APM_CAPTURE_BODY` and `ELASTIC_APM_TRANSACTION_MAX_SPANS` (#648)
 
 ## [v1.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.5.0)
 


### PR DESCRIPTION
Fix TestClientCancelRequest for Go master.
RoundTripper.CancelRequest is no longer guaranteed
to be called after RoundTrip returns.