### PR TITLE
docs: add ifeval for 7.10 release

### DIFF
--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -12,7 +12,12 @@ If your favorite logging framework is not already supported, there are two other
 
 Regardless of how you integrate APM with logging, you can use {filebeat-ref}[Filebeat] to
 send your logs to Elasticsearch, in order to correlate your traces and logs and link from
+ifeval::["{branch}"=="7.9"]
 APM to the {apm-app-ref}/xpack-logs.html[Logs app].
+endif::[]
+ifeval::["{branch}"!="7.9"]
+APM to the {observability-guide}/monitor-logs.html[Logs app].
+endif::[]
 
 [float]
 [[log-correlation-manual]]


### PR DESCRIPTION
## Summary

This PR fixes a documentation link that will break when `7.10` becomes the `current` stack version. It conditionally changes the link location of the Logs app docs based on the stack version defined in github.com/elastic/docs ([here](https://github.com/elastic/docs/blob/master/shared/versions/stack/current.asciidoc)).

```asciidoc
ifeval::["{branch}"=="7.9"]
APM to the {apm-app-ref}/xpack-logs.html[Logs app].
endif::[]
ifeval::["{branch}"!="7.9"]
APM to the {observability-guide}/monitor-logs.html[Logs app].
endif::[]
```

Admittedly, this isn't pretty, but it's the cleanest way to ensure this link continues to work for users who click it before and after the `7.10` release.

Tested by building locally with `:branch:` overridden to `7.9`, `7.10`, and `master`.

## Target

**This PR will need to be backported to `1.x`.**

## Related issue

* https://github.com/elastic/observability-docs/issues/215
* https://github.com/elastic/docs/pull/1994

## Follow-ups

After the release of `7.10`, I will backport a fix that removes the conditional code.