### PR TITLE
internal/apmhostutil: relax k8s cgroup regex

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,15 @@ endif::[]
 
 https://github.com/elastic/apm-agent-go/compare/v1.8.0...master[View commits]
 
+- module/apmgoredisv8: introduce new package to support go-redis v8 {pull}780[#(780)]
+- module/apmhttp: introduce httptrace client option {pull}788[#(788)]
+- module/apmsql: add support for database/sql/driver.Validator {pull}791[#(791)]
+- Record sample rate on transactions and spans, propagate through `tracestate` {pull}804[#(804)]
+- module/apmredigo: change redigo dependency to v1.8.2 {pull}807[#(807)]
+- Deprecate IGNORE_URLS, replace with TRANSACTION_IGNORE_URLS {pull}811[(#811)]
+- Tracer.Close now waits for the transport goroutine to end before returning {pull}816[#(816)]
+- Relax Kubernetes pod UID discovery rules {pull}819[#(819)]
+
 [[release-notes-1.x]]
 === Go Agent version 1.x
 

--- a/internal/apmhostutil/container_linux.go
+++ b/internal/apmhostutil/container_linux.go
@@ -44,7 +44,7 @@ var (
 
 	kubepodsRegexp = regexp.MustCompile(
 		"" +
-			`(?:^/kubepods/[^/]+/pod([^/]+)/$)|` +
+			`(?:^/kubepods[\S]*/pod([^/]+)/$)|` +
 			`(?:^/kubepods\.slice/kubepods-[^/]+\.slice/kubepods-[^/]+-pod([^/]+)\.slice/$)`,
 	)
 


### PR DESCRIPTION
Relax the regular expression to match additional paths like:

- 12:pids:/kubepods/kubepods/besteffort/pod0e886e9a-3879-45f9-b44d-86ef9df03224/244a65edefdffe31685c42317c9054e71dc1193048cf9459e2a4dd35cbc1dba4
- 10:cpuset:/kubepods/pod5eadac96-ab58-11ea-b82b-0242ac110009/7fe41c8a2d1da09420117894f11dd91f6c3a44dfeb7d125dc594bd53468861df

Closes #783 