### PR TITLE
Transaction.Discard sets TransactionData to nil

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.8.0...master[View commits]
 - Add cloud metadata, configurable with ELASTIC_APM_CLOUD_PROVIDER {pull}823[#(823)]
 - Round ELASTIC_APM_SAMPLING_RATE with 4 digits precision {pull}828[#(828)]
 - module/apmhttp: implement io.ReaderFrom in wrapped http.ResponseWriter {pull}830[#(830)]
+- Fixed Transaction.Discard so that it sets TransactionData to nil {pull}836[#(836)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/transaction.go
+++ b/transaction.go
@@ -246,6 +246,7 @@ func (tx *Transaction) Discard() {
 		return
 	}
 	tx.reset(tx.tracer)
+	tx.TransactionData = nil
 }
 
 // End enqueues tx for sending to the Elastic APM server.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -300,6 +300,20 @@ func TestTransactionSampleRateOmission(t *testing.T) {
 	}
 }
 
+func TestTransactionDiscard(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	tx := tracer.StartTransaction("name", "type")
+	tx.Discard()
+	assert.Nil(t, tx.TransactionData)
+	tx.End() // ending after discarding should be a no-op
+
+	tracer.Flush(nil)
+	payloads := transport.Payloads()
+	require.Empty(t, payloads)
+}
+
 func BenchmarkTransaction(b *testing.B) {
 	tracer, err := apm.NewTracer("service", "")
 	require.NoError(b, err)


### PR DESCRIPTION
Fix Transaction.Discard so that it sets TransactionData
to nil, like its documentation says. This is necessary
to avoid adding a transaction to the `sync.Pool` multiple
times (e.g. by calling End after after it has been discarded.)

Closes #835 