### PR TITLE
Add reference repo for apm-agent-go

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -48,6 +48,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-go.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
           steps {
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: '/var/lib/jenkins/.git-references/apm-agent-go.git')
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }


### PR DESCRIPTION
Adds reference repos.

These correspond to repos and download locations which can be seen in [the Jenkins job which mirrors them](https://apm-ci.elastic.co/job/jenkins-git-fetch-reference/).