### PR TITLE
Introduce experimental profiling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - module/apmgorm: sql.ErrNoRows is no longer reported as an error (#645)
  - Server URL path is cleaned/canonicalizsed in order to avoid 301 redirects (#658)
  - `context.request.socket.remote_address` now reports the peer address (#662)
+ - Experimental support for periodic CPU/heap profiling (#666)
 
 ## [v1.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.5.0)
 

--- a/config.go
+++ b/config.go
@@ -56,6 +56,13 @@ const (
 	envCentralConfig         = "ELASTIC_APM_CENTRAL_CONFIG"
 	envBreakdownMetrics      = "ELASTIC_APM_BREAKDOWN_METRICS"
 
+	// NOTE(axw) profiling environment variables are experimental.
+	// They may be removed in a future minor version without being
+	// considered a breaking change.
+	envCPUProfileInterval  = "ELASTIC_APM_CPU_PROFILE_INTERVAL"
+	envCPUProfileDuration  = "ELASTIC_APM_CPU_PROFILE_DURATION"
+	envHeapProfileInterval = "ELASTIC_APM_HEAP_PROFILE_INTERVAL"
+
 	defaultAPIRequestSize        = 750 * configutil.KByte
 	defaultAPIRequestTime        = 10 * time.Second
 	defaultAPIBufferSize         = 1 * configutil.MByte
@@ -266,6 +273,22 @@ func initialCentralConfigEnabled() (bool, error) {
 
 func initialBreakdownMetricsEnabled() (bool, error) {
 	return configutil.ParseBoolEnv(envBreakdownMetrics, true)
+}
+
+func initialCPUProfileIntervalDuration() (time.Duration, time.Duration, error) {
+	interval, err := configutil.ParseDurationEnv(envCPUProfileInterval, 0)
+	if err != nil || interval <= 0 {
+		return 0, 0, err
+	}
+	duration, err := configutil.ParseDurationEnv(envCPUProfileDuration, 0)
+	if err != nil || duration <= 0 {
+		return 0, 0, err
+	}
+	return interval, duration, nil
+}
+
+func initialHeapProfileInterval() (time.Duration, error) {
+	return configutil.ParseDurationEnv(envHeapProfileInterval, 0)
 }
 
 // updateRemoteConfig updates t and cfg with changes held in "attrs", and reverts to local

--- a/profiling.go
+++ b/profiling.go
@@ -1,0 +1,164 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"runtime/pprof"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type profilingState struct {
+	profileType  string
+	profileStart func(io.Writer) error
+	profileStop  func()
+	sender       profileSender
+
+	interval time.Duration
+	duration time.Duration // not relevant to all profiles
+
+	timer      *time.Timer
+	timerStart time.Time
+	buf        bytes.Buffer
+	finished   chan struct{}
+}
+
+// newCPUProfilingState calls newProfilingState with the
+// profiler type set to "cpu", and using pprof.StartCPUProfile
+// and pprof.StopCPUProfile.
+func newCPUProfilingState(sender profileSender) *profilingState {
+	return newProfilingState("cpu", pprof.StartCPUProfile, pprof.StopCPUProfile, sender)
+}
+
+// newHeapProfilingState calls newProfilingState with the
+// profiler type set to "heap", and using pprof.Lookup("heap").WriteTo(writer, 0).
+func newHeapProfilingState(sender profileSender) *profilingState {
+	return newLookupProfilingState("heap", sender)
+}
+
+func newLookupProfilingState(name string, sender profileSender) *profilingState {
+	profileStart := func(w io.Writer) error {
+		profile := pprof.Lookup(name)
+		if profile == nil {
+			return errors.Errorf("no profile called %q", name)
+		}
+		return profile.WriteTo(w, 0)
+	}
+	return newProfilingState("heap", profileStart, func() {}, sender)
+}
+
+// newProfilingState returns a new profilingState,
+// with its timer stopped. The timer may be started
+// by calling profilingState.updateConfig.
+func newProfilingState(
+	profileType string,
+	profileStart func(io.Writer) error,
+	profileStop func(),
+	sender profileSender,
+) *profilingState {
+	state := &profilingState{
+		profileType:  profileType,
+		profileStart: profileStart,
+		profileStop:  profileStop,
+		sender:       sender,
+		timer:        time.NewTimer(0),
+		finished:     make(chan struct{}, 1),
+	}
+	if !state.timer.Stop() {
+		<-state.timer.C
+	}
+	return state
+}
+
+func (state *profilingState) updateConfig(interval, duration time.Duration) {
+	if state.sender == nil {
+		// No profile sender, no point in starting a timer.
+		return
+	}
+	state.duration = duration
+	if state.interval == interval {
+		return
+	}
+	if state.timerStart.IsZero() {
+		state.interval = interval
+		state.resetTimer()
+	}
+	// TODO(axw) handle extending/cutting short running timers once
+	// it is possible to dynamically control profiling configuration.
+}
+
+func (state *profilingState) resetTimer() {
+	if state.interval != 0 {
+		state.timer.Reset(state.interval)
+		state.timerStart = time.Now()
+	} else {
+		state.timerStart = time.Time{}
+	}
+}
+
+// start spawns a goroutine that will capture a profile, send it using state.sender,
+// and finally signal state.finished.
+//
+// start will return immediately after spawning the goroutine.
+func (state *profilingState) start(ctx context.Context, logger Logger, metadata io.Reader) {
+	// The state.duration field may be updated after the goroutine starts,
+	// by the caller, so it must be read outside the goroutine.
+	duration := state.duration
+	go func() {
+		defer func() { state.finished <- struct{}{} }()
+		if err := state.profile(ctx, duration); err != nil {
+			if logger != nil && ctx.Err() == nil {
+				logger.Errorf("%s", err)
+			}
+			return
+		}
+		// TODO(axw) backoff like SendStream requests
+		if err := state.sender.SendProfile(ctx, metadata, &state.buf); err != nil {
+			if logger != nil && ctx.Err() == nil {
+				logger.Errorf("failed to send %s profile: %s", state.profileType, err)
+			}
+		}
+	}()
+}
+
+func (state *profilingState) profile(ctx context.Context, duration time.Duration) error {
+	state.buf.Reset()
+	if err := state.profileStart(&state.buf); err != nil {
+		return errors.Wrapf(err, "failed to start %s profile", state.profileType)
+	}
+	defer state.profileStop()
+
+	if duration > 0 {
+		timer := time.NewTimer(duration)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil
+}
+
+type profileSender interface {
+	SendProfile(ctx context.Context, metadata io.Reader, profile ...io.Reader) error
+}

--- a/profiling_test.go
+++ b/profiling_test.go
@@ -1,0 +1,125 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm_test
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.elastic.co/apm/apmtest"
+)
+
+func TestTracerCPUProfiling(t *testing.T) {
+	os.Setenv("ELASTIC_APM_CPU_PROFILE_INTERVAL", "100ms")
+	os.Setenv("ELASTIC_APM_CPU_PROFILE_DURATION", "1s")
+	defer os.Unsetenv("ELASTIC_APM_CPU_PROFILE_INTERVAL")
+	defer os.Unsetenv("ELASTIC_APM_CPU_PROFILE_DURATION")
+
+	tracer := apmtest.NewRecordingTracer()
+	defer tracer.Close()
+
+	timeout := time.After(10 * time.Second)
+	var profiles [][]byte
+	for len(profiles) == 0 {
+		select {
+		case <-timeout:
+			t.Fatal("timed out waiting for profile")
+		default: // busy loop so we get some CPU samples
+		}
+		profiles = tracer.Payloads().Profiles
+	}
+
+	info := parseProfile(profiles[0])
+	assert.EqualValues(t, []string{"samples/count", "cpu/nanoseconds"}, info.sampleTypes)
+}
+
+func TestTracerHeapProfiling(t *testing.T) {
+	os.Setenv("ELASTIC_APM_HEAP_PROFILE_INTERVAL", "100ms")
+	defer os.Unsetenv("ELASTIC_APM_HEAP_PROFILE_INTERVAL")
+
+	tracer := apmtest.NewRecordingTracer()
+	defer tracer.Close()
+
+	timeout := time.After(10 * time.Second)
+	var profiles [][]byte
+
+	tick := time.Tick(50 * time.Millisecond)
+	for len(profiles) == 0 {
+		select {
+		case <-timeout:
+			t.Fatal("timed out waiting for profile")
+		case <-tick:
+		}
+		profiles = tracer.Payloads().Profiles
+	}
+
+	info := parseProfile(profiles[0])
+	assert.EqualValues(t, []string{
+		"alloc_objects/count", "alloc_space/bytes",
+		"inuse_objects/count", "inuse_space/bytes",
+	}, info.sampleTypes)
+}
+
+// parseProfile parses the profile data using "go tool pprof".
+//
+// We could use github.com/google/pprof, but prefer not to add
+// a dependency for users just to run these unit test. More
+// thorough integration testing should be performed elsewhere.
+func parseProfile(data []byte) profileInfo {
+	f, err := ioutil.TempFile("", "apm_profiletest")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		panic(err)
+	}
+
+	cmd := exec.Command("go", "tool", "pprof", "-raw", f.Name())
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		panic(err)
+	}
+
+	var info profileInfo
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		if scanner.Text() == "Samples:" && scanner.Scan() {
+			info.sampleTypes = strings.Fields(scanner.Text())
+			return info
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+	panic("failed to locate sample types")
+}
+
+type profileInfo struct {
+	sampleTypes []string
+}


### PR DESCRIPTION
We introduce support for periodically sending
CPU and heap profiles to the APM Server. These
can be enabled by setting the undocumented and
experimental environment variables:

- ELASTIC_APM_CPU_PROFILE_INTERVAL
- ELASTIC_APM_CPU_PROFILE_DURATION
- ELASTIC_APM_HEAP_PROFILE_INTERVAL

This is part of https://github.com/elastic/apm/issues/121