### PR TITLE
Add span.context.destination.*

### DIFF
--- a/internal/apmhttputil/remoteaddr.go
+++ b/internal/apmhttputil/remoteaddr.go
@@ -19,10 +19,42 @@ package apmhttputil
 
 import (
 	"net/http"
+	"strconv"
 )
 
-// RemoteAddr returns the remote (peer) socket address for the HTTP request.
+// RemoteAddr returns the remote (peer) socket address for req,
+// a server HTTP request.
 func RemoteAddr(req *http.Request) string {
 	remoteAddr, _ := splitHost(req.RemoteAddr)
 	return remoteAddr
+}
+
+// DestinationAddr returns the destination server address and port
+// for req, a client HTTP request.
+//
+// If req.URL.Host contains a port it will be returned, and otherwise
+// the default port according to req.URL.Scheme will be returned. If
+// the included port is not a valid integer, or no port is included
+// and the scheme is unknown, the returned port value will be zero.
+func DestinationAddr(req *http.Request) (string, int) {
+	host, strport := splitHost(req.URL.Host)
+	var port int
+	if strport != "" {
+		port, _ = strconv.Atoi(strport)
+	} else {
+		port = SchemeDefaultPort(req.URL.Scheme)
+	}
+	return host, port
+}
+
+// SchemeDefaultPort returns the default port for the given URI scheme,
+// if known, or 0 otherwise.
+func SchemeDefaultPort(scheme string) int {
+	switch scheme {
+	case "http":
+		return 80
+	case "https":
+		return 443
+	}
+	return 0
 }

--- a/internal/apmhttputil/url.go
+++ b/internal/apmhttputil/url.go
@@ -98,6 +98,9 @@ func splitHost(in string) (host, port string) {
 	}
 	host, port, err := net.SplitHostPort(in)
 	if err != nil {
+		if n := len(in); n > 1 && in[0] == '[' && in[n-1] == ']' {
+			in = in[1 : n-1]
+		}
 		return in, ""
 	}
 	return host, port

--- a/internal/apmschema/jsonschema/request.json
+++ b/internal/apmschema/jsonschema/request.json
@@ -43,6 +43,7 @@
                     "type": ["boolean", "null"]
                 },
                 "remote_address": {
+                    "description": "The network address sending the request. Should be obtained through standard APIs and not parsed from any headers like 'Forwarded'.",
                     "type": ["string", "null"]
                 }
             }

