### PR TITLE
docs: fix gin 404s

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -60,7 +60,7 @@ the echo/middleware.Recover middleware.
 
 [[builtin-modules-apmgin]]
 ==== module/apmgin
-Package apmgin provides middleware for the https://gin-gonic.github.io/gin/[Gin] web framework.
+Package apmgin provides middleware for the https://gin-gonic.com/[Gin] web framework.
 
 For each request, a transaction is stored in the request context, which can be obtained via
 https://godoc.org/github.com/gin-gonic/gin#Context[gin.Context]`.Request.Context()` in your handler.

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -56,7 +56,7 @@ about Echo instrumentation.
 [float]
 ==== Gin
 
-We support the https://gin-gonic.github.io/gin/[Gin] web framework,
+We support the https://gin-gonic.com/[Gin] web framework,
 https://github.com/gin-gonic/gin/releases/tag/v1.2[v1.2] and greater.
 
 See <<builtin-modules-apmgin, module/apmgin>> for more information


### PR DESCRIPTION
This PR fixes two external 404s in the Go agent documentation.