### PR TITLE
[apm-ci] branches/tags with the format ^module/ are filtered

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -11,21 +11,19 @@
     view: APM-CI
     project-type: multibranch
     logrotate:
-      daysToKeep: 30
       numToKeep: 100
-    number-to-keep: '5'
-    days-to-keep: '1'
     concurrent: true
     node: linux
     script-path: Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
         notification-context: 'apm-ci'
+        head-filter-regex: '^(?!module/).*$'
         repo: apm-agent-go
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken


### PR DESCRIPTION
The pipeline should care only for those branches/tags which are not ^module based

Closes #608 

### Changes
![image](https://user-images.githubusercontent.com/2871786/68690498-06fae680-056a-11ea-9ebe-c7f91add9c31.png)

![image](https://user-images.githubusercontent.com/2871786/68690724-6fe25e80-056a-11ea-9b81-ed8afa7cc01c.png)