--- a/internal/apmschema/jsonschema/spans/span.json
+++ b/internal/apmschema/jsonschema/spans/span.json
@@ -41,6 +41,43 @@
                     "type": ["object", "null"],
                     "description": "Any other arbitrary data captured by the agent, optionally provided by the user",
                     "properties": {
+                        "destination": {
+                            "type": ["object", "null"],
+                            "description": "An object containing contextual data about the destination for spans",
+                            "properties": {
+                                "address": {
+                                    "type": ["string", "null"],
+                                    "description": "Destination network address: hostname (e.g. 'localhost'), FQDN (e.g. 'elastic.co'), IPv4 (e.g. '127.0.0.1') or IPv6 (e.g. '::1')",
+                                    "maxLength": 1024
+                                },
+                                "port": {
+                                    "type": ["integer", "null"],
+                                    "description": "Destination network port (e.g. 443)"
+                                },
+                                "service": {
+                                    "description": "Destination service context",
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                        "type": {
+                                            "description": "Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type.",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        },
+                                        "name": {
+                                            "description": "Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq')",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        },
+                                        "resource": {
+                                            "description": "Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        }
+                                    },
+				    "required": ["type", "name", "resource"]
+                                }
+                            }
+                        },
                         "db": {
                             "type": ["object", "null"],
                             "description": "An object containing contextual data for database spans",

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -486,6 +486,18 @@ func (v *SpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
+	if v.Destination != nil {
+		const prefix = ",\"destination\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.Destination.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if v.HTTP != nil {
 		const prefix = ",\"http\":"
 		if first {
@@ -512,6 +524,83 @@ func (v *SpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 	}
 	w.RawByte('}')
 	return firstErr
+}
+
+func (v *DestinationSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
+	w.RawByte('{')
+	first := true
+	if v.Address != "" {
+		const prefix = ",\"address\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Address)
+	}
+	if v.Port != 0 {
+		const prefix = ",\"port\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.Int64(int64(v.Port))
+	}
+	if v.Service != nil {
+		const prefix = ",\"service\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.Service.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	w.RawByte('}')
+	return firstErr
+}
+
+func (v *DestinationServiceSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	first := true
+	if v.Name != "" {
+		const prefix = ",\"name\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Name)
+	}
+	if v.Resource != "" {
+		const prefix = ",\"resource\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Resource)
+	}
+	if v.Type != "" {
+		const prefix = ",\"type\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Type)
+	}
+	w.RawByte('}')
+	return nil
 }
 
 func (v *DatabaseSpanContext) MarshalFastJSON(w *fastjson.Writer) error {

--- a/model/model.go
+++ b/model/model.go
@@ -263,6 +263,9 @@ type Span struct {
 
 // SpanContext holds contextual information relating to the span.
 type SpanContext struct {
+	// Destination holds information about a destination service.
+	Destination *DestinationSpanContext `json:"destination,omitempty"`
+
 	// Database holds contextual information for database
 	// operation spans.
 	Database *DatabaseSpanContext `json:"db,omitempty"`
@@ -272,6 +275,34 @@ type SpanContext struct {
 
 	// Tags holds user-defined key/value pairs.
 	Tags IfaceMap `json:"tags,omitempty"`
+}
+
+// DestinationSpanContext holds contextual information about the destination
+// for a span that relates to an operation involving an external service.
+type DestinationSpanContext struct {
+	// Address holds the network address of the destination service.
+	// This may be a hostname, FQDN, or (IPv4 or IPv6) network address.
+	Address string `json:"address,omitempty"`
+
+	// Port holds the network port for the destination service.
+	Port int `json:"port,omitempty"`
+
+	// Service holds additional destination service context.
+	Service *DestinationServiceSpanContext `json:"service,omitempty"`
+}
+
+// DestinationServiceSpanContext holds contextual information about a
+// destination service,.
+type DestinationServiceSpanContext struct {
+	// Type holds the destination service type.
+	Type string `json:"type,omitempty"`
+
+	// Name holds the destination service name.
+	Name string `json:"name,omitempty"`
+
+	// Resource identifies the destination service
+	// resource, e.g. a URI or message queue name.
+	Resource string `json:"resource,omitempty"`
 }
 
 // DatabaseSpanContext holds contextual information for database

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -147,6 +147,11 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span, sd *SpanData) 
 	out.Duration = sd.Duration.Seconds() * 1000
 	out.Context = sd.Context.build()
 
+	// Copy the span type to context.destination.service.type.
+	if out.Context != nil && out.Context.Destination != nil && out.Context.Destination.Service != nil {
+		out.Context.Destination.Service.Type = out.Type
+	}
+
 	w.modelStacktrace = appendModelStacktraceFrames(w.modelStacktrace, sd.stacktrace)
 	out.Stacktrace = w.modelStacktrace
 	w.setStacktraceContext(out.Stacktrace)

--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -79,6 +79,10 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx = apm.ContextWithSpan(ctx, span)
 	req = apmhttp.RequestWithContext(ctx, req)
 	span.Context.SetHTTPRequest(req)
+	span.Context.SetDestinationService(apm.DestinationServiceSpanContext{
+		Name:     "elasticsearch",
+		Resource: "elasticsearch",
+	})
 	span.Context.SetDatabase(apm.DatabaseSpanContext{
 		Type:      "elasticsearch",
 		Statement: statement,

--- a/module/apmelasticsearch/internal/integration/go.mod
+++ b/module/apmelasticsearch/internal/integration/go.mod
@@ -1,6 +1,7 @@
 module go.elastic.co/apm/module/apmelasticsearch/internal/integration
 
 require (
+	github.com/elastic/go-elasticsearch/v7 v7.5.0
 	github.com/fortytw2/leaktest v1.3.0 // indirect
 	github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 // indirect
 	github.com/olivere/elastic v6.2.16+incompatible

--- a/module/apmelasticsearch/internal/integration/go.sum
+++ b/module/apmelasticsearch/internal/integration/go.sum
@@ -3,6 +3,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/elastic/go-elasticsearch/v7 v7.5.0 h1:kXW+EKls2BwsyQujTmVrxANb3U0qoz9wEq8Zkf/JEco=
+github.com/elastic/go-elasticsearch/v7 v7.5.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-sysinfo v1.0.1 h1:lzGPX2sIXaETeMXitXL2XZU8K4B7k7JBhIKWxdOdUt8=
 github.com/elastic/go-sysinfo v1.0.1/go.mod h1:O/D5m1VpYLwGjCYzEt63g3Z1uO3jXfwyzzjiW90t8cY=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=

--- a/module/apmgorm/context.go
+++ b/module/apmgorm/context.go
@@ -132,6 +132,7 @@ func newAfterCallback(dsnInfo apmsql.DSNInfo) func(*gorm.Scope) {
 			return
 		}
 		span.Name = apmsql.QuerySignature(scope.SQL)
+		span.Context.SetDestinationAddress(dsnInfo.Address, dsnInfo.Port)
 		span.Context.SetDatabase(apm.DatabaseSpanContext{
 			Instance:  dsnInfo.Database,
 			Statement: scope.SQL,

--- a/module/apmot/tracer_test.go
+++ b/module/apmot/tracer_test.go
@@ -180,6 +180,15 @@ func TestHTTPSpan(t *testing.T) {
 	assert.Equal(t, "http", modelSpan.Subtype)
 	assert.Equal(t, &model.SpanContext{
 		HTTP: &model.HTTPSpanContext{URL: url},
+		Destination: &model.DestinationSpanContext{
+			Address: "testing.invalid",
+			Port:    8443,
+			Service: &model.DestinationServiceSpanContext{
+				Type:     "external",
+				Name:     "https://testing.invalid:8443",
+				Resource: "testing.invalid:8443",
+			},
+		},
 	}, modelSpan.Context)
 }
 

--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -66,6 +66,13 @@ func (c *conn) startStmtSpan(ctx context.Context, stmt, spanType string) (*apm.S
 func (c *conn) startSpan(ctx context.Context, name, spanType, stmt string) (*apm.Span, context.Context) {
 	span, ctx := apm.StartSpan(ctx, name, spanType)
 	if !span.Dropped() {
+		if c.dsnInfo.Address != "" {
+			span.Context.SetDestinationAddress(c.dsnInfo.Address, c.dsnInfo.Port)
+			span.Context.SetDestinationService(apm.DestinationServiceSpanContext{
+				Name:     c.driver.driverName,
+				Resource: c.driver.driverName,
+			})
+		}
 		span.Context.SetDatabase(apm.DatabaseSpanContext{
 			Instance:  c.dsnInfo.Database,
 			Statement: stmt,

--- a/module/apmsql/dsn.go
+++ b/module/apmsql/dsn.go
@@ -19,6 +19,12 @@ package apmsql
 
 // DSNInfo contains information from a database-specific data source name.
 type DSNInfo struct {
+	// Address is the database server address specified by the DSN.
+	Address string
+
+	// Port is the database server port specified by the DSN.
+	Port int
+
 	// Database is the name of the specific database identified by the DSN.
 	Database string
 

--- a/module/apmsql/mysql/mysql_test.go
+++ b/module/apmsql/mysql/mysql_test.go
@@ -56,6 +56,15 @@ func TestQueryContext(t *testing.T) {
 	assert.Equal(t, "SELECT FROM foo", spans[0].Name)
 	assert.Equal(t, "mysql", spans[0].Subtype)
 	assert.Equal(t, &model.SpanContext{
+		Destination: &model.DestinationSpanContext{
+			Address: mysqlHost,
+			Port:    3306,
+			Service: &model.DestinationServiceSpanContext{
+				Type:     "db",
+				Name:     "mysql",
+				Resource: "mysql",
+			},
+		},
 		Database: &model.DatabaseSpanContext{
 			Instance:  "test_db",
 			Statement: "SELECT * FROM foo",

--- a/module/apmsql/mysql/parser.go
+++ b/module/apmsql/mysql/parser.go
@@ -18,6 +18,9 @@
 package apmmysql
 
 import (
+	"net"
+	"strconv"
+
 	"github.com/go-sql-driver/mysql"
 
 	"go.elastic.co/apm/module/apmsql"
@@ -31,7 +34,16 @@ func ParseDSN(name string) apmsql.DSNInfo {
 		// so just return a zero value.
 		return apmsql.DSNInfo{}
 	}
+	var addr string
+	var port int
+	if cfg.Net == "tcp" {
+		host, portstr, _ := net.SplitHostPort(cfg.Addr)
+		port, _ = strconv.Atoi(portstr)
+		addr = host
+	}
 	return apmsql.DSNInfo{
+		Address:  addr,
+		Port:     port,
 		Database: cfg.DBName,
 		User:     cfg.User,
 	}

--- a/module/apmsql/mysql/parser_test.go
+++ b/module/apmsql/mysql/parser_test.go
@@ -28,8 +28,24 @@ import (
 
 func TestParseDSN(t *testing.T) {
 	info := apmmysql.ParseDSN("user:pass@/dbname")
-	assert.Equal(t, "dbname", info.Database)
-	assert.Equal(t, "user", info.User)
+	assert.Equal(t, apmsql.DSNInfo{
+		Address:  "127.0.0.1",
+		Port:     3306,
+		Database: "dbname",
+		User:     "user",
+	}, info)
+}
+
+func TestParseDSNAddr(t *testing.T) {
+	test := func(dsn, addr string, port int) {
+		parsed := apmmysql.ParseDSN(dsn)
+		assert.Equal(t, addr, parsed.Address)
+		assert.Equal(t, port, parsed.Port)
+	}
+	test("user:pass@tcp(1.2.3.4)/dbname", "1.2.3.4", 3306)
+	test("user:pass@tcp(1.2.3.4:1234)/dbname", "1.2.3.4", 1234)
+	test("user:pass@tcp(::1)/dbname", "::1", 3306)
+	test("user:pass@tcp([::1]:3306)/dbname", "::1", 3306)
 }
 
 func TestParseDSNError(t *testing.T) {

--- a/module/apmsql/pq/parser_test.go
+++ b/module/apmsql/pq/parser_test.go
@@ -23,28 +23,71 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"go.elastic.co/apm/module/apmsql"
 	apmpq "go.elastic.co/apm/module/apmsql/pq"
 )
 
+func patchEnv(k, v string) func() {
+	old, reset := os.LookupEnv(k)
+	os.Setenv(k, v)
+	if reset {
+		return func() { os.Setenv(k, old) }
+	} else {
+		return func() { os.Unsetenv(k) }
+	}
+}
+
 func TestParseDSNURL(t *testing.T) {
-	info := apmpq.ParseDSN("postgresql://user:pass@localhost/dbinst")
-	assert.Equal(t, "dbinst", info.Database)
-	assert.Equal(t, "user", info.User)
+	for _, k := range []string{"PGDATABASE", "PGUSER", "PGHOST", "PGPORT"} {
+		unpatch := patchEnv(k, "")
+		defer unpatch()
+	}
+
+	test := func(url, addr string, port int) {
+		info := apmpq.ParseDSN(url)
+		assert.Equal(t, apmsql.DSNInfo{
+			Address:  addr,
+			Port:     port,
+			Database: "dbinst",
+			User:     "user",
+		}, info)
+	}
+	test("postgresql://user:pass@localhost/dbinst", "localhost", 5432)
+	test("postgresql://user:pass@localhost:5432/dbinst", "localhost", 5432)
+	test("postgresql://user:pass@localhost:5433/dbinst", "localhost", 5433)
+	test("postgresql://user:pass@127.0.0.1/dbinst", "127.0.0.1", 5432)
+	test("postgresql://user:pass@[::1]:1234/dbinst", "::1", 1234)
+	test("postgresql://user:pass@[::1]/dbinst", "::1", 5432)
+	test("postgresql://user:pass@::1/dbinst", "::1", 5432)
 }
 
 func TestParseDSNConnectionString(t *testing.T) {
+	for _, k := range []string{"PGDATABASE", "PGUSER", "PGHOST", "PGPORT"} {
+		unpatch := patchEnv(k, "")
+		defer unpatch()
+	}
 	info := apmpq.ParseDSN("dbname=foo\\ bar user='baz'")
-	assert.Equal(t, "foo bar", info.Database)
-	assert.Equal(t, "baz", info.User)
+	assert.Equal(t, apmsql.DSNInfo{
+		Address:  "localhost",
+		Port:     5432,
+		Database: "foo bar",
+		User:     "baz",
+	}, info)
 }
 
 func TestParseDSNEnv(t *testing.T) {
-	os.Setenv("PGDATABASE", "dbinst")
-	os.Setenv("PGUSER", "bob")
-	defer os.Unsetenv("PGDATABASE")
-	defer os.Unsetenv("PGUSER")
+	for _, kv := range [][]string{
+		{"PGDATABASE", "dbinst"}, {"PGUSER", "bob"}, {"PGHOST", "postgres"}, {"PGPORT", "2345"},
+	} {
+		unpatch := patchEnv(kv[0], kv[1])
+		defer unpatch()
+	}
 
 	info := apmpq.ParseDSN("postgres://")
-	assert.Equal(t, "dbinst", info.Database)
-	assert.Equal(t, "bob", info.User)
+	assert.Equal(t, apmsql.DSNInfo{
+		Address:  "postgres",
+		Port:     2345,
+		Database: "dbinst",
+		User:     "bob",
+	}, info)
 }

--- a/module/apmsql/pq/pq_test.go
+++ b/module/apmsql/pq/pq_test.go
@@ -54,6 +54,15 @@ func TestQueryContext(t *testing.T) {
 	assert.Equal(t, "SELECT FROM foo", spans[0].Name)
 	assert.Equal(t, "postgresql", spans[0].Subtype)
 	assert.Equal(t, &model.SpanContext{
+		Destination: &model.DestinationSpanContext{
+			Address: os.Getenv("PGHOST"),
+			Port:    5432,
+			Service: &model.DestinationServiceSpanContext{
+				Type:     "db",
+				Name:     "postgresql",
+				Resource: "postgresql",
+			},
+		},
 		Database: &model.DatabaseSpanContext{
 			Instance:  "test_db",
 			Statement: "SELECT * FROM foo",

--- a/spancontext.go
+++ b/spancontext.go
@@ -18,16 +18,22 @@
 package apm
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
+	"go.elastic.co/apm/internal/apmhttputil"
 	"go.elastic.co/apm/model"
 )
 
 // SpanContext provides methods for setting span context.
 type SpanContext struct {
-	model    model.SpanContext
-	database model.DatabaseSpanContext
-	http     model.HTTPSpanContext
+	model              model.SpanContext
+	destination        model.DestinationSpanContext
+	destinationService model.DestinationServiceSpanContext
+	database           model.DatabaseSpanContext
+	http               model.HTTPSpanContext
 }
 
 // DatabaseSpanContext holds database span context.
@@ -46,11 +52,23 @@ type DatabaseSpanContext struct {
 	User string
 }
 
+// DestinationServiceSpanContext holds destination service span span.
+type DestinationServiceSpanContext struct {
+	// Name holds a name for the destination service, which may be used
+	// for grouping and labeling in service maps.
+	Name string
+
+	// Resource holds an identifier for a destination service resource,
+	// such as a message queue.
+	Resource string
+}
+
 func (c *SpanContext) build() *model.SpanContext {
 	switch {
 	case len(c.model.Tags) != 0:
 	case c.model.Database != nil:
 	case c.model.HTTP != nil:
+	case c.model.Destination != nil:
 	default:
 		return nil
 	}
@@ -106,13 +124,62 @@ func (c *SpanContext) SetDatabase(db DatabaseSpanContext) {
 //
 // This function relates to client requests. If the request URL contains
 // user info, it will be removed and excluded from the stored URL.
+//
+// SetHTTPRequest makes implicit calls to SetDestinationAddress and
+// SetDestinationService, using details from req.URL.
 func (c *SpanContext) SetHTTPRequest(req *http.Request) {
+	if req.URL == nil {
+		return
+	}
 	c.http.URL = req.URL
 	c.model.HTTP = &c.http
+
+	addr, port := apmhttputil.DestinationAddr(req)
+	c.SetDestinationAddress(addr, port)
+
+	destinationServiceURL := url.URL{Scheme: req.URL.Scheme, Host: req.URL.Host}
+	destinationServiceResource := destinationServiceURL.Host
+	if port != 0 && port == apmhttputil.SchemeDefaultPort(req.URL.Scheme) {
+		var hasDefaultPort bool
+		if n := len(destinationServiceURL.Host); n > 0 && destinationServiceURL.Host[n-1] != ']' {
+			if i := strings.LastIndexByte(destinationServiceURL.Host, ':'); i != -1 {
+				// Remove the default port from destination.service.name.
+				destinationServiceURL.Host = destinationServiceURL.Host[:i]
+				hasDefaultPort = true
+			}
+		}
+		if !hasDefaultPort {
+			// Add the default port to destination.service.resource.
+			destinationServiceResource = fmt.Sprintf("%s:%d", destinationServiceResource, port)
+		}
+	}
+	c.SetDestinationService(DestinationServiceSpanContext{
+		Name:     destinationServiceURL.String(),
+		Resource: destinationServiceResource,
+	})
 }
 
 // SetHTTPStatusCode records the HTTP response status code.
 func (c *SpanContext) SetHTTPStatusCode(statusCode int) {
 	c.http.StatusCode = statusCode
 	c.model.HTTP = &c.http
+}
+
+// SetDestinationAddress sets the destination address and port in the context.
+//
+// SetDestinationAddress has no effect when called when an empty addr.
+func (c *SpanContext) SetDestinationAddress(addr string, port int) {
+	if addr != "" {
+		c.destination.Address = truncateString(addr)
+		c.destination.Port = port
+		c.model.Destination = &c.destination
+	}
+}
+
+// SetDestinationService sets the destination service info in the context.
+func (c *SpanContext) SetDestinationService(service DestinationServiceSpanContext) {
+	c.destinationService.Name = truncateString(service.Name)
+	c.destinationService.Resource = truncateString(service.Resource)
+	c.destination.Service = &c.destinationService
+	c.model.Destination = &c.destination
 }

--- a/spancontext_test.go
+++ b/spancontext_test.go
@@ -19,6 +19,8 @@ package apm_test
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +48,77 @@ func TestSpanContextSetLabel(t *testing.T) {
 		{Key: "foo", Value: "bar!"},
 		{Key: "qux", Value: true},
 	}, spans[0].Context.Tags)
+}
+
+func TestSpanContextSetHTTPRequest(t *testing.T) {
+	type testcase struct {
+		url string
+
+		addr     string
+		port     int
+		name     string
+		resource string
+	}
+
+	testcases := []testcase{{
+		url:      "http://localhost/foo/bar",
+		addr:     "localhost",
+		port:     80,
+		name:     "http://localhost",
+		resource: "localhost:80",
+	}, {
+		url:      "http://localhost:80/foo/bar",
+		addr:     "localhost",
+		port:     80,
+		name:     "http://localhost",
+		resource: "localhost:80",
+	}, {
+		url:      "https://[::1]/foo/bar",
+		addr:     "::1",
+		port:     443,
+		name:     "https://[::1]",
+		resource: "[::1]:443",
+	}, {
+		url:      "https://[::1]:8443/foo/bar",
+		addr:     "::1",
+		port:     8443,
+		name:     "https://[::1]:8443",
+		resource: "[::1]:8443",
+	}, {
+		url:      "gopher://gopher.invalid:70",
+		addr:     "gopher.invalid",
+		port:     70,
+		name:     "gopher://gopher.invalid:70",
+		resource: "gopher.invalid:70",
+	}, {
+		url:      "gopher://gopher.invalid",
+		addr:     "gopher.invalid",
+		port:     0,
+		name:     "gopher://gopher.invalid",
+		resource: "gopher.invalid",
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.url, func(t *testing.T) {
+			url, err := url.Parse(tc.url)
+			require.NoError(t, err)
+
+			_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+				span, _ := apm.StartSpan(ctx, "name", "type")
+				span.Context.SetHTTPRequest(&http.Request{URL: url})
+				span.End()
+			})
+			require.Len(t, spans, 1)
+
+			assert.Equal(t, &model.DestinationSpanContext{
+				Address: tc.addr,
+				Port:    tc.port,
+				Service: &model.DestinationServiceSpanContext{
+					Type:     spans[0].Type,
+					Name:     tc.name,
+					Resource: tc.resource,
+				},
+			}, spans[0].Context.Destination)
+		})
+	}
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -90,13 +90,23 @@ func TestValidateSpanType(t *testing.T) {
 	})
 }
 
-func TestValidateDatabaseSpanContextInstance(t *testing.T) {
+func TestValidateDatabaseSpanContext(t *testing.T) {
 	validateSpan(t, func(s *apm.Span) {
 		s.Context.SetDatabase(apm.DatabaseSpanContext{
 			Instance:  strings.Repeat("x", 1025),
 			Statement: strings.Repeat("x", 1025),
 			Type:      strings.Repeat("x", 1025),
 			User:      strings.Repeat("x", 1025),
+		})
+	})
+}
+
+func TestValidateDestinationSpanContext(t *testing.T) {
+	validateSpan(t, func(s *apm.Span) {
+		s.Context.SetDestinationAddress(strings.Repeat("x", 1025), 0)
+		s.Context.SetDestinationService(apm.DestinationServiceSpanContext{
+			Name:     strings.Repeat("x", 1025),
+			Resource: strings.Repeat("x", 1025),
 		})
 	})
 }


### PR DESCRIPTION
Add span.context fields:

 - destination.address
 - destination.port
 - destination.service.type
 - destination.service.name
 - destination.service.resource

Implement support for (client) HTTP,
Elasticsearch, PostgreSQL and MySQL
(via apmsql or GORM) spans.