### PR TITLE
module/apmsql: add tracingDriver.Unwrap method

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ endif::[]
 
 https://github.com/elastic/apm-agent-go/compare/v1.9.0...master[View commits]
 
+- module/apmsql: add tracingDriver.Unwrap method to get underlying driver {pull}#849[#(849)]
+
 [[release-notes-1.x]]
 === Go Agent version 1.x
 

--- a/module/apmsql/apmsql_test.go
+++ b/module/apmsql/apmsql_test.go
@@ -37,6 +37,18 @@ func init() {
 	apmsql.Register("sqlite3_test", &sqlite3TestDriver{})
 }
 
+func TestDriverUnwrap(t *testing.T) {
+	var underlying struct {
+		driver.Driver
+	}
+	type Unwrapper interface {
+		Unwrap() driver.Driver
+	}
+	wrapped := apmsql.Wrap(&underlying)
+	u := wrapped.(Unwrapper)
+	assert.Equal(t, &underlying, u.Unwrap())
+}
+
 func TestPingContext(t *testing.T) {
 	db, err := apmsql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)

--- a/module/apmsql/driver.go
+++ b/module/apmsql/driver.go
@@ -152,3 +152,8 @@ func (d *tracingDriver) Open(name string) (driver.Conn, error) {
 	}
 	return newConn(conn, d, d.dsnParser(name)), nil
 }
+
+// Unwrap returns the wrapped database/sql/driver.Driver.
+func (d *tracingDriver) Unwrap() driver.Driver {
+	return d.Driver
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-go/issues/848