### PR TITLE
chore(ci): use same approach for *nix workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,8 +207,11 @@ pipeline {
               }
               retry(3) {
                 dir("${BASE_DIR}"){
-                  sh script: './scripts/jenkins/build-test.sh', label: 'Build and test'
+                  sh script: './scripts/jenkins/build.sh', label: 'Build'
                 }
+              }
+              dir("${BASE_DIR}"){
+                sh script: './scripts/jenkins/test.sh', label: 'Test'
               }
             }
           }

--- a/scripts/jenkins/build-test.sh
+++ b/scripts/jenkins/build-test.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-./scripts/jenkins/build.sh
-./scripts/jenkins/test.sh


### PR DESCRIPTION
## What does this PR do?
It splits the execution of the build & test scripts for OSX, following same strategy used in the Linux workers

## Why is it important?
Consistency

## Related issues
- Closes #797