### PR TITLE
Record {transaction,sample}.sample_rate

### DIFF
--- a/config.go
+++ b/config.go
@@ -388,6 +388,7 @@ func (t *Tracer) updateRemoteConfig(logger WarningLogger, old, attrs map[string]
 			} else {
 				updates = append(updates, func(cfg *instrumentationConfig) {
 					cfg.sampler = sampler
+					cfg.extendedSampler, _ = sampler.(ExtendedSampler)
 				})
 			}
 		default:
@@ -479,6 +480,7 @@ type instrumentationConfigValues struct {
 	recording             bool
 	captureBody           CaptureBodyMode
 	captureHeaders        bool
+	extendedSampler       ExtendedSampler
 	maxSpans              int
 	sampler               Sampler
 	spanFramesMinDuration time.Duration

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -390,6 +390,10 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) error {
 		w.RawString(",\"result\":")
 		w.String(v.Result)
 	}
+	if v.SampleRate != nil {
+		w.RawString(",\"sample_rate\":")
+		w.Float64(*v.SampleRate)
+	}
 	if v.Sampled != nil {
 		w.RawString(",\"sampled\":")
 		w.Bool(*v.Sampled)
@@ -444,6 +448,10 @@ func (v *Span) MarshalFastJSON(w *fastjson.Writer) error {
 		if err := v.ParentID.MarshalFastJSON(w); err != nil && firstErr == nil {
 			firstErr = err
 		}
+	}
+	if v.SampleRate != nil {
+		w.RawString(",\"sample_rate\":")
+		w.Float64(*v.SampleRate)
 	}
 	if v.Stacktrace != nil {
 		w.RawString(",\"stacktrace\":")

--- a/model/model.go
+++ b/model/model.go
@@ -205,6 +205,10 @@ type Transaction struct {
 	// it to true.
 	Sampled *bool `json:"sampled,omitempty"`
 
+	// SampleRate holds the sample rate in effect when the trace was started,
+	// if known. This is used by the server to aggregate transaction metrics.
+	SampleRate *float64 `json:"sample_rate,omitempty"`
+
 	// SpanCount holds statistics on spans within a transaction.
 	SpanCount SpanCount `json:"span_count"`
 }
@@ -253,6 +257,10 @@ type Span struct {
 
 	// ParentID holds the ID of the span's parent (span or transaction).
 	ParentID SpanID `json:"parent_id,omitempty"`
+
+	// SampleRate holds the sample rate in effect when the trace was started,
+	// if known. This is used by the server to aggregate span metrics.
+	SampleRate *float64 `json:"sample_rate,omitempty"`
 
 	// Context holds contextual information relating to the span.
 	Context *SpanContext `json:"context,omitempty"`

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -109,6 +109,9 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 	if !sampled {
 		out.Sampled = &notSampled
 	}
+	if tx.traceContext.State.haveSampleRate {
+		out.SampleRate = &tx.traceContext.State.sampleRate
+	}
 
 	out.ParentID = model.SpanID(td.parentSpan)
 	out.Name = truncateString(td.Name)
@@ -137,6 +140,9 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span, sd *SpanData) 
 	out.ID = model.SpanID(span.traceContext.Span)
 	out.TraceID = model.TraceID(span.traceContext.Trace)
 	out.TransactionID = model.SpanID(span.transactionID)
+	if span.traceContext.State.haveSampleRate {
+		out.SampleRate = &span.traceContext.State.sampleRate
+	}
 
 	out.ParentID = model.SpanID(sd.parentID)
 	out.Name = truncateString(sd.Name)

--- a/module/apmgrpc/client_test.go
+++ b/module/apmgrpc/client_test.go
@@ -93,7 +93,7 @@ func testClientSpan(t *testing.T, traceparentHeaders ...string) {
 	}
 	assert.Equal(t, clientSpans[0].TraceID, serverTransactions[1].TraceID)
 	assert.Equal(t, clientSpans[0].ID, serverTransactions[1].ParentID)
-	assert.Equal(t, "server_span", serverSpans[0].Name) // no tracestate
+	assert.Equal(t, "es=s:1", serverSpans[0].Name) // automatically created tracestate
 	assert.Equal(t, "vendor=tracestate", serverSpans[1].Name)
 
 	traceparentValue := apmhttp.FormatTraceparentHeader(apm.TraceContext{

--- a/module/apmot/harness_test.go
+++ b/module/apmot/harness_test.go
@@ -115,5 +115,6 @@ func (harnessAPIProbe) SameSpanContext(span opentracing.Span, sc opentracing.Spa
 	if !ok {
 		return false
 	}
-	return ctx1.traceContext == ctx2.traceContext
+	return ctx1.traceContext.Trace == ctx2.traceContext.Trace &&
+		ctx1.traceContext.Span == ctx2.traceContext.Span
 }

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -86,3 +86,23 @@ func TestRatioSamplerNever(t *testing.T) {
 		Span: apm.SpanID{255, 255, 255, 255, 255, 255, 255, 255},
 	}))
 }
+
+func TestRatioSamplerExtended(t *testing.T) {
+	s := apm.NewRatioSampler(0.5).(apm.ExtendedSampler)
+
+	result := s.SampleExtended(apm.SampleParams{
+		TraceContext: apm.TraceContext{Span: apm.SpanID{255, 0, 0, 0, 0, 0, 0, 0}},
+	})
+	assert.Equal(t, apm.SampleResult{
+		Sampled:    false,
+		SampleRate: 0.5,
+	}, result)
+
+	result = s.SampleExtended(apm.SampleParams{
+		TraceContext: apm.TraceContext{Span: apm.SpanID{1, 0, 0, 0, 0, 0, 0, 0}},
+	})
+	assert.Equal(t, apm.SampleResult{
+		Sampled:    true,
+		SampleRate: 0.5,
+	}, result)
+}

--- a/tracecontext.go
+++ b/tracecontext.go
@@ -22,9 +22,15 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"unicode"
 
 	"github.com/pkg/errors"
+)
+
+const (
+	elasticTracestateVendorKey = "es"
 )
 
 var (
@@ -152,6 +158,13 @@ func (o TraceOptions) WithRecorded(recorded bool) TraceOptions {
 // TraceState holds vendor-specific state for a trace.
 type TraceState struct {
 	head *TraceStateEntry
+
+	// Fields related to parsing the Elastic ("es") tracestate entry.
+	//
+	// These must not be modified after NewTraceState returns.
+	parseElasticTracestateError error
+	haveSampleRate              bool
+	sampleRate                  float64
 }
 
 // NewTraceState returns a TraceState based on entries.
@@ -167,7 +180,53 @@ func NewTraceState(entries ...TraceStateEntry) TraceState {
 		}
 		last = &e
 	}
+	for _, e := range entries {
+		if e.Key != elasticTracestateVendorKey {
+			continue
+		}
+		out.parseElasticTracestateError = out.parseElasticTracestate(e)
+		break
+	}
 	return out
+}
+
+// parseElasticTracestate parses an Elastic ("es") tracestate entry.
+//
+// Per https://github.com/elastic/apm/blob/master/specs/agents/tracing-distributed-tracing.md,
+// the "es" tracestate value format is: "key:value;key:value...". Unknown keys are ignored.
+func (s *TraceState) parseElasticTracestate(e TraceStateEntry) error {
+	if err := e.Validate(); err != nil {
+		return err
+	}
+	value := e.Value
+	for value != "" {
+		kv := value
+		end := strings.IndexRune(value, ';')
+		if end >= 0 {
+			kv = value[:end]
+			value = value[end+1:]
+		} else {
+			value = ""
+		}
+		sep := strings.IndexRune(kv, ':')
+		if sep == -1 {
+			return errors.New("malformed 'es' tracestate entry")
+		}
+		k, v := kv[:sep], kv[sep+1:]
+		switch k {
+		case "s":
+			sampleRate, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return err
+			}
+			if sampleRate < 0 || sampleRate > 1 {
+				return fmt.Errorf("sample rate %q out of range", v)
+			}
+			s.sampleRate = sampleRate
+			s.haveSampleRate = true
+		}
+	}
+	return nil
 }
 
 // String returns s as a comma-separated list of key-value pairs.
