### PR TITLE
module/apmhttp: implement io.ReaderFrom in wrapper

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.8.0...master[View commits]
 - Relax Kubernetes pod UID discovery rules {pull}819[#(819)]
 - Add transaction and span outcome {pull}820[#(820)]
 - Add cloud metadata, configurable with ELASTIC_APM_CLOUD_PROVIDER {pull}823[#(823)]
+- module/apmhttp: implement io.ReaderFrom in wrapped http.ResponseWriter {pull}830[#(830)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -24,6 +24,7 @@ function pin() {
 }
 
 if (! go run scripts/mingoversion.go 1.11 &>/dev/null); then
+  pin github.com/astaxie/beego v1.11.1
   pin github.com/gin-gonic/gin v1.3.0
   pin github.com/stretchr/testify v1.4.0
   pin github.com/cucumber/godog v0.8.0


### PR DESCRIPTION
If the http.ResponseWriter implements io.ReaderFrom,
make sure the wrapped ResponseWriter also does and
passes through.

Closes #826