### PR TITLE
ci(jenkins): when GitHub timeout issues then retry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,8 +262,11 @@ def generateStep(version){
         echo "${version}"
         dir("${BASE_DIR}"){
           withEnv(["GO_VERSION=${version}"]) {
-            sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
-            sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+            retry(2) {
+              sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
+              sh script: './scripts/jenkins/build.sh', label: 'Build'
+            }
+            sh script: './scripts/jenkins/test.sh', label: 'Test'
           }
         }
       } catch(e){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,8 +182,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
-                sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+                buildAndTest()
               }
             }
           }
@@ -262,11 +261,7 @@ def generateStep(version){
         echo "${version}"
         dir("${BASE_DIR}"){
           withEnv(["GO_VERSION=${version}"]) {
-            retry(2) {
-              sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
-              sh script: './scripts/jenkins/build.sh', label: 'Build'
-            }
-            sh script: './scripts/jenkins/test.sh', label: 'Test'
+            buildAndTest()
           }
         }
       } catch(e){
@@ -290,4 +285,12 @@ def generateStepAndCatchError(version){
 
 def cleanDir(path){
   powershell label: "Clean ${path}", script: "Remove-Item -Recurse -Force ${path}"
+}
+
+def buildAndTest() {
+  retry(2) {
+    sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
+    sh script: './scripts/jenkins/build.sh', label: 'Build'
+  }
+  sh script: './scripts/jenkins/test.sh', label: 'Test'
 }

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -20,7 +20,7 @@ function pin() {
     url="https://$repo"
   fi
   mkdir -p "$orgdir"
-  (cd "$orgdir" && [ -d "${projname}" ] && rm -rf $projname)
+  (cd "$orgdir" && rm -rf $projname || true)
   (cd "$orgdir" && git clone "$url" && cd "${projname}" && git checkout $commit)
 }
 

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -20,7 +20,8 @@ function pin() {
     url="https://$repo"
   fi
   mkdir -p "$orgdir"
-  (cd "$orgdir" && git clone "$url" && cd $projname && git checkout $commit)
+  (cd "$orgdir" && [ -d "${projname}" ] && rm -rf $projname)
+  (cd "$orgdir" && git clone "$url" && cd "${projname}" && git checkout $commit)
 }
 
 if (! go run scripts/mingoversion.go 1.11 &>/dev/null); then

--- a/scripts/jenkins/build.sh
+++ b/scripts/jenkins/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Install Go using the same travis approach
+echo "Installing ${GO_VERSION} with gimme."
+eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+
+make install

--- a/scripts/jenkins/test.sh
+++ b/scripts/jenkins/test.sh
@@ -5,4 +5,4 @@ set -euxo pipefail
 echo "Installing ${GO_VERSION} with gimme."
 eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
 
-make install check
+make check


### PR DESCRIPTION
## What does this PR do?

Decouple the build scripts to build and test.
Retry if it fails when building as GitHub gets some timeout issues from GCP

## Why is it important?

More tolerance when timeout issues.

A typical timeout issue:

```
[2020-02-06T13:28:25.232Z] + mkdir -p /var/lib/jenkins/workspace/agent-go_apm-agent-go-mbp_PR-714/src/github.com/gocql

[2020-02-06T13:28:25.232Z] + cd /var/lib/jenkins/workspace/agent-go_apm-agent-go-mbp_PR-714/src/github.com/gocql

[2020-02-06T13:28:25.232Z] + git clone https://github.com/gocql/gocql

[2020-02-06T13:28:25.232Z] Cloning into 'gocql'...

[2020-02-06T13:28:57.345Z] fatal: unable to access 'https://github.com/gocql/gocql/': Failed to connect to github.com port 443: Connection timed out

script returned exit code 128
```

See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-go%2Fapm-agent-go-mbp/detail/PR-714/3/pipeline/87#step-147-log-74)

## Related issues

See https://issuetracker.google.com/issues/146072599