### PR TITLE
ci(jenkins): fixes known issue with params/env variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,6 +228,7 @@ pipeline {
         stage('Opbeans') {
           environment {
             REPO_NAME = "${OPBEANS_REPO}"
+            GO_VERSION = "${params.GO_VERSION}"
           }
           steps {
             deleteDir()


### PR DESCRIPTION
Fixes the current issue when running the opbeans release with the pipeline. 

Further details [here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-go%2Fapm-agent-go-mbp/detail/v1.7.0/2/pipeline#step-397-log-8)

See [JENKINS-41929](https://issues.jenkins-ci.org/browse/JENKINS-41929)