@@ -199,8 +258,16 @@ func (s TraceState) Validate() error {
 		if i == 32 {
 			return errors.New("tracestate contains more than the maximum allowed number of entries, 32")
 		}
-		if err := e.Validate(); err != nil {
-			return errors.Wrapf(err, "invalid tracestate entry at position %d", i)
+		if e.Key == elasticTracestateVendorKey {
+			// s.parseElasticTracestateError holds a general e.Validate error if any
+			// occurred, or any other error specific to the Elastic tracestate format.
+			if err := s.parseElasticTracestateError; err != nil {
+				return errors.Wrapf(err, "invalid tracestate entry at position %d", i)
+			}
+		} else {
+			if err := e.Validate(); err != nil {
+				return errors.Wrapf(err, "invalid tracestate entry at position %d", i)
+			}
 		}
 		if prev, ok := recorded[e.Key]; ok {
 			return fmt.Errorf("duplicate tracestate key %q at positions %d and %d", e.Key, prev, i)
@@ -260,4 +327,11 @@ func (e *TraceStateEntry) validateValue() error {
 		}
 	}
 	return nil
+}
+
+func formatElasticTracestateValue(sampleRate float64) string {
+	// 0      -> "s:0"
+	// 1      -> "s:1"
+	// 0.5555 -> "s:0.555" (any rounding should be applied prior)
+	return fmt.Sprintf("s:%.3g", sampleRate)
 }

--- a/tracecontext_test.go
+++ b/tracecontext_test.go
@@ -105,3 +105,14 @@ func TestTraceStateInvalidValueCharacter(t *testing.T) {
 			`invalid tracestate entry at position 0: invalid value for key "oy": value contains invalid character '\x00'`)
 	}
 }
