### PR TITLE
Reduce memory on rand source in Transaction code

### DIFF
--- a/span.go
+++ b/span.go
@@ -108,7 +108,7 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 		if opts.SpanID.Validate() == nil {
 			span.traceContext.Span = opts.SpanID
 		} else {
-			binary.LittleEndian.PutUint64(span.traceContext.Span[:], tx.rand.Uint64())
+			binary.LittleEndian.PutUint64(span.traceContext.Span[:], globalRand.Uint64())
 		}
 		span.stackFramesMinDuration = tx.spanFramesMinDuration
 		span.stackTraceLimit = tx.stackTraceLimit

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -177,8 +177,7 @@ func BenchmarkTransaction(b *testing.B) {
 		rand := rand.New(rand.NewSource(globalRand.Int63()))
 		mu.Unlock()
 		for pb.Next() {
-			tx := tracer.StartTransaction(names[rand.Intn(len(names))], "type")
-			tx.End()
+			tracer.StartTransaction(names[rand.Intn(len(names))], "type")
 		}
 	})
 }


### PR DESCRIPTION
This PR addresses high memory use in the transaction code.  We found that large amounts of memory were being allocated to the `StartTransactionOptions` method when creating a random source on each transaction.  This is not required to achieve threadsafe, uniq ids.  

![Screen Shot 2019-12-03 at 4 42 28 PM](https://user-images.githubusercontent.com/50927074/70093446-6d65a880-15ee-11ea-9c9c-de4967035262.png)

I implemented a simple mutexted global random source that satisfies the needs of the code.  

The existing benchmark for Transaction was masking the memory in use.  For each new math/rand rng source, >5kb is allocated.  But since the benchmark was starting/ending inside the loop block it likely was getting elided or using stack memory.  Whatever the reason, when removing the end method, shows the expected memory use.  I have removed it for this PR.

Example benchmarks showing memory use after removing the end method and the performance of this PR.
```bash
$ ~/go/src/github.com/jasonmoo-we/apm-agent-go master: go test -v -run xxx -benchmem -bench Transaction
goos: darwin
goarch: amd64
pkg: go.elastic.co/apm
BenchmarkTransaction-8   	 5158528	       228 ns/op	      81 B/op	       1 allocs/op
PASS
ok  	go.elastic.co/apm	5.254s
$ ~/go/src/github.com/jasonmoo-we/apm-agent-go master: g df
diff --git a/transaction_test.go b/transaction_test.go
index 935cd82..f0be6d2 100644
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -177,8 +177,8 @@ func BenchmarkTransaction(b *testing.B) {
 		rand := rand.New(rand.NewSource(globalRand.Int63()))
 		mu.Unlock()
 		for pb.Next() {
-			tx := tracer.StartTransaction(names[rand.Intn(len(names))], "type")
-			tx.End()
+			tracer.StartTransaction(names[rand.Intn(len(names))], "type")
+			// tx.End()
 		}
 	})
 }
$ ~/go/src/github.com/jasonmoo-we/apm-agent-go master: go test -v -run xxx -benchmem -bench Transaction
goos: darwin
goarch: amd64
pkg: go.elastic.co/apm
BenchmarkTransaction-8   	  527340	      2723 ns/op	    6465 B/op	       7 allocs/op
PASS
ok  	go.elastic.co/apm	3.755s
$ ~/go/src/github.com/jasonmoo-we/apm-agent-go jasonmoo-we/reduce-memory-on-rand-sourcing: go test -v -run xxx -benchmem -bench Transaction
goos: darwin
goarch: amd64
pkg: go.elastic.co/apm
BenchmarkTransaction-8   	 2269914	       553 ns/op	     896 B/op	       3 allocs/op
PASS
ok  	go.elastic.co/apm	2.009s
```


