### PR TITLE
Make sanitize_field_names centrally configurable

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,8 @@ endif::[]
 https://github.com/elastic/apm-agent-go/compare/v1.9.0...master[View commits]
 
 - module/apmsql: add tracingDriver.Unwrap method to get underlying driver {pull}#849[#(849)]
+- module/apmgopgv10: add support for github.com/go-pg/pg/v10 {pull}857[(#857)]
+- Enable central configuration of "sanitize_field_names" {pull}856[(#856)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/config.go
+++ b/config.go
@@ -358,6 +358,11 @@ func (t *Tracer) updateRemoteConfig(logger WarningLogger, old, attrs map[string]
 					cfg.recording = recording
 				})
 			}
+		case envSanitizeFieldNames:
+			matchers := configutil.ParseWildcardPatterns(v)
+			updates = append(updates, func(cfg *instrumentationConfig) {
+				cfg.sanitizedFieldNames = matchers
+			})
 		case envSpanFramesMinDuration:
 			duration, err := configutil.ParseDuration(v)
 			if err != nil {
@@ -487,4 +492,5 @@ type instrumentationConfigValues struct {
 	spanFramesMinDuration time.Duration
 	stackTraceLimit       int
 	propagateLegacyHeader bool
+	sanitizedFieldNames   wildcard.Matchers
 }

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -126,12 +126,12 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 		out.Context = td.Context.build()
 	}
 
-	if len(w.cfg.sanitizedFieldNames) != 0 && out.Context != nil {
+	if len(td.sanitizedFieldNames) != 0 && out.Context != nil {
 		if out.Context.Request != nil {
-			sanitizeRequest(out.Context.Request, w.cfg.sanitizedFieldNames)
+			sanitizeRequest(out.Context.Request, td.sanitizedFieldNames)
 		}
 		if out.Context.Response != nil {
-			sanitizeResponse(out.Context.Response, w.cfg.sanitizedFieldNames)
+			sanitizeResponse(out.Context.Response, td.sanitizedFieldNames)
 		}
 	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -23,6 +23,8 @@ import (
 	"math/rand"
 	"sync"
 	"time"
+
+	"go.elastic.co/apm/internal/wildcard"
 )
 
 // StartTransaction returns a new Transaction with the specified
@@ -66,6 +68,7 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	tx.stackTraceLimit = instrumentationConfig.stackTraceLimit
 	tx.Context.captureHeaders = instrumentationConfig.captureHeaders
 	tx.propagateLegacyHeader = instrumentationConfig.propagateLegacyHeader
+	tx.sanitizedFieldNames = instrumentationConfig.sanitizedFieldNames
 	tx.breakdownMetricsEnabled = t.breakdownMetrics.enabled
 
 	var root bool
@@ -343,6 +346,7 @@ type TransactionData struct {
 	stackTraceLimit         int
 	breakdownMetricsEnabled bool
 	propagateLegacyHeader   bool
+	sanitizedFieldNames     wildcard.Matchers
 	timestamp               time.Time
 
 	mu            sync.Mutex


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-go/issues/821