+
+func TestTraceStateInvalidElasticEntry(t *testing.T) {
+	ts := apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "foo"})
+	assert.EqualError(t, ts.Validate(), `invalid tracestate entry at position 0: malformed 'es' tracestate entry`)
+
+	ts = apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "s:foo"})
+	assert.EqualError(t, ts.Validate(), `invalid tracestate entry at position 0: strconv.ParseFloat: parsing "foo": invalid syntax`)
+
+	ts = apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "s:1.5"})
+	assert.EqualError(t, ts.Validate(), `invalid tracestate entry at position 0: sample rate "1.5" out of range`)
+}

--- a/tracer.go
+++ b/tracer.go
@@ -412,6 +412,7 @@ func newTracer(opts TracerOptions) *Tracer {
 	})
 	t.setLocalInstrumentationConfig(envTransactionSampleRate, func(cfg *instrumentationConfigValues) {
 		cfg.sampler = opts.sampler
+		cfg.extendedSampler, _ = opts.sampler.(ExtendedSampler)
 	})
 	t.setLocalInstrumentationConfig(envSpanFramesMinDuration, func(cfg *instrumentationConfigValues) {
 		cfg.spanFramesMinDuration = opts.spanFramesMinDuration
@@ -664,6 +665,7 @@ func (t *Tracer) SetRecording(r bool) {
 func (t *Tracer) SetSampler(s Sampler) {
 	t.setLocalInstrumentationConfig(envTransactionSampleRate, func(cfg *instrumentationConfigValues) {
 		cfg.sampler = s
+		cfg.extendedSampler, _ = s.(ExtendedSampler)
 	})
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -175,6 +175,116 @@ func TestTransactionNotRecording(t *testing.T) {
 	require.Empty(t, payloads.Transactions)
 }
 
+func TestTransactionSampleRate(t *testing.T) {
+	type test struct {
+		actualSampleRate   float64
+		recordedSampleRate float64
+		expectedTraceState string
+	}
+	tests := []test{
+		{0, 0, "es=s:0"},
+		{1, 1, "es=s:1"},
+		{0.5555, 0.556, "es=s:0.556"},
+	}
+	for _, test := range tests {
+		test := test // copy for closure
+		t.Run(fmt.Sprintf("%v", test.actualSampleRate), func(t *testing.T) {
+			tracer := apmtest.NewRecordingTracer()
+			defer tracer.Close()
+
+			tracer.SetSampler(apm.NewRatioSampler(test.actualSampleRate))
+			tx := tracer.StartTransactionOptions("name", "type", apm.TransactionOptions{
+				// Use a known transaction ID for deterministic sampling.
+				TransactionID: apm.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+			})
+			tx.End()
+			tracer.Flush(nil)
+
+			payloads := tracer.Payloads()
+			assert.Equal(t, test.recordedSampleRate, *payloads.Transactions[0].SampleRate)
+			assert.Equal(t, test.expectedTraceState, tx.TraceContext().State.String())
+		})
+	}
+}
+
+func TestTransactionUnsampledSampleRate(t *testing.T) {
+	tracer := apmtest.NewRecordingTracer()
+	defer tracer.Close()
+	tracer.SetSampler(apm.NewRatioSampler(0))
+
+	tx := tracer.StartTransactionOptions("name", "type", apm.TransactionOptions{})
+	tx.End()
+	tracer.Flush(nil)
+
+	payloads := tracer.Payloads()
+	assert.Equal(t, float64(0), *payloads.Transactions[0].SampleRate)
+	assert.Equal(t, "es=s:0", tx.TraceContext().State.String())
+}
+
+func TestTransactionSampleRatePropagation(t *testing.T) {
+	tracer := apmtest.NewRecordingTracer()
+	defer tracer.Close()
+
+	for _, tracestate := range []apm.TraceState{
+		apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "s:0.5"}),
+		apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "x:y;s:0.5;zz:y"}),
+		apm.NewTraceState(
+			apm.TraceStateEntry{Key: "other", Value: "s:1.0"},
+			apm.TraceStateEntry{Key: "es", Value: "s:0.5"},
+		),
+	} {
+		tx := tracer.StartTransactionOptions("name", "type", apm.TransactionOptions{
+			TraceContext: apm.TraceContext{
+				Trace: apm.TraceID{1},
+				Span:  apm.SpanID{1},
+				State: tracestate,
+			},
+		})
+		tx.End()
+	}
+	tracer.Flush(nil)
+
+	payloads := tracer.Payloads()
+	assert.Len(t, payloads.Transactions, 3)
+	for _, tx := range payloads.Transactions {
+		assert.Equal(t, 0.5, *tx.SampleRate)
+	}
+}
+
+func TestTransactionSampleRateOmission(t *testing.T) {
+	tracer := apmtest.NewRecordingTracer()
+	defer tracer.Close()
+
+	// For downstream transactions, sample_rate should be
+	// omitted if a valid value is not found in tracestate.
+	for _, tracestate := range []apm.TraceState{
+		apm.TraceState{}, // empty
+		apm.NewTraceState(apm.TraceStateEntry{Key: "other", Value: "s:1.0"}), // not "es", ignored
+		apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "s:123.0"}),  // out of range
+		apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: ""}),         // 's' missing
+		apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "wat"}),      // malformed
+	} {
+		for _, sampled := range []bool{false, true} {
+			tx := tracer.StartTransactionOptions("name", "type", apm.TransactionOptions{
+				TraceContext: apm.TraceContext{
+					Trace:   apm.TraceID{1},
+					Span:    apm.SpanID{1},
+					Options: apm.TraceOptions(0).WithRecorded(sampled),
+					State:   tracestate,
+				},
+			})
+			tx.End()
+		}
+	}
+	tracer.Flush(nil)
+
+	payloads := tracer.Payloads()
+	assert.Len(t, payloads.Transactions, 10)
+	for _, tx := range payloads.Transactions {
+		assert.Nil(t, tx.SampleRate)
+	}
+}
+
 func BenchmarkTransaction(b *testing.B) {
 	tracer, err := apm.NewTracer("service", "")
 	require.NoError(b, err)

--- a/utils_go10.go
+++ b/utils_go10.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.10
+
+package apm
+
+import "math"
+
+func round(x float64) float64 {
+	return math.Round(x)
+}

--- a/utils_go9.go
+++ b/utils_go9.go
@@ -1,0 +1,33 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !go1.10
+
+package apm
+
+import "math"
+
+// Implementation of math.Round for Go < 1.10.
+//
+// Code shamelessly copied from pkg/math.
+func round(x float64) float64 {
+	t := math.Trunc(x)
+	if math.Abs(x-t) >= 0.5 {
+		return t + math.Copysign(1, x)
+	}
+	return t
+}


### PR DESCRIPTION
Introduce the new ExtendedSampler interface, which
Samplers may implement to return the effective
sampling rate. This is implemented by the built-in
ratioSampler.

When starting a root transaction we now call the
ExtendedSampler method if implemented, and store
the effective sampling rate in the transaction's
tracestate under our "es" vendor key.

When receiving tracestate, we parse our "es" vendor
value and extract the sample rate.

When encoding transactions and spans we record the
sample rate (from tracestate) in the transaction and
span events.