### PR TITLE
ci(jenkins): retry/sleep to avoid timeout issues with GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,12 @@ def generateStep(version){
         echo "${version}"
         dir("${BASE_DIR}"){
           withEnv(["GO_VERSION=${version}"]) {
-            sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
+            // Another retry in case there are any environmental issues
+            // See https://issuetracker.google.com/issues/146072599 for more context
+            retry(2) {
+              sleep randomNumber(min: 2, max: 5)
+              sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
+            }
             sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
           }
         }


### PR DESCRIPTION
```
[2020-02-26T12:33:51.150Z] + cd /var/lib/jenkins/workspace/agent-go_apm-agent-go-mbp_master/src/github.com/labstack
[2020-02-26T12:33:51.150Z] + git clone https://github.com/labstack/echo
[2020-02-26T12:33:51.150Z] Cloning into 'echo'...
[2020-02-26T12:34:23.223Z] fatal: unable to access 'https://github.com/labstack/echo/': Failed to connect to github.com port 443: Connection timed out
```
here - [step](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-go%2Fapm-agent-go-mbp/detail/master/120/pipeline/86#step-140-log-128)


Caused by https://issuetracker.google.com/issues/146072599