### PR TITLE
[docs] Add placeholder changelog file to 1.x

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,0 +1,1 @@
+This is a placeholder file. Release notes are published in CHANGELOG.md


### PR DESCRIPTION
As discussed on slack, this PR adds a placeholder `CHANGELOG.asciidoc` file to `1.x`. This allows us to merge https://github.com/elastic/docs/pull/1503. During the next release, release notes will overwrite this file and `1.x` release notes will then be published to the documentation!