### PR TITLE
module/apmot: fix nil-pointer deref in Inject

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.7.2...master[View commits]
 - Add "recording" config option, to dynamically disable event recording {pull}737[(#737)]
 - Enable central configuration of "stack_frames_min_duration" and "stack_trace_limit" {pull}742[(#742)]
 - Implement "CloseIdleConnections" on the Elasticsearch RoundTripper {pull}750[(#750)]
+- Fix apmot nil pointer dereference in Tracer.Inject {pull}763[(#763)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/module/apmot/tracer.go
+++ b/module/apmot/tracer.go
@@ -107,10 +107,9 @@ func (t *otTracer) Inject(sc opentracing.SpanContext, format interface{}, carrie
 		if !ok {
 			return opentracing.ErrInvalidCarrier
 		}
-		tx := spanContext.Transaction()
 		headerValue := apmhttp.FormatTraceparentHeader(spanContext.traceContext)
 		writer.Set(apmhttp.W3CTraceparentHeader, headerValue)
-		if tx.ShouldPropagateLegacyHeader() {
+		if t.tracer.ShouldPropagateLegacyHeader() {
 			writer.Set(apmhttp.ElasticTraceparentHeader, headerValue)
 		}
 		if tracestate := spanContext.traceContext.State.String(); tracestate != "" {

--- a/tracer.go
+++ b/tracer.go
@@ -503,6 +503,16 @@ func (t *Tracer) Active() bool {
 	return atomic.LoadInt32(&t.active) == 1
 }
 
+// ShouldPropagateLegacyHeader reports whether instrumentation should
+// propagate the legacy "Elastic-Apm-Traceparent" header in addition to
+// the standard W3C "traceparent" header.
+//
+// This method will be removed in a future major version when we remove
+// support for propagating the legacy header.
+func (t *Tracer) ShouldPropagateLegacyHeader() bool {
+	return t.instrumentationConfig().propagateLegacyHeader
+}
+
 // SetRequestDuration sets the maximum amount of time to keep a request open
 // to the APM server for streaming data before closing the stream and starting
 // a new request.


### PR DESCRIPTION
If the SpanContext passed to Inject does not contain a Transaction, then Inject would panic due to a nil pointer dereference. Transaction will always be nil in the result of Extract, and will only be set when creating a new span with the context.

We were using the transaction to check if we should inject the legacy header. Since this is not a dynamic configuration setting, we can just use the tracer instead, by adding a `tracer.ShouldPropagateLegacyHeader` method.

Fixes #761 
Supersedes #762 