### PR TITLE
docs: fix typo in ELASTIC_APM_RECORDING config

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -236,7 +236,7 @@ any data to the Elastic APM server, and instrumentation overhead is minimized.
 | `ELASTIC_APM_RECORDING` | true    | `false`
 |============
 
-Enable or disable recording of events. If set to false, then the Go agent does
+Enable or disable recording of events. If set to false, then the Go agent does not
 send any events to the Elastic APM server, and instrumentation overhead is
 minimized, but the agent will continue to poll the server for configuration changes.
 


### PR DESCRIPTION
Missing the crucial word "not".