### PR TITLE
[docs] Add direct_html flag to build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ update-modules:
 .PHONY: docs
 docs:
 ifdef ELASTIC_DOCS
-	$(ELASTIC_DOCS)/build_docs --asciidoctor --chunk=1 $(BUILD_DOCS_ARGS) --doc docs/index.asciidoc --out docs/html
+	$(ELASTIC_DOCS)/build_docs --direct_html --chunk=1 $(BUILD_DOCS_ARGS) --doc docs/index.asciidoc --out docs/html
 else
 	@echo "\nELASTIC_DOCS is not defined.\n"
 	@exit 1


### PR DESCRIPTION
Adds the `--direct_html` flag to the docs build script. See https://github.com/elastic/docs/pull/1642.