### PR TITLE
set url.full even when path is empty

### DIFF
--- a/model/marshal.go
+++ b/model/marshal.go
@@ -191,7 +191,7 @@ func (v *URL) MarshalFastJSON(w *fastjson.Writer) error {
 		}
 		w.String(v.Search)
 	}
-	if schemeEnd != -1 && v.Hostname != "" && v.Path != "" {
+	if schemeEnd != -1 && v.Hostname != "" {
 		before := w.Size()
 		w.RawString(",\"full\":")
 		if !v.marshalFullURL(w, w.Bytes()[schemeBegin:schemeEnd]) {
@@ -243,10 +243,12 @@ func (v *URL) marshalFullURL(w *fastjson.Writer, scheme []byte) bool {
 		w.RawByte(':')
 		w.StringContents(v.Port)
 	}
-	if !strings.HasPrefix(v.Path, "/") {
-		w.RawByte('/')
+	if v.Path != "" {
+		if !strings.HasPrefix(v.Path, "/") {
+			w.RawByte('/')
+		}
+		w.StringContents(v.Path)
 	}
-	w.StringContents(v.Path)
 	if v.Search != "" {
 		w.RawByte('?')
 		w.StringContents(v.Search)

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -401,12 +401,14 @@ func TestMarshalURL(t *testing.T) {
 }
 
 func TestMarshalURLPathEmpty(t *testing.T) {
-	var empty fastjson.Writer
-	(&model.URL{
+	in := model.URL{
 		Hostname: "example.com",
 		Path:     "",
 		Protocol: "http",
-	}).MarshalFastJSON(&empty)
+	}
+
+	var w fastjson.Writer
+	w.MarshalFastJSON(&w)
 
 	var out model.URL
 	err := json.Unmarshal(empty.Bytes(), &out)

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -408,10 +408,10 @@ func TestMarshalURLPathEmpty(t *testing.T) {
 	}
 
 	var w fastjson.Writer
-	w.MarshalFastJSON(&w)
+	in.MarshalFastJSON(&w)
 
 	var out model.URL
-	err := json.Unmarshal(empty.Bytes(), &out)
+	err := json.Unmarshal(w.Bytes(), &out)
 	require.NoError(t, err)
 	assert.Equal(t, "http://example.com", out.Full)
 }

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -400,6 +400,20 @@ func TestMarshalURL(t *testing.T) {
 	assert.Equal(t, in, out)
 }
 
+func TestMarshalURLPathEmpty(t *testing.T) {
+	var empty fastjson.Writer
+	(&model.URL{
+		Hostname: "example.com",
+		Path:     "",
+		Protocol: "http",
+	}).MarshalFastJSON(&empty)
+
+	var out model.URL
+	err := json.Unmarshal(empty.Bytes(), &out)
+	require.NoError(t, err)
+	assert.Equal(t, "http://example.com", out.Full)
+}
+
 func TestMarshalURLPathLeadingSlashMissing(t *testing.T) {
 	in := model.URL{
 		Path:     "foo",


### PR DESCRIPTION
`url.full` is not set when path is empty but is when rootless.  This makes a difference in the APM UI:

## Empty Before

<img width="470" alt="image" src="https://user-images.githubusercontent.com/83483/80751145-4953b800-8af7-11ea-867d-9d35b8a31b9f.png">

## Empty After

<img width="592" alt="image" src="https://user-images.githubusercontent.com/83483/80751160-51135c80-8af7-11ea-9f06-c93c9f7a832b.png">

## Rootless

<img width="576" alt="image" src="https://user-images.githubusercontent.com/83483/80751184-5b355b00-8af7-11ea-8bce-ee9fdb2bee55.png">
