### PR TITLE
model: update generate script for modules

### DIFF
--- a/model/generate.sh
+++ b/model/generate.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-go run ../../fastjson/cmd/generate-fastjson/main.go -f -o marshal_fastjson.go .
+go run go.elastic.co/fastjson/cmd/generate-fastjson -f -o marshal_fastjson.go .
 exec go-licenser marshal_fastjson.go


### PR DESCRIPTION
Rather than relying on relative location of fastjson
within $GOPATH, use "go run <package>". This means
"go generate" won't work with older versions of Go,
but this is only for agent development so no big deal.