### PR TITLE
Implement CloseIdleConnections on apmelasticsearch

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.7.2...master[View commits]
 
 - Add "recording" config option, to dynamically disable event recording {pull}737[(#737)]
 - Enable central configuration of "stack_frames_min_duration" and "stack_trace_limit" {pull}742[(#742)]
+- Implement "CloseIdleConnections" on the Elasticsearch RoundTripper {pull}750[(#750)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -99,6 +99,16 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
+// CloseIdleConnections calls r.r.CloseIdleConnections if the method exists.
+func (r *roundTripper) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if tr, ok := r.r.(closeIdler); ok {
+		tr.CloseIdleConnections()
+	}
+}
+
 type responseBody struct {
 	span *apm.Span
 	body io.ReadCloser


### PR DESCRIPTION
The apmelasticsearch `roundTripper` did not implement `CloseIdleConnections` and we (@charith-elastic who did the investigation) believe we observed a goroutine leak as a consequence of that. 

This PR adds support for `CloseIdleConnections` and propagates it to the wrapped transport/ `RoundTripper` if it implements it.