### PR TITLE
chore(ci): separate retries into two separate steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,10 +280,10 @@ def generateStep(version){
         withEnv(["GO_VERSION=${version}"]) {
           // Another retry in case there are any environmental issues
           // See https://issuetracker.google.com/issues/146072599 for more context
-          deleteDir()
-          unstash 'source'
           retry(3) {
             dir("${BASE_DIR}"){
+              deleteDir()
+              unstash 'source'
               sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,11 +280,15 @@ def generateStep(version){
         withEnv(["GO_VERSION=${version}"]) {
           // Another retry in case there are any environmental issues
           // See https://issuetracker.google.com/issues/146072599 for more context
+          deleteDir()
+          unstash 'source'
           retry(3) {
-            deleteDir()
-            unstash 'source'
             dir("${BASE_DIR}"){
               sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
+            }
+          }
+          retry(3) {
+            dir("${BASE_DIR}"){
               sh script: './scripts/jenkins/build.sh', label: 'Build'
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,11 +198,17 @@ pipeline {
           }
           steps {
             withGithubNotify(context: 'Build-Test - OSX') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
-                sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+              retry(3) {
+                deleteDir()
+                unstash 'source'
+                dir("${BASE_DIR}"){
+                  sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
+                }
+              }
+              retry(3) {
+                dir("${BASE_DIR}"){
+                  sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -281,9 +281,9 @@ def generateStep(version){
           // Another retry in case there are any environmental issues
           // See https://issuetracker.google.com/issues/146072599 for more context
           retry(3) {
+            deleteDir()
+            unstash 'source'
             dir("${BASE_DIR}"){
-              deleteDir()
-              unstash 'source'
               sh script: './scripts/jenkins/before_install.sh', label: 'Install dependencies'
             }
           }


### PR DESCRIPTION
## What is this PR doing?
It separates the before_install and build scripts into two different retries on CI

## Why is it important?
With previous approach, if the second step (build) failed, then the before_install will be executed again, even if it already executed with success