### PR TITLE
Fix string(0) in test for Go 1.15

### DIFF
--- a/tracecontext_test.go
+++ b/tracecontext_test.go
@@ -97,8 +97,8 @@ func TestTraceStateInvalidValueLength(t *testing.T) {
 
 func TestTraceStateInvalidValueCharacter(t *testing.T) {
 	for _, value := range []string{
-		string(0),
-		"header" + string(0) + "trailer",
+		string(rune(0)),
+		"header" + string(rune(0)) + "trailer",
 	} {
 		ts := apm.NewTraceState(apm.TraceStateEntry{Key: "oy", Value: value})
 		assert.EqualError(t, ts.Validate(),


### PR DESCRIPTION
Go 1.15 doesn't care for `string(0)`, prefers `string(rune(0))`.