### PR TITLE
ci(jenkins): add resilience when timeout issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,7 +286,12 @@ def generateStep(version){
               sleep randomNumber(min: 2, max: 5)
               sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
             }
-            sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+            // Another retry in case there are any environmental issues
+            // See https://issuetracker.google.com/issues/146072599 for more context
+            retry(2) {
+              sleep randomNumber(min: 2, max: 5)
+              sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+            }
           }
         }
       } catch(e){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,7 +279,7 @@ def generateStep(version){
         withEnv(["GO_VERSION=${version}"]) {
           // Another retry in case there are any environmental issues
           // See https://issuetracker.google.com/issues/146072599 for more context
-          retry(2) {
+          retry(3) {
             deleteDir()
             unstash 'source'
             dir("${BASE_DIR}"){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,23 +275,19 @@ def generateStep(version){
   return {
     node('linux && immutable'){
       try {
-        deleteDir()
-        unstash 'source'
         echo "${version}"
-        dir("${BASE_DIR}"){
-          withEnv(["GO_VERSION=${version}"]) {
-            // Another retry in case there are any environmental issues
-            // See https://issuetracker.google.com/issues/146072599 for more context
-            retry(2) {
-              sleep randomNumber(min: 2, max: 5)
+        withEnv(["GO_VERSION=${version}"]) {
+          // Another retry in case there are any environmental issues
+          // See https://issuetracker.google.com/issues/146072599 for more context
+          retry(2) {
+            deleteDir()
+            unstash 'source'
+            dir("${BASE_DIR}"){
               sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
-            }
-            // Another retry in case there are any environmental issues
-            // See https://issuetracker.google.com/issues/146072599 for more context
-            retry(2) {
-              sleep randomNumber(min: 2, max: 5)
               sh script: './scripts/jenkins/build.sh', label: 'Build'
             }
+          }
+          dir("${BASE_DIR}"){
             sh script: './scripts/jenkins/test.sh', label: 'Test'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,8 +290,9 @@ def generateStep(version){
             // See https://issuetracker.google.com/issues/146072599 for more context
             retry(2) {
               sleep randomNumber(min: 2, max: 5)
-              sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+              sh script: './scripts/jenkins/build.sh', label: 'Build'
             }
+            sh script: './scripts/jenkins/test.sh', label: 'Test'
           }
         }
       } catch(e){

--- a/scripts/jenkins/build-test.sh
+++ b/scripts/jenkins/build-test.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
-
-make install precheck check-modules
-
-# Run the tests
-set +e
-export OUT_FILE="build/test-report.out"
-mkdir -p build
-make test 2>&1 | tee ${OUT_FILE}
-status=$?
-
-go get -v -u github.com/jstemmer/go-junit-report
-go-junit-report > "build/junit-apm-agent-go-${GO_VERSION}.xml" < ${OUT_FILE}
-
-exit ${status}
+./scripts/jenkins/build.sh
+./scripts/jenkins/test.sh

--- a/scripts/jenkins/build.sh
+++ b/scripts/jenkins/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Install Go using the same travis approach
+echo "Installing ${GO_VERSION} with gimme."
+eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+
+make install precheck check-modules

--- a/scripts/jenkins/test.sh
+++ b/scripts/jenkins/test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Install Go using the same travis approach
+echo "Installing ${GO_VERSION} with gimme."
+eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+
+# Run the tests
+set +e
+export OUT_FILE="build/test-report.out"
+mkdir -p build
+make test 2>&1 | tee ${OUT_FILE}
+status=$?
+
+go get -v -u github.com/jstemmer/go-junit-report
+go-junit-report > "build/junit-apm-agent-go-${GO_VERSION}.xml" < ${OUT_FILE}
+
+exit ${status}


### PR DESCRIPTION
### What

Split build-test.sh into two different scripts to retry if there are build errors when fetching the dependencies from github, see the below error:

```
[2020-03-27T14:35:15.622Z] Cloning into '/var/lib/jenkins/workspace/agent-go_apm-agent-go-mbp_master/src/github.com/prometheus/procfs'...
[2020-03-27T14:35:15.622Z] fatal: unable to access 'https://github.com/prometheus/procfs/': Failed to connect to github.com port 443: Connection timed out
[2020-03-27T14:35:15.622Z] package github.com/prometheus/procfs: exit status 128
```

### Why

Timeout issues are still a problem in the GCP, for such, we do use the retry/sleep approach. On the other hand, by decoupling the script in two different steps will help to retry the test step when there are genuine test failures, aka faster feedback.


