### PR TITLE
model: add Cloud metadata types

### DIFF
--- a/apmtest/recorder_test.go
+++ b/apmtest/recorder_test.go
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmtest_test
+
+import (
+	"bytes"
+	"compress/zlib"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm/apmtest"
+	"go.elastic.co/apm/model"
+)
+
+func TestRecordingTracerCloudMetadata(t *testing.T) {
+	r := apmtest.NewRecordingTracer()
+
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	fmt.Fprint(zw, `{"metadata":{"cloud":{"provider":"zeus","region":"troposphere","availability_zone":"torrid","account":{"id":"okayenough"}}}}`)
+	assert.NoError(t, zw.Close())
+
+	err := r.SendStream(context.Background(), &buf)
+	require.NoError(t, err)
+	assert.Equal(t, model.Cloud{
+		Provider:         "zeus",
+		Region:           "troposphere",
+		AvailabilityZone: "torrid",
+		Account:          &model.CloudAccount{ID: "okayenough"},
+	}, r.CloudMetadata())
+}

--- a/apmtest/recorder_test.go
+++ b/apmtest/recorder_test.go
@@ -34,17 +34,18 @@ import (
 func TestRecordingTracerCloudMetadata(t *testing.T) {
 	r := apmtest.NewRecordingTracer()
 
+	// Add just enough cloud metadata to check that it is picked up
+	// by the recorder.
+	//
+	// TODO this test should be removed when we send cloud metadata
+	// from the agent, at which point we should have a test that
+	// ensures the tracer's cloud metadata is sent as expected.
 	var buf bytes.Buffer
 	zw := zlib.NewWriter(&buf)
-	fmt.Fprint(zw, `{"metadata":{"cloud":{"provider":"zeus","region":"troposphere","availability_zone":"torrid","account":{"id":"okayenough"}}}}`)
+	fmt.Fprint(zw, `{"metadata":{"cloud":{"provider":"zeus"}}}`)
 	assert.NoError(t, zw.Close())
 
 	err := r.SendStream(context.Background(), &buf)
 	require.NoError(t, err)
-	assert.Equal(t, model.Cloud{
-		Provider:         "zeus",
-		Region:           "troposphere",
-		AvailabilityZone: "torrid",
-		Account:          &model.CloudAccount{ID: "okayenough"},
-	}, r.CloudMetadata())
+	assert.Equal(t, model.Cloud{Provider: "zeus"}, r.CloudMetadata())
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -349,6 +349,138 @@ func (v *KubernetesPod) MarshalFastJSON(w *fastjson.Writer) error {
 	return nil
 }
 
+func (v *Cloud) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
+	w.RawByte('{')
+	w.RawString("\"provider\":")
+	w.String(v.Provider)
+	if v.Account != nil {
+		w.RawString(",\"account\":")
+		if err := v.Account.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if v.AvailabilityZone != "" {
+		w.RawString(",\"availability_zone\":")
+		w.String(v.AvailabilityZone)
+	}
+	if v.Instance != nil {
+		w.RawString(",\"instance\":")
+		if err := v.Instance.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if v.Machine != nil {
+		w.RawString(",\"machine\":")
+		if err := v.Machine.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if v.Project != nil {
+		w.RawString(",\"project\":")
+		if err := v.Project.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if v.Region != "" {
+		w.RawString(",\"region\":")
+		w.String(v.Region)
+	}
+	w.RawByte('}')
+	return firstErr
+}
+
+func (v *CloudInstance) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	first := true
+	if v.ID != "" {
+		const prefix = ",\"id\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.ID)
+	}
+	if v.Name != "" {
+		const prefix = ",\"name\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Name)
+	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *CloudMachine) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	if v.Type != "" {
+		w.RawString("\"type\":")
+		w.String(v.Type)
+	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *CloudAccount) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	first := true
+	if v.ID != "" {
+		const prefix = ",\"id\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.ID)
+	}
+	if v.Name != "" {
+		const prefix = ",\"name\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Name)
+	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *CloudProject) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	first := true
+	if v.ID != "" {
+		const prefix = ",\"id\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.ID)
+	}
+	if v.Name != "" {
+		const prefix = ",\"name\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Name)
+	}
+	w.RawByte('}')
+	return nil
+}
+
 func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) error {
 	var firstErr error
 	w.RawByte('{')

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -529,6 +529,36 @@ func TestTransactionUnmarshalJSON(t *testing.T) {
 	assert.Equal(t, tx, out)
 }
 
+func TestMarshalCloud(t *testing.T) {
+	cloud := fakeCloud()
+
+	var w fastjson.Writer
+	cloud.MarshalFastJSON(&w)
+
+	decoded := mustUnmarshalJSON(w)
+	expect := map[string]interface{}{
+		"provider":          "zeus",
+		"region":            "troposphere",
+		"availability_zone": "torrid",
+		"instance": map[string]interface{}{
+			"id":   "instance_id",
+			"name": "instance_name",
+		},
+		"machine": map[string]interface{}{
+			"type": "machine_type",
+		},
+		"account": map[string]interface{}{
+			"id":   "account_id",
+			"name": "account_name",
+		},
+		"project": map[string]interface{}{
+			"id":   "project_id",
+			"name": "project_name",
+		},
+	}
+	assert.Equal(t, expect, decoded)
+}
+
 func fakeTransaction() model.Transaction {
 	return model.Transaction{
 		TraceID:   model.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
@@ -683,6 +713,29 @@ func fakeProcess() *model.Process {
 		Ppid:  &ppid,
 		Title: "my-fake-service",
 		Argv:  []string{"my-fake-service", "-f", "config.yml"},
+	}
+}
+
+func fakeCloud() *model.Cloud {
+	return &model.Cloud{
+		Provider:         "zeus",
+		Region:           "troposphere",
+		AvailabilityZone: "torrid",
+		Instance: &model.CloudInstance{
+			ID:   "instance_id",
+			Name: "instance_name",
+		},
+		Machine: &model.CloudMachine{
+			Type: "machine_type",
+		},
+		Account: &model.CloudAccount{
+			ID:   "account_id",
+			Name: "account_name",
+		},
+		Project: &model.CloudProject{
+			ID:   "project_id",
+			Name: "project_name",
+		},
 	}
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -165,6 +165,63 @@ type KubernetesPod struct {
 	UID string `json:"uid,omitempty"`
 }
 
+// Cloud represents the cloud in which the service is running.
+type Cloud struct {
+	// Provider is the cloud provider name, e.g. aws, azure, gcp.
+	Provider string `json:"provider"`
+
+	// Region is the cloud region name, e.g. us-east-1.
+	Region string `json:"region,omitempty"`
+
+	// AvailabilityZone is the cloud availability zone name, e.g. us-east-1a.
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+
+	// Instance holds information about the cloud instance (virtual machine).
+	Instance *CloudInstance `json:"instance,omitempty"`
+
+	// Machine also holds information about the cloud instance (virtual machine).
+	Machine *CloudMachine `json:"machine,omitempty"`
+
+	// Account holds information about the cloud account.
+	Account *CloudAccount `json:"account,omitempty"`
+
+	// Project holds information about the cloud project.
+	Project *CloudProject `json:"project,omitempty"`
+}
+
+// CloudInstance holds information about a cloud instance (virtual machine).
+type CloudInstance struct {
+	// ID holds the cloud instance identifier.
+	ID string `json:"id,omitempty"`
+
+	// ID holds the cloud instance name.
+	Name string `json:"name,omitempty"`
+}
+
+// CloudMachine holds information about a cloud instance (virtual machine).
+type CloudMachine struct {
+	// Type holds the cloud instance type, e.g. t2.medium.
+	Type string `json:"type,omitempty"`
+}
+
+// CloudAccount holds information about a cloud account.
+type CloudAccount struct {
+	// ID holds the cloud account identifier.
+	ID string `json:"id,omitempty"`
+
+	// ID holds the cloud account name.
+	Name string `json:"name,omitempty"`
+}
+
+// CloudProject holds information about a cloud project.
+type CloudProject struct {
+	// ID holds the cloud project identifier.
+	ID string `json:"id,omitempty"`
+
+	// Name holds the cloud project name.
+	Name string `json:"name,omitempty"`
+}
+
 // Transaction represents a transaction handled by the service.
 type Transaction struct {
 	// ID holds the 64-bit hex-encoded transaction ID.

--- a/scripts/jenkins/windows/build-test.bat
+++ b/scripts/jenkins/windows/build-test.bat
@@ -5,7 +5,7 @@
 go get -v -u github.com/jstemmer/go-junit-report
 go get -t ./...
 mkdir build
-go test -v ./... &> build\\test.out
+go test -v ./... > build\\test.out 2>&1
 type build\\test.out
 type build\\test.out | go-junit-report > build\\junit-apm-agent-go.xml
 type build\\junit-apm-agent-go.xml

--- a/scripts/jenkins/windows/build-test.bat
+++ b/scripts/jenkins/windows/build-test.bat
@@ -5,5 +5,7 @@
 go get -v -u github.com/jstemmer/go-junit-report
 go get -t ./...
 mkdir build
-go test -v ./... 2>&1 | go-junit-report > build\\junit-apm-agent-go.xml
+go test -v ./... &> build\\test.out
+type build\\test.out
+type build\\test.out | go-junit-report > build\\junit-apm-agent-go.xml
 type build\\junit-apm-agent-go.xml

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -76,10 +76,24 @@ func (r *RecorderTransport) SendProfile(ctx context.Context, metadata io.Reader,
 
 // Metadata returns the metadata recorded by the transport. If metadata is yet to
 // be received, this method will panic.
+//
+// TODO(axw) introduce an exported type which contains all metadata, and return
+// that. Although we don't guarantee stability for this package this has a high
+// probability of breaking existing external tests, so let's do that in v2.
 func (r *RecorderTransport) Metadata() (_ model.System, _ model.Process, _ model.Service, labels model.IfaceMap) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.metadata.System, r.metadata.Process, r.metadata.Service, r.metadata.Labels
+}
+
+// CloudMetadata returns the cloud metadata recorded by the transport. If metadata
+// is yet to be received, this method will panic.
+//
+// TODO(axw) remove when Metadata returns an exported type containing all metadata.
+func (r *RecorderTransport) CloudMetadata() model.Cloud {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.metadata.Cloud
 }
 
 // Payloads returns the payloads recorded by SendStream.
@@ -199,5 +213,6 @@ type metadata struct {
 	System  model.System   `json:"system"`
 	Process model.Process  `json:"process"`
 	Service model.Service  `json:"service"`
+	Cloud   model.Cloud    `json:"cloud"`
 	Labels  model.IfaceMap `json:"labels,omitempty"`
 }


### PR DESCRIPTION
This is part of https://github.com/elastic/apm-agent-go/issues/786. No metadata collection yet, just adding the types and a method to RecorderTracer for testing.

This unblocks translating [OpenTelemetry cloud semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/cloud.md) while we continue to work on collecting metadata in the agent.