### PR TITLE
Implement ELASTIC_APM_SERVICE_NODE_NAME config

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -140,6 +140,24 @@ A version string for the currently deployed version of the service.
 If you don't version your deployments, the recommended value for this field is the commit identifier
 of the deployed revision, e.g. the output of `git rev-parse HEAD`.
 
+[[float]
+[[config-service-node-name]]
+=== `ELASTIC_APM_SERVICE_NODE_NAME`
+
+[options="header"]
+|============
+| Environment                     | Default | Example
+| `ELASTIC_APM_SERVICE_NODE_NAME` |         | `my-node-name`
+|============
+
+Optional name used to differentiate between nodes in a service. 
+Must be unique, otherwise data from multiple nodes will be aggregated together.
+
+If you do not specify `ELASTIC_APM_SERVICE_NODE_NAME`, services will be identified using the container ID if available, 
+otherwise the host name.
+
+NOTE: This feature is fully supported in the APM Server versions >= 7.5.
+
 [float]
 [[config-environment]]
 === `ELASTIC_APM_ENVIRONMENT`

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -153,7 +153,7 @@ of the deployed revision, e.g. the output of `git rev-parse HEAD`.
 Optional name used to differentiate between nodes in a service. 
 Must be unique, otherwise data from multiple nodes will be aggregated together.
 
-If you do not specify `ELASTIC_APM_SERVICE_NODE_NAME`, services will be identified using the container ID if available, 
+If you do not specify `ELASTIC_APM_SERVICE_NODE_NAME`, service nodes will be identified using the container ID if available, 
 otherwise the host name.
 
 NOTE: This feature is fully supported in the APM Server versions >= 7.5.

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -15,6 +15,10 @@ on your hosts.
 
 As of Elastic Stack version 6.6, these metrics will be visualized in the APM UI.
 
+In some cases data from multiple nodes will be combined. As of Elastic Stack version 7.5, 
+you will be able to set a unique name for each node to avoid this problem. 
+Otherwise, data will be aggregated separately based on container ID or host name.
+
 *`system.cpu.total.norm.pct`*::
 +
 --

--- a/env_test.go
+++ b/env_test.go
@@ -386,3 +386,8 @@ func TestTracerCaptureHeadersEnv(t *testing.T) {
 	assert.Nil(t, tx.Context.Request.Headers)
 	assert.Nil(t, tx.Context.Response.Headers)
 }
+
+func TestServiceNodeNameEnvSpecified(t *testing.T) {
+	_, _, service, _ := getSubprocessMetadata(t, "ELASTIC_APM_SERVICE_NODE_NAME=foo_bar")
+	assert.Equal(t, "foo_bar", service.ServiceNode.ConfiguredName)
+}

--- a/env_test.go
+++ b/env_test.go
@@ -389,5 +389,5 @@ func TestTracerCaptureHeadersEnv(t *testing.T) {
 
 func TestServiceNodeNameEnvSpecified(t *testing.T) {
 	_, _, service, _ := getSubprocessMetadata(t, "ELASTIC_APM_SERVICE_NODE_NAME=foo_bar")
-	assert.Equal(t, "foo_bar", service.ServiceNode.ConfiguredName)
+	assert.Equal(t, "foo_bar", service.Node.ConfiguredName)
 }

--- a/internal/apmschema/jsonschema/service.json
+++ b/internal/apmschema/jsonschema/service.json
@@ -81,6 +81,16 @@
             "description": "Version of the service emitting this event",
             "type": ["string", "null"],
             "maxLength": 1024
+        },
+        "node": {
+            "description": "Unique meaningful name of the service node.",
+            "type": ["object", "null"],
+            "properties": {
+                "configured_name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
         }
     }
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -95,7 +95,7 @@ func (v *Service) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
-	if v.ServiceNode != nil {
+	if v.Node != nil {
 		const prefix = ",\"node\":"
 		if first {
 			first = false
@@ -103,7 +103,7 @@ func (v *Service) MarshalFastJSON(w *fastjson.Writer) error {
 		} else {
 			w.RawString(prefix)
 		}
-		if err := v.ServiceNode.MarshalFastJSON(w); err != nil && firstErr == nil {
+		if err := v.Node.MarshalFastJSON(w); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -83,18 +83,6 @@ func (v *Service) MarshalFastJSON(w *fastjson.Writer) error {
 		}
 		w.String(v.Name)
 	}
-	if v.Runtime != nil {
-		const prefix = ",\"runtime\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		if err := v.Runtime.MarshalFastJSON(w); err != nil && firstErr == nil {
-			firstErr = err
-		}
-	}
 	if v.Node != nil {
 		const prefix = ",\"node\":"
 		if first {
@@ -104,6 +92,18 @@ func (v *Service) MarshalFastJSON(w *fastjson.Writer) error {
 			w.RawString(prefix)
 		}
 		if err := v.Node.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if v.Runtime != nil {
+		const prefix = ",\"runtime\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.Runtime.MarshalFastJSON(w); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -95,6 +95,18 @@ func (v *Service) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
+	if v.ServiceNode != nil {
+		const prefix = ",\"node\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.ServiceNode.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if v.Version != "" {
 		const prefix = ",\"version\":"
 		if first {
@@ -147,6 +159,16 @@ func (v *Runtime) MarshalFastJSON(w *fastjson.Writer) error {
 	w.String(v.Name)
 	w.RawString(",\"version\":")
 	w.String(v.Version)
+	w.RawByte('}')
+	return nil
+}
+
+func (v *ServiceNode) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	if v.ConfiguredName != "" {
+		w.RawString("\"configured_name\":")
+		w.String(v.ConfiguredName)
+	}
 	w.RawByte('}')
 	return nil
 }

--- a/model/model.go
+++ b/model/model.go
@@ -49,6 +49,9 @@ type Service struct {
 	// Runtime holds information about the programming language runtime
 	// running this service.
 	Runtime *Runtime `json:"runtime,omitempty"`
+
+	// ServiceNode holds unique information about each service node
+	ServiceNode *ServiceNode `json:"node,omitempty"`
 }
 
 // Agent holds information about the Elastic APM agent.
@@ -86,6 +89,12 @@ type Runtime struct {
 
 	// Version is the version of the programming language runtime.
 	Version string `json:"version"`
+}
+
+// ServiceNode holds unique information about each service node
+type ServiceNode struct {
+	// ConfiguredName holds the name of the service node
+	ConfiguredName string `json:"configured_name,omitempty"`
 }
 
 // System represents the system (operating system and machine) running the

--- a/model/model.go
+++ b/model/model.go
@@ -50,8 +50,8 @@ type Service struct {
 	// running this service.
 	Runtime *Runtime `json:"runtime,omitempty"`
 
-	// ServiceNode holds unique information about each service node
-	ServiceNode *ServiceNode `json:"node,omitempty"`
+	// Node holds unique information about each service node
+	Node *ServiceNode `json:"node,omitempty"`
 }
 
 // Agent holds information about the Elastic APM agent.

--- a/utils.go
+++ b/utils.go
@@ -97,7 +97,7 @@ func makeService(name, version, environment string) model.Service {
 
 	serviceNodeName := os.Getenv(envServiceNodeName)
 	if serviceNodeName != "" {
-		service.ServiceNode = &model.ServiceNode{ConfiguredName: truncateString(serviceNodeName)}
+		service.Node = &model.ServiceNode{ConfiguredName: truncateString(serviceNodeName)}
 	}
 
 	return service

--- a/utils.go
+++ b/utils.go
@@ -50,7 +50,8 @@ var (
 )
 
 const (
-	envHostname = "ELASTIC_APM_HOSTNAME"
+	envHostname        = "ELASTIC_APM_HOSTNAME"
+	envServiceNodeName = "ELASTIC_APM_SERVICE_NODE_NAME"
 
 	serviceNameValidClass = "a-zA-Z0-9 _-"
 
@@ -85,7 +86,7 @@ func getCurrentProcess() model.Process {
 }
 
 func makeService(name, version, environment string) model.Service {
-	return model.Service{
+	service := model.Service{
 		Name:        truncateString(name),
 		Version:     truncateString(version),
 		Environment: truncateString(environment),
@@ -93,6 +94,13 @@ func makeService(name, version, environment string) model.Service {
 		Language:    &goLanguage,
 		Runtime:     &goRuntime,
 	}
+
+	serviceNodeName := os.Getenv(envServiceNodeName)
+	if serviceNodeName != "" {
+		service.ServiceNode = &model.ServiceNode{ConfiguredName: truncateString(serviceNodeName)}
+	}
+
+	return service
 }
 
 func getLocalSystem() model.System {


### PR DESCRIPTION
Adds an optional `ELASTIC_APM_SERVICE_NODE_NAME` config to the agent, along with relevant documentation.

Things to note:
 - I ran the `apmschema/update.sh` script, and a lot more things were changed rather than just the expected additions in `service.json`. Is this expected? Should I modify the script to only generate changes in the relevant file?
- I was unable to use `go generate` to generate the `model/marshal_fastjson.go` file (I manually edited the file just so I could get unstuck 😄 ). 
  After I pulled the `fastjson` repo and ran the generate command all I kept getting was a strange modules error (I am able to run the tests and everything else just fine):

```console
karen$ go generate
2019/10/13 18:55:45 /Users/karen/go/src/github.com/karencfv/apm-agent-go/model/marshal.go:29:2: could not import github.com/pkg/errors (can't find import: "github.com/pkg/errors")
exit status 1
marshal.go:34: running "sh": exit status 1
```

  I tried several things, but was unsuccessful in getting it to work. Have you come across this? Do you have any ideas on how to get it to work so I can get rid of my handcrafted code in `model/marshal_fastjson.go`?

Closes: https://github.com/elastic/apm-agent-go/issues/634