### PR TITLE
Use/send "traceparent" header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
  - Server URL path is cleaned/canonicalizsed in order to avoid 301 redirects (#658)
  - `context.request.socket.remote_address` now reports the peer address (#662)
  - Experimental support for periodic CPU/heap profiling (#666)
+ - module/apmnegroni: introduce tracing Negroni middleware (#671)
+ - Unescape hyphens in k8s pod UIDs when the systemd cgroup driver is used (#672)
+ - Read and propagate the standard W3C "traceparent" header (#674)
 
 ## [v1.5.0](https://github.com/elastic/apm-agent-go/releases/tag/v1.5.0)
 

--- a/config.go
+++ b/config.go
@@ -35,26 +35,27 @@ import (
 )
 
 const (
-	envMetricsInterval       = "ELASTIC_APM_METRICS_INTERVAL"
-	envMaxSpans              = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
-	envTransactionSampleRate = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
-	envSanitizeFieldNames    = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
-	envCaptureHeaders        = "ELASTIC_APM_CAPTURE_HEADERS"
-	envCaptureBody           = "ELASTIC_APM_CAPTURE_BODY"
-	envServiceName           = "ELASTIC_APM_SERVICE_NAME"
-	envServiceVersion        = "ELASTIC_APM_SERVICE_VERSION"
-	envEnvironment           = "ELASTIC_APM_ENVIRONMENT"
-	envSpanFramesMinDuration = "ELASTIC_APM_SPAN_FRAMES_MIN_DURATION"
-	envActive                = "ELASTIC_APM_ACTIVE"
-	envAPIRequestSize        = "ELASTIC_APM_API_REQUEST_SIZE"
-	envAPIRequestTime        = "ELASTIC_APM_API_REQUEST_TIME"
-	envAPIBufferSize         = "ELASTIC_APM_API_BUFFER_SIZE"
-	envMetricsBufferSize     = "ELASTIC_APM_METRICS_BUFFER_SIZE"
-	envDisableMetrics        = "ELASTIC_APM_DISABLE_METRICS"
-	envGlobalLabels          = "ELASTIC_APM_GLOBAL_LABELS"
-	envStackTraceLimit       = "ELASTIC_APM_STACK_TRACE_LIMIT"
-	envCentralConfig         = "ELASTIC_APM_CENTRAL_CONFIG"
-	envBreakdownMetrics      = "ELASTIC_APM_BREAKDOWN_METRICS"
+	envMetricsInterval             = "ELASTIC_APM_METRICS_INTERVAL"
+	envMaxSpans                    = "ELASTIC_APM_TRANSACTION_MAX_SPANS"
+	envTransactionSampleRate       = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE"
+	envSanitizeFieldNames          = "ELASTIC_APM_SANITIZE_FIELD_NAMES"
+	envCaptureHeaders              = "ELASTIC_APM_CAPTURE_HEADERS"
+	envCaptureBody                 = "ELASTIC_APM_CAPTURE_BODY"
+	envServiceName                 = "ELASTIC_APM_SERVICE_NAME"
+	envServiceVersion              = "ELASTIC_APM_SERVICE_VERSION"
+	envEnvironment                 = "ELASTIC_APM_ENVIRONMENT"
+	envSpanFramesMinDuration       = "ELASTIC_APM_SPAN_FRAMES_MIN_DURATION"
+	envActive                      = "ELASTIC_APM_ACTIVE"
+	envAPIRequestSize              = "ELASTIC_APM_API_REQUEST_SIZE"
+	envAPIRequestTime              = "ELASTIC_APM_API_REQUEST_TIME"
+	envAPIBufferSize               = "ELASTIC_APM_API_BUFFER_SIZE"
+	envMetricsBufferSize           = "ELASTIC_APM_METRICS_BUFFER_SIZE"
+	envDisableMetrics              = "ELASTIC_APM_DISABLE_METRICS"
+	envGlobalLabels                = "ELASTIC_APM_GLOBAL_LABELS"
+	envStackTraceLimit             = "ELASTIC_APM_STACK_TRACE_LIMIT"
+	envCentralConfig               = "ELASTIC_APM_CENTRAL_CONFIG"
+	envBreakdownMetrics            = "ELASTIC_APM_BREAKDOWN_METRICS"
+	envUseElasticTraceparentHeader = "ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER"
 
 	// NOTE(axw) profiling environment variables are experimental.
 	// They may be removed in a future minor version without being
@@ -275,6 +276,10 @@ func initialBreakdownMetricsEnabled() (bool, error) {
 	return configutil.ParseBoolEnv(envBreakdownMetrics, true)
 }
 
+func initialUseElasticTraceparentHeader() (bool, error) {
+	return configutil.ParseBoolEnv(envUseElasticTraceparentHeader, true)
+}
+
 func initialCPUProfileIntervalDuration() (time.Duration, time.Duration, error) {
 	interval, err := configutil.ParseDurationEnv(envCPUProfileInterval, 0)
 	if err != nil || interval <= 0 {
@@ -439,4 +444,5 @@ type instrumentationConfigValues struct {
 	sampler               Sampler
 	spanFramesMinDuration time.Duration
 	stackTraceLimit       int
+	propagateLegacyHeader bool
 }

--- a/module/apmgrpc/go.sum
+++ b/module/apmgrpc/go.sum
@@ -24,6 +24,7 @@ github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -95,9 +95,10 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	req = &reqCopy
 
+	propagateLegacyHeader := tx.ShouldPropagateLegacyHeader()
 	traceContext := tx.TraceContext()
 	if !traceContext.Options.Recorded() {
-		req.Header.Set(TraceparentHeader, FormatTraceparentHeader(traceContext))
+		r.setHeaders(req, traceContext, propagateLegacyHeader)
 		return r.r.RoundTrip(req)
 	}
 
@@ -113,7 +114,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		span = nil
 	}
 
-	req.Header.Set(TraceparentHeader, FormatTraceparentHeader(traceContext))
+	r.setHeaders(req, traceContext, propagateLegacyHeader)
 	resp, err := r.r.RoundTrip(req)
 	if span != nil {
 		if err != nil {
@@ -124,6 +125,14 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 	return resp, err
+}
+
+func (r *roundTripper) setHeaders(req *http.Request, traceContext apm.TraceContext, propagateLegacyHeader bool) {
+	headerValue := FormatTraceparentHeader(traceContext)
+	if propagateLegacyHeader {
+		req.Header.Set(ElasticTraceparentHeader, headerValue)
+	}
+	req.Header.Set(W3CTraceparentHeader, headerValue)
 }
 
 // CloseIdleConnections calls r.r.CloseIdleConnections if the method exists.

--- a/module/apmhttp/traceheaders.go
+++ b/module/apmhttp/traceheaders.go
@@ -30,10 +30,19 @@ import (
 const (
 	// TraceparentHeader is the HTTP header for trace propagation.
 	//
-	// NOTE: at this time, the W3C Trace-Context headers are not finalised.
-	// To avoid producing possibly invalid traceparent headers, we will
-	// use an alternative name until the format is frozen.
-	TraceparentHeader = "Elastic-Apm-Traceparent"
+	// For backwards compatibility, this is currently an alias for
+	// for ElasticTraceparentHeader, but the more specific constants
+	// below should be preferred. In a future version this will be
+	// replaced by the standard W3C header.
+	TraceparentHeader = ElasticTraceparentHeader
+
+	// ElasticTraceparentHeader is the legacy HTTP header for trace propagation,
+	// maintained for backwards compatibility with older agents.
+	ElasticTraceparentHeader = "Elastic-Apm-Traceparent"
+
+	// W3CTraceparentHeader is the standard W3C Trace-Context HTTP
+	// header for trace propagation.
+	W3CTraceparentHeader = "Traceparent"
 )
 
 // FormatTraceparentHeader formats the given trace context as a


### PR DESCRIPTION
We will now look for and propagate the W3C "traceparent" header. We still look for "Elastic-Apm-Traceparent" and use it if present, and otherwise we use the "traceparent" header. We will always send "traceparent" in outgoing requests, and optionally send the "Elastic-Apm-Traceparent" header.

We introduce the `ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER` environment variable, which controls whether or not we send the "Elastic-Apm-Tracparent" header; currently this defaults to true, but we will later flip the value and eventually remove the config altogether. The value is accessed
through the new method, `Transaction.ShouldPropagateLegacyHeader`.

Part of #503 (still need to implement support for "tracestate" to close it)