### PR TITLE
internal/apmschema: fix package dir lookup

### DIFF
--- a/internal/apmschema/schema.go
+++ b/internal/apmschema/schema.go
@@ -18,7 +18,6 @@
 package apmschema
 
 import (
-	"go/build"
 	"log"
 	"path"
 	"path/filepath"
@@ -45,13 +44,13 @@ var (
 )
 
 func init() {
-	pkg, err := build.Default.Import("go.elastic.co/apm/internal/apmschema", "", build.FindOnly)
-	if err != nil {
-		log.Fatal(err)
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("source line info not available")
 	}
 	compiler := jsonschema.NewCompiler()
 	compiler.Draft = jsonschema.Draft4
-	schemaDir := path.Join(filepath.ToSlash(pkg.Dir), "jsonschema")
+	schemaDir := path.Join(filepath.ToSlash(filepath.Dir(filename)), "jsonschema")
 	if runtime.GOOS == "windows" {
 		schemaDir = "/" + schemaDir
 	}


### PR DESCRIPTION
Rather than using go/build to locate the package
to get its directory, just use the source line
info. This is simpler, faster, and works when
the agent is located outside of $GOPATH.

Thanks to @jonbodner for the smarter approach
of using `runtime.Caller`.

Closes #667