### PR TITLE
Allow overriding the span ref validation

### DIFF
--- a/module/apmot/context.go
+++ b/module/apmot/context.go
@@ -79,7 +79,14 @@ func parentSpanContext(refs []opentracing.SpanReference) (*spanContext, bool) {
 // specific test case: TestStartSpanWithParent, which tests both child-of and
 // follows-from.
 
-var isValidSpanRef = isChildOfSpanRef
+// var isValidSpanRef = isChildOfSpanRef
+var isValidSpanRef = func(ref opentracing.SpanReference) bool {
+	switch ref.Type {
+	case opentracing.ChildOfRef, opentracing.FollowsFromRef:
+		return true
+	}
+	return false
+}
 
 func isChildOfSpanRef(ref opentracing.SpanReference) bool {
 	return ref.Type == opentracing.ChildOfRef

--- a/module/apmot/context.go
+++ b/module/apmot/context.go
@@ -47,9 +47,9 @@ func (s *spanContext) Transaction() *apm.Transaction {
 // ForeachBaggageItem is a no-op; we do not support baggage propagation.
 func (*spanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
 
-func parentSpanContext(refs []opentracing.SpanReference) (*spanContext, bool) {
+func (t *otTracer) parentSpanContext(refs []opentracing.SpanReference) (*spanContext, bool) {
 	for _, ref := range refs {
-		if !isValidSpanRef(ref) {
+		if !t.isValidSpanRef(ref) {
 			continue
 		}
 		if ctx, ok := ref.ReferencedContext.(*spanContext); ok {
@@ -75,19 +75,9 @@ func parentSpanContext(refs []opentracing.SpanReference) (*spanContext, bool) {
 }
 
 // NOTE(axw) we currently support only "child-of" span references, but we make
-// it possible to override them in order to appease the OT test harness in one
-// specific test case: TestStartSpanWithParent, which tests both child-of and
-// follows-from.
-
-// var isValidSpanRef = isChildOfSpanRef
-var isValidSpanRef = func(ref opentracing.SpanReference) bool {
-	switch ref.Type {
-	case opentracing.ChildOfRef, opentracing.FollowsFromRef:
-		return true
-	}
-	return false
-}
-
+// it possible to override them using options in order to appease the OT test
+// harness in one specific test case: TestStartSpanWithParent, which tests
+// both child-of and follows-from.
 func isChildOfSpanRef(ref opentracing.SpanReference) bool {
 	return ref.Type == opentracing.ChildOfRef
 }

--- a/module/apmot/harness_test.go
+++ b/module/apmot/harness_test.go
@@ -85,7 +85,7 @@ func (w harnessSuiteWrapper) TestStartSpanWithParent() {
 	// that to prevent us from testing the child-of case.
 	w.TearDownTest()
 
-	tracerOptions = append(tracerOptions, WithSpanValidator(func(ref opentracing.SpanReference) bool {
+	tracerOptions = append(tracerOptions, WithSpanRefValidator(func(ref opentracing.SpanReference) bool {
 		switch ref.Type {
 		case opentracing.ChildOfRef, opentracing.FollowsFromRef:
 			return true

--- a/module/apmot/tracer.go
+++ b/module/apmot/tracer.go
@@ -34,6 +34,9 @@ import (
 //
 // By default, the returned tracer will use apm.DefaultTracer.
 // This can be overridden by using a WithTracer option.
+// The option WithSpanRefValidator allows to override the
+// set of spans that are traced. By default only child-of
+// spans are traced.
 func New(opts ...Option) opentracing.Tracer {
 	t := &otTracer{
 		tracer:         apm.DefaultTracer,
@@ -204,9 +207,9 @@ func WithTracer(t *apm.Tracer) Option {
 // SpanRefValidator verifies if a span is valid and can be processed.
 type SpanRefValidator func(ref opentracing.SpanReference) bool
 
-// WithSpanValidator returns an Option which sets the span validation
+// WithSpanRefValidator returns an Option which sets the span validation
 // function. By default only child-of span are considered valid.
-func WithSpanValidator(validator SpanRefValidator) Option {
+func WithSpanRefValidator(validator SpanRefValidator) Option {
 	if validator == nil {
 		panic("validator == nil")
 	}


### PR DESCRIPTION
This is a candidate pull request to address https://github.com/elastic/apm-agent-go/issues/843