### PR TITLE
update github.com/cucumber/godog package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.elastic.co/apm
 
 require (
 	github.com/armon/go-radix v1.0.0
-	github.com/cucumber/godog v0.8.0
+	github.com/cucumber/godog v0.8.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/elastic/go-sysinfo v1.1.1
 	github.com/google/go-cmp v0.3.1


### PR DESCRIPTION
bug with go 1.14

```
verifying github.com/cucumber/godog@v0.8.0/go.mod: checksum mismatch
	downloaded: h1:Cp3tEV1LRAyH/RuCThcxHS/+9ORZ+FMzPva2AZ5Ki+A=
	go.sum:     h1:FQ2MobPXycdSajAK3inNgLSAKGFmZqbE4S/CExz41Ys=
```