### PR TITLE
ci(jenkins): enable opbeans syncup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,6 @@ pipeline {
         stage('Opbeans') {
           environment {
             REPO_NAME = "${OPBEANS_REPO}"
-            BRANCH_NAME = 'v1.6.0'
           }
           steps {
             deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
     HOME = "${env.WORKSPACE}"
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    OPBEANS_REPO = 'opbeans-go'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -218,6 +219,27 @@ pipeline {
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+      }
+    }
+    stage('Release') {
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        tag pattern: 'v\\d+\\.\\d+\\d+', comparator: 'REGEXP'
+      }
+      stages {
+        stage('Opbeans') {
+          steps {
+            deleteDir()
+            dir("${OPBEANS_REPO}"){
+              git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                  url: "git@github.com:elastic/${OPBEANS_REPO}.git"
+              // TODO: Upgrade dependencies for the given version.
+              // gitCreateTag(tag: "${env.BRANCH_NAME}", pushArgs: '--force')
+              gitCreateTag(tag: "${env.BRANCH_NAME}")
+            }
+          }
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -269,7 +269,7 @@ pipeline {
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git",
                   branch: 'feature/release'
-              sh ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
               // The opbeans-go pipeline will trigger a release for the master branch
               gitPush()
               // The opbeans-go pipeline will trigger a release for the release tag

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,13 +232,15 @@ pipeline {
       }
       stages {
         stage('Opbeans') {
+          environment {
+            REPO_NAME = "${OPBEANS_REPO}"
+          }
           steps {
             deleteDir()
             dir("${OPBEANS_REPO}"){
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git"
               // TODO: Upgrade dependencies for the given version.
-              // gitCreateTag(tag: "${env.BRANCH_NAME}", pushArgs: '--force')
               gitCreateTag(tag: "${env.BRANCH_NAME}")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,10 +225,7 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        anyOf {
-          tag pattern: 'v\\d+\\.\\d+\\d+', comparator: 'REGEXP'
-          branch 'PR-678'
-        }
+        tag pattern: 'v\\d+\\.\\d+\\d+', comparator: 'REGEXP'
       }
       stages {
         stage('Opbeans') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,12 +63,7 @@ pipeline {
         stage('Tests') {
           options { skipDefaultCheckout() }
           when {
-            allOf {
-              expression { return params.test_ci }
-              not {
-                branch 'PR-678'
-              }
-            }
+            expression { return params.test_ci }
           }
           steps {
             withGithubNotify(context: 'Tests', tab: 'tests') {
@@ -95,12 +90,7 @@ pipeline {
         stage('Coverage') {
           options { skipDefaultCheckout() }
           when {
-            allOf {
-              expression { return params.docker_test_ci }
-              not {
-                branch 'PR-678'
-              }
-            }
+            expression { return params.docker_test_ci }
           }
           steps {
             withGithubNotify(context: 'Coverage') {
@@ -136,9 +126,6 @@ pipeline {
                 expression { return params.Run_As_Master_Branch }
               }
               expression { return params.bench_ci }
-              not {
-                branch 'PR-678'
-              }
             }
           }
           steps {
@@ -160,12 +147,6 @@ pipeline {
         stage('Windows') {
           agent { label 'windows-2019-immutable' }
           options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            not {
-              branch 'PR-678'
-            }
-          }
           environment {
             GOROOT = "c:\\Go"
             GOPATH = "${env.WORKSPACE}"
@@ -194,12 +175,6 @@ pipeline {
         }
         stage('OSX') {
           agent { label 'macosx' }
-          when {
-            beforeAgent true
-            not {
-              branch 'PR-678'
-            }
-          }
           options { skipDefaultCheckout() }
           environment {
             GO_VERSION = "${params.GO_VERSION}"
@@ -233,9 +208,6 @@ pipeline {
             environment name: 'GIT_BUILD_CAUSE', value: 'pr'
             expression { return !params.Run_As_Master_Branch }
           }
-          not {
-            branch 'PR-678'
-          }
         }
       }
       steps {
@@ -267,8 +239,7 @@ pipeline {
             deleteDir()
             dir("${OPBEANS_REPO}"){
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                  url: "git@github.com:elastic/${OPBEANS_REPO}.git",
-                  branch: 'feature/release'
+                  url: "git@github.com:elastic/${OPBEANS_REPO}.git"
               sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
               // The opbeans-go pipeline will trigger a release for the master branch
               gitPush()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,6 +262,7 @@ pipeline {
         stage('Opbeans') {
           environment {
             REPO_NAME = "${OPBEANS_REPO}"
+            BRANCH_NAME = 'v1.6.0'
           }
           steps {
             deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,7 +240,10 @@ pipeline {
             dir("${OPBEANS_REPO}"){
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git"
-              // TODO: Upgrade dependencies for the given version.
+              sh ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+              // The opbeans-go pipeline will trigger a release for the master branch
+              gitPush()
+              // The opbeans-go pipeline will trigger a release for the release tag
               gitCreateTag(tag: "${env.BRANCH_NAME}")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,7 +225,10 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        tag pattern: 'v\\d+\\.\\d+\\d+', comparator: 'REGEXP'
+        anyOf {
+          tag pattern: 'v\\d+\\.\\d+\\d+', comparator: 'REGEXP'
+          branch 'PR-678'
+        }
       }
       stages {
         stage('Opbeans') {


### PR DESCRIPTION
When a new tag, aka a new release, is created then, the automation will kick the opbeans build which consists of the following tasks:
- [x] Bump dependency versions in the opbeans-go
- [x] Push changes. (Implementation within the opbeans-go but the call it's done within this pipeline)
- [x] Create a tag to trigger the release pipeline in the opbeans-go. That particular tag will match with the same one that the one in the agent itself.

This particular pipeline will push the changes into the `master` branch for the opbeans-go and tag it with the name of the tag version too. Therefore, the opbeans-go pipeline will trigger two builds, the one for its master branch and the other one for the just created tag. This particular flow is implemented within the opbeans-go.

### UTs

- PRs UI view

![image](https://user-images.githubusercontent.com/2871786/69261576-b6af0480-0bb9-11ea-973d-ee859a72acc1.png)

- Release tags UI view

A simplistic view

![image](https://user-images.githubusercontent.com/2871786/69335226-5c16b680-0c54-11ea-8ada-085a341f5162.png)

The above build bumped the version to `v1.6.0` and caused to trigger the opbeans-go pipeline

![image](https://user-images.githubusercontent.com/2871786/69335330-9e3ff800-0c54-11ea-8fac-1ae15f4d7cf2.png)

![image](https://user-images.githubusercontent.com/2871786/69335421-d6473b00-0c54-11ea-8fc3-22b16566c41b.png)
