### PR TITLE
chore: adds vanity import for files that don't have it.

### DIFF
--- a/apmconfig/doc.go
+++ b/apmconfig/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmconfig provides an API for watching agent config
 // changes.
-package apmconfig
+package apmconfig // import "go.elastic.co/apm/apmconfig"

--- a/apmconfig/watcher.go
+++ b/apmconfig/watcher.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmconfig
+package apmconfig // import "go.elastic.co/apm/apmconfig"
 
 import (
 	"context"

--- a/apmtest/configwatcher.go
+++ b/apmtest/configwatcher.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 import (
 	"context"

--- a/apmtest/discard.go
+++ b/apmtest/discard.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 import (
 	"log"

--- a/apmtest/env.go
+++ b/apmtest/env.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 import "os"
 

--- a/apmtest/httpsuite.go
+++ b/apmtest/httpsuite.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 import (
 	"net/http"

--- a/apmtest/recorder.go
+++ b/apmtest/recorder.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 import (
 	"context"

--- a/apmtest/recordlogger.go
+++ b/apmtest/recordlogger.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 import "fmt"
 

--- a/apmtest/testlogger.go
+++ b/apmtest/testlogger.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 // TestLogger is an implementation of apm.Logger,
 // logging to a testing.T.

--- a/apmtest/withtransaction.go
+++ b/apmtest/withtransaction.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmtest
+package apmtest // import "go.elastic.co/apm/apmtest"
 
 import (
 	"context"

--- a/breakdown.go
+++ b/breakdown.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"fmt"

--- a/builtin_metrics.go
+++ b/builtin_metrics.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"context"

--- a/capturebody.go
+++ b/capturebody.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"bytes"

--- a/config.go
+++ b/config.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"os"

--- a/context.go
+++ b/context.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"fmt"

--- a/error.go
+++ b/error.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"crypto/rand"

--- a/error_unix.go
+++ b/error_unix.go
@@ -17,7 +17,7 @@
 
 // +build !windows
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"syscall"

--- a/error_windows.go
+++ b/error_windows.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"syscall"

--- a/fmt.go
+++ b/fmt.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"context"

--- a/fnv.go
+++ b/fnv.go
@@ -21,7 +21,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 const (
 	offset64 = 14695981039346656037

--- a/gocontext.go
+++ b/gocontext.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"context"

--- a/gofuzz.go
+++ b/gofuzz.go
@@ -17,7 +17,7 @@
 
 // +build gofuzz
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"bytes"

--- a/logger.go
+++ b/logger.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 // Logger is an interface for logging, used by the tracer
 // to log tracer errors and other interesting events.

--- a/metrics.go
+++ b/metrics.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"context"

--- a/model/doc.go
+++ b/model/doc.go
@@ -18,4 +18,4 @@
 // Package model provides the Elastic APM model types.
 //
 // https://www.elastic.co/guide/en/apm/server/current/intake-api.html
-package model
+package model // import "go.elastic.co/apm/model"

--- a/model/gofuzz.go
+++ b/model/gofuzz.go
@@ -17,7 +17,7 @@
 
 // +build gofuzz
 
-package model
+package model // import "go.elastic.co/apm/model"
 
 import (
 	"bytes"

--- a/model/maps.go
+++ b/model/maps.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package model
+package model // import "go.elastic.co/apm/model"
 
 // StringMap is a slice-representation of map[string]string,
 // optimized for fast JSON encoding.

--- a/model/marshal.go
+++ b/model/marshal.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package model
+package model // import "go.elastic.co/apm/model"
 
 import (
 	"encoding/hex"

--- a/model/model.go
+++ b/model/model.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package model
+package model // import "go.elastic.co/apm/model"
 
 import (
 	"net/http"

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"go.elastic.co/apm/internal/ringbuffer"

--- a/module/apmbeego/doc.go
+++ b/module/apmbeego/doc.go
@@ -16,4 +16,4 @@
 // under the License.
 
 // Package apmbeego provides tracing and error-reporting middleware for Beego applications.
-package apmbeego
+package apmbeego // import "go.elastic.co/apm/module/apmbeego"

--- a/module/apmbeego/filter.go
+++ b/module/apmbeego/filter.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmbeego
+package apmbeego // import "go.elastic.co/apm/module/apmbeego"
 
 import (
 	"context"

--- a/module/apmchi/doc.go
+++ b/module/apmchi/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmchi provides middleware for the Chi router,
 // for tracing HTTP requests.
-package apmchi
+package apmchi // import "go.elastic.co/apm/module/apmchi"

--- a/module/apmchi/middleware.go
+++ b/module/apmchi/middleware.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmchi
+package apmchi // import "go.elastic.co/apm/module/apmchi"
 
 import (
 	"net/http"

--- a/module/apmecho/doc.go
+++ b/module/apmecho/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmecho provides middleware for the Echo framework,
 // for tracing HTTP requests.
-package apmecho
+package apmecho // import "go.elastic.co/apm/module/apmecho"

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmecho
+package apmecho // import "go.elastic.co/apm/module/apmecho"
 
 import (
 	"errors"

--- a/module/apmechov4/doc.go
+++ b/module/apmechov4/doc.go
@@ -19,4 +19,4 @@
 
 // Package apmechov4 provides middleware for the version 4 of Echo framework,
 // for tracing HTTP requests.
-package apmechov4
+package apmechov4 // import "go.elastic.co/apm/module/apmechov4"

--- a/module/apmechov4/middleware.go
+++ b/module/apmechov4/middleware.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmechov4
+package apmechov4 // import "go.elastic.co/apm/module/apmechov4"
 
 import (
 	"errors"

--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmelasticsearch
+package apmelasticsearch // import "go.elastic.co/apm/module/apmelasticsearch"
 
 import (
 	"bytes"

--- a/module/apmelasticsearch/doc.go
+++ b/module/apmelasticsearch/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmelasticsearch provides support for tracing the
 // HTTP transport layer of Elasticsearch clients.
-package apmelasticsearch
+package apmelasticsearch // import "go.elastic.co/apm/module/apmelasticsearch"

--- a/module/apmelasticsearch/requestname.go
+++ b/module/apmelasticsearch/requestname.go
@@ -17,7 +17,7 @@
 
 // +build go1.10
 
-package apmelasticsearch
+package apmelasticsearch // import "go.elastic.co/apm/module/apmelasticsearch"
 
 import (
 	"net/http"

--- a/module/apmelasticsearch/requestname_go19.go
+++ b/module/apmelasticsearch/requestname_go19.go
@@ -17,7 +17,7 @@
 
 // +build !go1.10
 
-package apmelasticsearch
+package apmelasticsearch // import "go.elastic.co/apm/module/apmelasticsearch"
 
 import (
 	"fmt"

--- a/module/apmgin/doc.go
+++ b/module/apmgin/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmgin provides middleware for the Gin framework,
 // for tracing HTTP requests.
-package apmgin
+package apmgin // import "go.elastic.co/apm/module/apmgin"

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmgin
+package apmgin // import "go.elastic.co/apm/module/apmgin"
 
 import (
 	"net/http"

--- a/module/apmgocql/doc.go
+++ b/module/apmgocql/doc.go
@@ -18,4 +18,4 @@
 // +build go1.9
 
 // Package apmgocql provides an observer for tracing gocql (Cassandra) query spans.
-package apmgocql
+package apmgocql // import "go.elastic.co/apm/module/apmgocql"

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgocql
+package apmgocql // import "go.elastic.co/apm/module/apmgocql"
 
 import (
 	"context"

--- a/module/apmgocql/signature.go
+++ b/module/apmgocql/signature.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgocql
+package apmgocql // import "go.elastic.co/apm/module/apmgocql"
 
 import (
 	"strings"

--- a/module/apmgokit/doc.go
+++ b/module/apmgokit/doc.go
@@ -28,4 +28,4 @@
 //
 // Go kit-based gRPC servers and clients can both be wrapped
 // using the interceptors provided in module/apmgrpc.
-package apmgokit
+package apmgokit // import "go.elastic.co/apm/module/apmgokit"

--- a/module/apmgometrics/gatherer.go
+++ b/module/apmgometrics/gatherer.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmgometrics
+package apmgometrics // import "go.elastic.co/apm/module/apmgometrics"
 
 import (
 	"context"

--- a/module/apmgopg/doc.go
+++ b/module/apmgopg/doc.go
@@ -18,4 +18,4 @@
 // +build go1.11
 
 // Package apmgopg provides wrappers for tracing go-pg operations.
-package apmgopg
+package apmgopg // import "go.elastic.co/apm/module/apmgopg"

--- a/module/apmgopg/hook.go
+++ b/module/apmgopg/hook.go
@@ -17,7 +17,7 @@
 
 // +build go1.11
 
-package apmgopg
+package apmgopg // import "go.elastic.co/apm/module/apmgopg"
 
 import (
 	"errors"

--- a/module/apmgoredis/client.go
+++ b/module/apmgoredis/client.go
@@ -17,7 +17,7 @@
 
 // +build go1.11
 
-package apmgoredis
+package apmgoredis // import "go.elastic.co/apm/module/apmgoredis"
 
 import (
 	"context"

--- a/module/apmgoredis/doc.go
+++ b/module/apmgoredis/doc.go
@@ -18,4 +18,4 @@
 // +build go1.11
 
 // Package apmgoredis provides helpers for tracing github.com/go-redis/redis client operations as spans.
-package apmgoredis
+package apmgoredis // import "go.elastic.co/apm/module/apmgoredis"

--- a/module/apmgoredisv8/doc.go
+++ b/module/apmgoredisv8/doc.go
@@ -18,4 +18,4 @@
 // +build go1.11
 
 // Package apmgoredisv8 provides helpers for tracing github.com/go-redis/redis/v8 client operations as spans.
-package apmgoredisv8
+package apmgoredisv8 // import "go.elastic.co/apm/module/apmgoredisv8"

--- a/module/apmgoredisv8/hook.go
+++ b/module/apmgoredisv8/hook.go
@@ -17,7 +17,7 @@
 
 // +build go1.11
 
-package apmgoredisv8
+package apmgoredisv8 // import "go.elastic.co/apm/module/apmgoredisv8"
 
 import (
 	"bytes"

--- a/module/apmgorilla/context.go
+++ b/module/apmgorilla/context.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmgorilla
+package apmgorilla // import "go.elastic.co/apm/module/apmgorilla"
 
 import (
 	"bytes"

--- a/module/apmgorilla/middleware.go
+++ b/module/apmgorilla/middleware.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmgorilla
+package apmgorilla // import "go.elastic.co/apm/module/apmgorilla"
 
 import (
 	"net/http"

--- a/module/apmgorm/context.go
+++ b/module/apmgorm/context.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgorm
+package apmgorm // import "go.elastic.co/apm/module/apmgorm"
 
 import (
 	"context"

--- a/module/apmgorm/dialects/mysql/init.go
+++ b/module/apmgorm/dialects/mysql/init.go
@@ -17,7 +17,7 @@
 
 // Package apmgormmysql imports the gorm mysql dialect package,
 // and also registers the mysql driver with apmsql.
-package apmgormmysql
+package apmgormmysql // import "go.elastic.co/apm/module/apmgorm/dialects/mysql"
 
 import (
 	_ "github.com/jinzhu/gorm/dialects/mysql" // import the mysql dialect

--- a/module/apmgorm/dialects/postgres/init.go
+++ b/module/apmgorm/dialects/postgres/init.go
@@ -17,7 +17,7 @@
 
 // Package apmgormpostgres imports the gorm postgres dialect package,
 // and also registers the lib/pq driver with apmsql.
-package apmgormpostgres
+package apmgormpostgres // import "go.elastic.co/apm/module/apmgorm/dialects/postgres"
 
 import (
 	_ "github.com/jinzhu/gorm/dialects/postgres" // import the postgres dialect

--- a/module/apmgorm/dialects/sqlite/init.go
+++ b/module/apmgorm/dialects/sqlite/init.go
@@ -17,7 +17,7 @@
 
 // Package apmgormsqlite imports the gorm sqlite dialect package,
 // and also registers the sqlite3 driver with apmsql.
-package apmgormsqlite
+package apmgormsqlite // import "go.elastic.co/apm/module/apmgorm/dialects/sqlite"
 
 import (
 	_ "github.com/jinzhu/gorm/dialects/sqlite" // import the sqlite dialect

--- a/module/apmgorm/doc.go
+++ b/module/apmgorm/doc.go
@@ -18,4 +18,4 @@
 // +build go1.9
 
 // Package apmgorm provides wrappers for tracing GORM operations.
-package apmgorm
+package apmgorm // import "go.elastic.co/apm/module/apmgorm"

--- a/module/apmgorm/open.go
+++ b/module/apmgorm/open.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgorm
+package apmgorm // import "go.elastic.co/apm/module/apmgorm"
 
 import (
 	"github.com/jinzhu/gorm"

--- a/module/apmgormv2/doc.go
+++ b/module/apmgormv2/doc.go
@@ -16,4 +16,4 @@
 // under the License.
 
 // Package apmgormv2 provides wrappers for tracing GORM operations.
-package apmgormv2
+package apmgormv2 // import "go.elastic.co/apm/module/apmgormv2"

--- a/module/apmgormv2/driver/mysql/init.go
+++ b/module/apmgormv2/driver/mysql/init.go
@@ -19,7 +19,7 @@
 
 // Package apmmysql imports the gorm mysql dialect package,
 // and also registers the mysql driver with apmsql.
-package apmmysql
+package apmmysql // import "go.elastic.co/apm/module/apmgormv2/driver/mysql"
 
 import (
 	"gorm.io/driver/mysql"

--- a/module/apmgormv2/driver/postgres/init.go
+++ b/module/apmgormv2/driver/postgres/init.go
@@ -19,7 +19,7 @@
 
 // Package apmpostgres imports the gorm mysql dialect package,
 // and also registers the mysql driver with apmsql.
-package apmpostgres
+package apmpostgres // import "go.elastic.co/apm/module/apmgormv2/driver/postgres"
 
 import (
 	"gorm.io/driver/postgres"

--- a/module/apmgormv2/driver/sqlite/init.go
+++ b/module/apmgormv2/driver/sqlite/init.go
@@ -19,7 +19,7 @@
 
 // Package apmsqlite imports the gorm sqlite dialect package,
 // and also registers the sqlite3 driver with apmsql.
-package apmsqlite
+package apmsqlite // import "go.elastic.co/apm/module/apmgormv2/driver/sqlite"
 
 import (
 	"gorm.io/driver/sqlite"

--- a/module/apmgrpc/client.go
+++ b/module/apmgrpc/client.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgrpc
+package apmgrpc // import "go.elastic.co/apm/module/apmgrpc"
 
 import (
 	"golang.org/x/net/context"

--- a/module/apmgrpc/doc.go
+++ b/module/apmgrpc/doc.go
@@ -18,4 +18,4 @@
 // +build go1.9
 
 // Package apmgrpc provides interceptors for tracing gRPC.
-package apmgrpc
+package apmgrpc // import "go.elastic.co/apm/module/apmgrpc"

--- a/module/apmgrpc/ignorer.go
+++ b/module/apmgrpc/ignorer.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgrpc
+package apmgrpc // import "go.elastic.co/apm/module/apmgrpc"
 
 import (
 	"regexp"

--- a/module/apmgrpc/packages.go
+++ b/module/apmgrpc/packages.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgrpc
+package apmgrpc // import "go.elastic.co/apm/module/apmgrpc"
 
 import "go.elastic.co/apm/stacktrace"
 

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmgrpc
+package apmgrpc // import "go.elastic.co/apm/module/apmgrpc"
 
 import (
 	"strings"

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"io"

--- a/module/apmhttp/clienttrace.go
+++ b/module/apmhttp/clienttrace.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"context"

--- a/module/apmhttp/context.go
+++ b/module/apmhttp/context.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"fmt"

--- a/module/apmhttp/doc.go
+++ b/module/apmhttp/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmhttp provides a tracing middleware http.Handler for
 // servers, and a tracing http.RoundTripper for clients.
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"context"

--- a/module/apmhttp/ignorer.go
+++ b/module/apmhttp/ignorer.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"net/http"

--- a/module/apmhttp/recovery.go
+++ b/module/apmhttp/recovery.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"net/http"

--- a/module/apmhttp/requestname.go
+++ b/module/apmhttp/requestname.go
@@ -17,7 +17,7 @@
 
 // +build go1.10
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"net/http"

--- a/module/apmhttp/requestname_go19.go
+++ b/module/apmhttp/requestname_go19.go
@@ -17,7 +17,7 @@
 
 // +build !go1.10
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import "net/http"
 

--- a/module/apmhttp/traceheaders.go
+++ b/module/apmhttp/traceheaders.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttp
+package apmhttp // import "go.elastic.co/apm/module/apmhttp"
 
 import (
 	"encoding/hex"

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttprouter
+package apmhttprouter // import "go.elastic.co/apm/module/apmhttprouter"
 
 import (
 	"net/http"

--- a/module/apmhttprouter/router.go
+++ b/module/apmhttprouter/router.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmhttprouter
+package apmhttprouter // import "go.elastic.co/apm/module/apmhttprouter"
 
 import (
 	"context"

--- a/module/apmlambda/doc.go
+++ b/module/apmlambda/doc.go
@@ -16,4 +16,4 @@
 // under the License.
 
 // Package apmlambda provides tracing for AWS Lambda functions.
-package apmlambda
+package apmlambda // import "go.elastic.co/apm/module/apmlambda"

--- a/module/apmlambda/lambda.go
+++ b/module/apmlambda/lambda.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmlambda
+package apmlambda // import "go.elastic.co/apm/module/apmlambda"
 
 import (
 	"log"

--- a/module/apmlogrus/fields.go
+++ b/module/apmlogrus/fields.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmlogrus
+package apmlogrus // import "go.elastic.co/apm/module/apmlogrus"
 
 import (
 	"context"

--- a/module/apmlogrus/hook.go
+++ b/module/apmlogrus/hook.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmlogrus
+package apmlogrus // import "go.elastic.co/apm/module/apmlogrus"
 
 import (
 	"context"

--- a/module/apmmongo/doc.go
+++ b/module/apmmongo/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmmongo provides a CommandMonitor implementation
 // for tracing Mongo commands.
-package apmmongo
+package apmmongo // import "go.elastic.co/apm/module/apmmongo"

--- a/module/apmmongo/monitor.go
+++ b/module/apmmongo/monitor.go
@@ -17,7 +17,7 @@
 
 // +build go1.10
 
-package apmmongo
+package apmmongo // import "go.elastic.co/apm/module/apmmongo"
 
 import (
 	"context"

--- a/module/apmnegroni/middleware.go
+++ b/module/apmnegroni/middleware.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmnegroni
+package apmnegroni // import "go.elastic.co/apm/module/apmnegroni"
 
 import (
 	"context"

--- a/module/apmot/context.go
+++ b/module/apmot/context.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmot
+package apmot // import "go.elastic.co/apm/module/apmot"
 
 import (
 	"time"

--- a/module/apmot/doc.go
+++ b/module/apmot/doc.go
@@ -21,4 +21,4 @@
 //  - binary propagation format
 //  - baggage
 //  - logging (generally; errors are reported)
-package apmot
+package apmot // import "go.elastic.co/apm/module/apmot"

--- a/module/apmot/log.go
+++ b/module/apmot/log.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmot
+package apmot // import "go.elastic.co/apm/module/apmot"
 
 import (
 	"time"

--- a/module/apmot/span.go
+++ b/module/apmot/span.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmot
+package apmot // import "go.elastic.co/apm/module/apmot"
 
 import (
 	"fmt"

--- a/module/apmot/tracer.go
+++ b/module/apmot/tracer.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmot
+package apmot // import "go.elastic.co/apm/module/apmot"
 
 import (
 	"io"

--- a/module/apmot/wrapper.go
+++ b/module/apmot/wrapper.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmot
+package apmot // import "go.elastic.co/apm/module/apmot"
 
 import (
 	"context"

--- a/module/apmprometheus/gatherer.go
+++ b/module/apmprometheus/gatherer.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmprometheus
+package apmprometheus // import "go.elastic.co/apm/module/apmprometheus"
 
 import (
 	"context"

--- a/module/apmredigo/conn.go
+++ b/module/apmredigo/conn.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmredigo
+package apmredigo // import "go.elastic.co/apm/module/apmredigo"
 
 import (
 	"context"

--- a/module/apmredigo/doc.go
+++ b/module/apmredigo/doc.go
@@ -16,4 +16,4 @@
 // under the License.
 
 // Package apmredigo provides helpers for tracing github.com/gomodule/redigo/redis client operations as spans.
-package apmredigo
+package apmredigo // import "go.elastic.co/apm/module/apmredigo"

--- a/module/apmrestful/doc.go
+++ b/module/apmrestful/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmrestful provides a tracing and panic/exception
 // reporting filter for for the go-restful framework.
-package apmrestful
+package apmrestful // import "go.elastic.co/apm/module/apmrestful"

--- a/module/apmrestful/filter.go
+++ b/module/apmrestful/filter.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmrestful
+package apmrestful // import "go.elastic.co/apm/module/apmrestful"
 
 import (
 	"net/http"

--- a/module/apmrestful/route.go
+++ b/module/apmrestful/route.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmrestful
+package apmrestful // import "go.elastic.co/apm/module/apmrestful"
 
 import (
 	"bytes"

--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"context"

--- a/module/apmsql/conn_go110.go
+++ b/module/apmsql/conn_go110.go
@@ -17,7 +17,7 @@
 
 // +build go1.10
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"context"

--- a/module/apmsql/conn_go115.go
+++ b/module/apmsql/conn_go115.go
@@ -17,7 +17,7 @@
 
 // +build go1.15
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"database/sql/driver"

--- a/module/apmsql/conn_pre_go110.go
+++ b/module/apmsql/conn_pre_go110.go
@@ -17,7 +17,7 @@
 
 // +build !go1.10
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import "database/sql/driver"
 

--- a/module/apmsql/conn_pre_go115.go
+++ b/module/apmsql/conn_pre_go115.go
@@ -17,7 +17,7 @@
 
 // +build !go1.15
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import "database/sql/driver"
 

--- a/module/apmsql/doc.go
+++ b/module/apmsql/doc.go
@@ -16,4 +16,4 @@
 // under the License.
 
 // Package apmsql provides wrappers for tracing SQL query spans.
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"

--- a/module/apmsql/driver.go
+++ b/module/apmsql/driver.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"database/sql"

--- a/module/apmsql/driver_go110.go
+++ b/module/apmsql/driver_go110.go
@@ -17,7 +17,7 @@
 
 // +build go1.10
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"context"

--- a/module/apmsql/dsn.go
+++ b/module/apmsql/dsn.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 // DSNInfo contains information from a database-specific data source name.
 type DSNInfo struct {

--- a/module/apmsql/gofuzz_signature.go
+++ b/module/apmsql/gofuzz_signature.go
@@ -17,7 +17,7 @@
 
 // +build gofuzz
 
-package apmsql_test
+package apmsql_test // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"strings"

--- a/module/apmsql/mysql/doc.go
+++ b/module/apmsql/mysql/doc.go
@@ -18,4 +18,4 @@
 // Package apmmysql registers the "mysql" driver with
 // apmsql, so that you can trace go-sql-driver/mysql
 // database connections.
-package apmmysql
+package apmmysql // import "go.elastic.co/apm/module/apmsql/mysql"

--- a/module/apmsql/mysql/init.go
+++ b/module/apmsql/mysql/init.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmmysql
+package apmmysql // import "go.elastic.co/apm/module/apmsql/mysql"
 
 import (
 	"github.com/go-sql-driver/mysql"

--- a/module/apmsql/mysql/parser.go
+++ b/module/apmsql/mysql/parser.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmmysql
+package apmmysql // import "go.elastic.co/apm/module/apmsql/mysql"
 
 import (
 	"net"

--- a/module/apmsql/pgxv4/doc.go
+++ b/module/apmsql/pgxv4/doc.go
@@ -20,4 +20,4 @@
 
 // +build go1.14
 
-package apmpgxv4
+package apmpgxv4 // import "go.elastic.co/apm/module/apmsql/pgxv4"

--- a/module/apmsql/pgxv4/init.go
+++ b/module/apmsql/pgxv4/init.go
@@ -17,7 +17,7 @@
 
 // +build go1.14
 
-package apmpgxv4
+package apmpgxv4 // import "go.elastic.co/apm/module/apmsql/pgxv4"
 
 import (
 	"github.com/jackc/pgx/v4/stdlib"

--- a/module/apmsql/pq/doc.go
+++ b/module/apmsql/pq/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmpq registers the "postgres" driver with
 // apmsql, so that you can trace lib/pq database connections.
-package apmpq
+package apmpq // import "go.elastic.co/apm/module/apmsql/pq"

--- a/module/apmsql/pq/init.go
+++ b/module/apmsql/pq/init.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmpq
+package apmpq // import "go.elastic.co/apm/module/apmsql/pq"
 
 import (
 	"github.com/lib/pq"

--- a/module/apmsql/pq/parser.go
+++ b/module/apmsql/pq/parser.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmpq
+package apmpq // import "go.elastic.co/apm/module/apmsql/pq"
 
 import (
 	"go.elastic.co/apm/module/apmsql"

--- a/module/apmsql/signature.go
+++ b/module/apmsql/signature.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"strings"

--- a/module/apmsql/sqlite3/doc.go
+++ b/module/apmsql/sqlite3/doc.go
@@ -17,4 +17,4 @@
 
 // Package apmsqlite3 registers the "sqlite3" driver with
 // apmsql, so that you can trace sqlite3 database connections.
-package apmsqlite3
+package apmsqlite3 // import "go.elastic.co/apm/module/apmsql/sqlite3"

--- a/module/apmsql/sqlite3/init.go
+++ b/module/apmsql/sqlite3/init.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsqlite3
+package apmsqlite3 // import "go.elastic.co/apm/module/apmsql/sqlite3"
 
 import (
 	sqlite3 "github.com/mattn/go-sqlite3"

--- a/module/apmsql/sqlite3/parser.go
+++ b/module/apmsql/sqlite3/parser.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsqlite3
+package apmsqlite3 // import "go.elastic.co/apm/module/apmsql/sqlite3"
 
 import (
 	"strings"

--- a/module/apmsql/stmt.go
+++ b/module/apmsql/stmt.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"context"

--- a/module/apmsql/stmt_pre_go19.go
+++ b/module/apmsql/stmt_pre_go19.go
@@ -17,7 +17,7 @@
 
 // +build !go1.9
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import "database/sql/driver"
 

--- a/module/apmsql/utils.go
+++ b/module/apmsql/utils.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmsql
+package apmsql // import "go.elastic.co/apm/module/apmsql"
 
 import (
 	"database/sql/driver"

--- a/module/apmzap/core.go
+++ b/module/apmzap/core.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmzap
+package apmzap // import "go.elastic.co/apm/module/apmzap"
 
 import (
 	"context"

--- a/module/apmzap/fields.go
+++ b/module/apmzap/fields.go
@@ -17,7 +17,7 @@
 
 // +build go1.9
 
-package apmzap
+package apmzap // import "go.elastic.co/apm/module/apmzap"
 
 import (
 	"context"

--- a/module/apmzerolog/context.go
+++ b/module/apmzerolog/context.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmzerolog
+package apmzerolog // import "go.elastic.co/apm/module/apmzerolog"
 
 import (
 	"context"

--- a/module/apmzerolog/doc.go
+++ b/module/apmzerolog/doc.go
@@ -18,4 +18,4 @@
 // Package apmzerolog provides an implementaton of zerolog.LevelWriter
 // for sending error records to Elastic APM, as well as functions for
 // adding trace context and detailed error stack traces to log records.
-package apmzerolog
+package apmzerolog // import "go.elastic.co/apm/module/apmzerolog"

--- a/module/apmzerolog/stack.go
+++ b/module/apmzerolog/stack.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmzerolog
+package apmzerolog // import "go.elastic.co/apm/module/apmzerolog"
 
 import (
 	"strconv"

--- a/module/apmzerolog/writer.go
+++ b/module/apmzerolog/writer.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apmzerolog
+package apmzerolog // import "go.elastic.co/apm/module/apmzerolog"
 
 import (
 	"bytes"

--- a/profiling.go
+++ b/profiling.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"bytes"

--- a/sampler.go
+++ b/sampler.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"encoding/binary"

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"go.elastic.co/apm/internal/wildcard"

--- a/scripts/generate.go
+++ b/scripts/generate.go
@@ -17,4 +17,4 @@
 
 //go:generate go run gendockerfile.go -base=..
 
-package scripts
+package scripts // import "go.elastic.co/apm/scripts"

--- a/span.go
+++ b/span.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	cryptorand "crypto/rand"

--- a/spancontext.go
+++ b/spancontext.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"fmt"

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"path/filepath"

--- a/stacktrace/context.go
+++ b/stacktrace/context.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package stacktrace
+package stacktrace // import "go.elastic.co/apm/stacktrace"
 
 import (
 	"bufio"

--- a/stacktrace/doc.go
+++ b/stacktrace/doc.go
@@ -17,4 +17,4 @@
 
 // Package stacktrace provides a simplified stack frame type,
 // functions for obtaining stack frames, and related utilities.
-package stacktrace
+package stacktrace // import "go.elastic.co/apm/stacktrace"

--- a/stacktrace/frame.go
+++ b/stacktrace/frame.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package stacktrace
+package stacktrace // import "go.elastic.co/apm/stacktrace"
 
 // Frame describes a stack frame.
 type Frame struct {

--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package stacktrace
+package stacktrace // import "go.elastic.co/apm/stacktrace"
 
 import (
 	"runtime"

--- a/tracecontext.go
+++ b/tracecontext.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"bytes"

--- a/tracer.go
+++ b/tracer.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"bytes"

--- a/tracer_stats.go
+++ b/tracer_stats.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 // TracerStats holds statistics for a Tracer.
 type TracerStats struct {

--- a/transaction.go
+++ b/transaction.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	cryptorand "crypto/rand"

--- a/transport/api.go
+++ b/transport/api.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transport
+package transport // import "go.elastic.co/apm/transport"
 
 import (
 	"context"

--- a/transport/default.go
+++ b/transport/default.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transport
+package transport // import "go.elastic.co/apm/transport"
 
 var (
 	// Default is the default Transport, using the

--- a/transport/discard.go
+++ b/transport/discard.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transport
+package transport // import "go.elastic.co/apm/transport"
 
 import (
 	"context"

--- a/transport/doc.go
+++ b/transport/doc.go
@@ -17,4 +17,4 @@
 
 // Package transport provides an interface and implementation
 // for transporting data to the Elastic APM server.
-package transport
+package transport // import "go.elastic.co/apm/transport"

--- a/transport/http.go
+++ b/transport/http.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transport
+package transport // import "go.elastic.co/apm/transport"
 
 import (
 	"bytes"

--- a/transport/transporttest/doc.go
+++ b/transport/transporttest/doc.go
@@ -17,4 +17,4 @@
 
 // Package transporttest provides implementations of
 // transport.Transport for testing purposes.
-package transporttest
+package transporttest // import "go.elastic.co/apm/transport/transporttest"

--- a/transport/transporttest/err.go
+++ b/transport/transporttest/err.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transporttest
+package transporttest // import "go.elastic.co/apm/transport/transporttest"
 
 import (
 	"context"

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transporttest
+package transporttest // import "go.elastic.co/apm/transport/transporttest"
 
 import (
 	"compress/zlib"

--- a/utils.go
+++ b/utils.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"context"

--- a/utils_go10.go
+++ b/utils_go10.go
@@ -17,7 +17,7 @@
 
 // +build go1.10
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import "math"
 

--- a/utils_go9.go
+++ b/utils_go9.go
@@ -17,7 +17,7 @@
 
 // +build !go1.10
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import "math"
 

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"bytes"

--- a/utils_other.go
+++ b/utils_other.go
@@ -17,7 +17,7 @@
 
 //+build !linux
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 import (
 	"github.com/pkg/errors"

--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apm
+package apm // import "go.elastic.co/apm"
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.


### PR DESCRIPTION
This PR adds the vanity import for those files not having them. Generation has been done with https://github.com/jcchavezs/porto.

Fixes https://github.com/elastic/apm-agent-go/issues/840