### PR TITLE
internal/hostutil: unescape systemd cgroup paths

### DIFF
--- a/internal/apmhostutil/container_linux.go
+++ b/internal/apmhostutil/container_linux.go
@@ -131,7 +131,9 @@ func readCgroupContainerInfo(r io.Reader) (*model.Container, *model.Kubernetes, 
 			hostname, _ := os.Hostname()
 			uid := match[1]
 			if uid == "" {
-				uid = match[2]
+				// Systemd cgroup driver is being used,
+				// so we need to unescape '_' back to '-'.
+				uid = strings.Replace(match[2], "_", "-", -1)
 			}
 			kubernetes = &model.Kubernetes{
 				Pod: &model.KubernetesPod{

--- a/internal/apmhostutil/container_linux_test.go
+++ b/internal/apmhostutil/container_linux_test.go
@@ -139,7 +139,7 @@ func TestCgroupContainerInfoKubernetesSystemd(t *testing.T) {
 	assert.Equal(t, &model.Container{ID: "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63"}, container)
 	assert.Equal(t, &model.Kubernetes{
 		Pod: &model.KubernetesPod{
-			UID:  "90d81341_92de_11e7_8cf2_507b9d4141fa",
+			UID:  "90d81341-92de-11e7-8cf2-507b9d4141fa",
 			Name: hostname,
 		},
 	}, kubernetes)


### PR DESCRIPTION
When k8s is using the systemd cgroup driver,
hyphens in pod UIDs will be escaped and translated
to underscores. We need to reverse this when
parsing the cgroup file.

See https://github.com/elastic/apm/pull/165