### PR TITLE
Introduce "recording" config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ endif::[]
 
 https://github.com/elastic/apm-agent-go/compare/v1.7.2...master[View commits]
 
+- Add "recording" config option, to dynamically disable event recording {pull}737[(#737)]
+
 [[release-notes-1.x]]
 === Go Agent version 1.x
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -213,6 +213,20 @@ Enable or disable the agent. If set to false, then the Go agent does not send
 any data to the Elastic APM server, and instrumentation overhead is minimized.
 
 [float]
+[[config-recording]]
+=== `ELASTIC_APM_RECORDING`
+
+[options="header"]
+|============
+| Environment             | Default | Example
+| `ELASTIC_APM_RECORDING` | true    | `false`
+|============
+
+Enable or disable recording of events. If set to false, then the Go agent does
+send any events to the Elastic APM server, and instrumentation overhead is
+minimized, but the agent will continue to poll the server for configuration changes.
+
+[float]
 [[config-global-labels]]
 === `ELASTIC_APM_GLOBAL_LABELS`
 

--- a/env_test.go
+++ b/env_test.go
@@ -334,6 +334,7 @@ func TestTracerActiveEnv(t *testing.T) {
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 	assert.False(t, tracer.Active())
+	assert.False(t, tracer.Recording()) // inactive => not recording
 
 	tx := tracer.StartTransaction("name", "type")
 	tx.End()

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -64,7 +64,7 @@ type middleware struct {
 
 func (m *middleware) handle(c echo.Context) error {
 	req := c.Request()
-	if !m.tracer.Active() || m.requestIgnorer(req) {
+	if !m.tracer.Recording() || m.requestIgnorer(req) {
 		return m.handler(c)
 	}
 	name := req.Method + " " + c.Path()

--- a/module/apmechov4/middleware.go
+++ b/module/apmechov4/middleware.go
@@ -66,7 +66,7 @@ type middleware struct {
 
 func (m *middleware) handle(c echo.Context) error {
 	req := c.Request()
-	if !m.tracer.Active() || m.requestIgnorer(req) {
+	if !m.tracer.Recording() || m.requestIgnorer(req) {
 		return m.handler(c)
 	}
 	name := req.Method + " " + c.Path()

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -69,7 +69,7 @@ type routeInfo struct {
 }
 
 func (m *middleware) handle(c *gin.Context) {
-	if !m.tracer.Active() || m.requestIgnorer(c.Request) {
+	if !m.tracer.Recording() || m.requestIgnorer(c.Request) {
 		c.Next()
 		return
 	}

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -63,7 +63,7 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
-		if !opts.tracer.Active() || opts.requestIgnorer(info) {
+		if !opts.tracer.Recording() || opts.requestIgnorer(info) {
 			return handler(ctx, req)
 		}
 		tx, ctx := startTransaction(ctx, opts.tracer, info.FullMethod)

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -67,7 +67,7 @@ type handler struct {
 // ServeHTTP delegates to h.Handler, tracing the transaction with
 // h.Tracer, or apm.DefaultTracer if h.Tracer is nil.
 func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if !h.tracer.Active() || h.requestIgnorer(req) {
+	if !h.tracer.Recording() || h.requestIgnorer(req) {
 		h.handler.ServeHTTP(w, req)
 		return
 	}

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -38,7 +38,7 @@ import (
 func Wrap(h httprouter.Handle, route string, o ...Option) httprouter.Handle {
 	opts := gatherOptions(o...)
 	return func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
-		if !opts.tracer.Active() || opts.requestIgnorer(req) {
+		if !opts.tracer.Recording() || opts.requestIgnorer(req) {
 			h(w, req, p)
 			return
 		}

--- a/module/apmlogrus/hook.go
+++ b/module/apmlogrus/hook.go
@@ -87,7 +87,7 @@ func (h *Hook) Levels() []logrus.Level {
 // Fire reports the log entry as an error to the APM Server.
 func (h *Hook) Fire(entry *logrus.Entry) error {
 	tracer := h.tracer()
-	if !tracer.Active() {
+	if !tracer.Recording() {
 		return nil
 	}
 

--- a/module/apmrestful/filter.go
+++ b/module/apmrestful/filter.go
@@ -51,7 +51,7 @@ type filter struct {
 }
 
 func (f *filter) filter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
-	if !f.tracer.Active() || f.requestIgnorer(req.Request) {
+	if !f.tracer.Recording() || f.requestIgnorer(req.Request) {
 		chain.ProcessFilter(req, resp)
 		return
 	}

--- a/module/apmzap/core.go
+++ b/module/apmzap/core.go
@@ -87,7 +87,7 @@ func (c *Core) With(fields []zapcore.Field) zapcore.Core {
 
 // Check checks if the entry should be logged, and adds c to checked if so.
 func (c *Core) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if entry.Level < zapcore.ErrorLevel || !c.tracer().Active() {
+	if entry.Level < zapcore.ErrorLevel || !c.tracer().Recording() {
 		return checked
 	}
 	return checked.AddCore(entry, c)
@@ -122,7 +122,7 @@ func (c *contextCore) With(fields []zapcore.Field) zapcore.Core {
 }
 
 func (c *contextCore) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if entry.Level < zapcore.ErrorLevel || !c.core.tracer().Active() {
+	if entry.Level < zapcore.ErrorLevel || !c.core.tracer().Recording() {
 		return checked
 	}
 	return checked.AddCore(entry, c)

--- a/module/apmzerolog/writer.go
+++ b/module/apmzerolog/writer.go
@@ -108,7 +108,7 @@ func (w *Writer) WriteLevel(level zerolog.Level, p []byte) (int, error) {
 		return len(p), nil
 	}
 	tracer := w.tracer()
-	if !tracer.Active() {
+	if !tracer.Recording() {
 		return len(p), nil
 	}
 	var logRecord logRecord

--- a/profiling.go
+++ b/profiling.go
@@ -136,6 +136,10 @@ func (state *profilingState) start(ctx context.Context, logger Logger, metadata 
 			if logger != nil && ctx.Err() == nil {
 				logger.Errorf("failed to send %s profile: %s", state.profileType, err)
 			}
+			return
+		}
+		if logger != nil {
+			logger.Debugf("sent %s profile", state.profileType)
 		}
 	}()
 }


### PR DESCRIPTION
We introduce the ELASTIC_APM_RECORDING configuration.
This is a boolean configuration that defaults to true,
controlling whether events are recorded and sent. When
recording is true there should be no change; when false:

 - Transactions will always be recorded as "unsampled",
   and will be silently discarded when ended, without
   affecting tracer statistics
 - Spans will all be dropped by virtue of transactions
   all being unsampled
 - Captured errors will not have details filled in, and
   will be silently discarded when "sent" without affecting
   tracer statistics
 - Breakdown metrics will not be updated
 - Metrics gathering will be disabled

Recording can be updated via central config and by using
the new Tracer.SetRecording method.

We also introduce a new Tracer.Recording method which
reports whether events are being recorded. If the tracer
is inactive (Tracer.Active returns false), then
Tracer.Recording will also return false. This new method
can be used by instrumentation to avoid expensive
instrumentation paths when recording is disabled. We have
updated all provided instrumentation modules to use the
new Tracer.Recording method instead of Tracer.Active.