### PR TITLE
docs: Add link to Agent/Server compatibility

### DIFF
--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -41,4 +41,5 @@ This collection happens in a background goroutine that is automatically started 
 === Additional Components
 
 APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together. 
+The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].


### PR DESCRIPTION
## What does this PR do?
This PR adds a link to the Agent/Server compatibility matrix.

## Related issues

For https://github.com/elastic/apm/issues/229.

## Screenshots

<img width="695" alt="Screen Shot 2020-03-25 at 4 04 17 PM" src="https://user-images.githubusercontent.com/5618806/77593911-55be7280-6eb2-11ea-95f4-06486ade9250.png">
