### PR TITLE
Revert "ci(jenkins): Install latest golang version for Windows (#702)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,6 +167,9 @@ pipeline {
           post {
             always {
               junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/junit-*.xml")
+              dir("${BASE_DIR}"){
+                bat script: 'scripts/jenkins/windows/uninstall-tools.bat', label: 'Uninstall tools'
+              }
               cleanWs(disableDeferredWipeout: true, notFailBuild: true)
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,10 +167,6 @@ pipeline {
           post {
             always {
               junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/junit-*.xml")
-              dir("${BASE_DIR}"){
-                bat script: 'scripts/jenkins/windows/uninstall-tools.bat', label: 'Uninstall tools'
-              }
-              cleanWs(disableDeferredWipeout: true, notFailBuild: true)
             }
           }
         }

--- a/scripts/jenkins/windows/install-tools.bat
+++ b/scripts/jenkins/windows/install-tools.bat
@@ -3,7 +3,4 @@
 ::
 
 choco config set cacheLocation %WORKSPACE%
-:: Install latest as long as https://github.com/chocolatey/chocolatey.org/issues/803
-:: is not resolved.
-:: choco install golang --version %GO_VERSION% -y --no-progress
-choco install golang -y --no-progress
+choco install golang --version %GO_VERSION% -y --no-progress

--- a/scripts/jenkins/windows/uninstall-tools.bat
+++ b/scripts/jenkins/windows/uninstall-tools.bat
@@ -1,5 +1,0 @@
-::
-:: This script install the required tools
-::
-
-choco uninstall golang --version %GO_VERSION% -y

--- a/scripts/jenkins/windows/uninstall-tools.bat
+++ b/scripts/jenkins/windows/uninstall-tools.bat
@@ -1,0 +1,5 @@
+::
+:: This script install the required tools
+::
+
+choco uninstall golang --version %GO_VERSION% -y


### PR DESCRIPTION
This reverts commit 4b3f3047ac8ca73fce1ac35424106c4a64e84b85.

Caused by https://github.com/chocolatey/chocolatey.org/issues/804

The revert does only care for the latest version, it does not revert the unrequired changes with the CI ephemeral workers (delete workspace and uninstall the go version)