### PR TITLE
Update tests and doc comments to use SERVER_URL

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -175,8 +175,8 @@ func TestTracerCentralConfigUpdateDisabled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	os.Setenv("ELASTIC_APM_SERVER_URLS", server.URL)
-	defer os.Unsetenv("ELASTIC_APM_SERVER_URLS")
+	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
+	defer os.Unsetenv("ELASTIC_APM_SERVER_URL")
 
 	os.Setenv("ELASTIC_APM_CENTRAL_CONFIG", "false")
 	defer os.Unsetenv("ELASTIC_APM_CENTRAL_CONFIG")

--- a/env_test.go
+++ b/env_test.go
@@ -52,8 +52,8 @@ func TestTracerRequestTimeEnv(t *testing.T) {
 	}))
 	defer server.Close()
 
-	os.Setenv("ELASTIC_APM_SERVER_URLS", server.URL)
-	defer os.Unsetenv("ELASTIC_APM_SERVER_URLS")
+	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
+	defer os.Unsetenv("ELASTIC_APM_SERVER_URL")
 
 	httpTransport, err := transport.NewHTTPTransport()
 	require.NoError(t, err)

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -273,8 +273,8 @@ func TestTracerRequestSize(t *testing.T) {
 	}))
 	defer server.Close()
 
-	os.Setenv("ELASTIC_APM_SERVER_URLS", server.URL)
-	defer os.Unsetenv("ELASTIC_APM_SERVER_URLS")
+	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
+	defer os.Unsetenv("ELASTIC_APM_SERVER_URL")
 
 	httpTransport, err := transport.NewHTTPTransport()
 	require.NoError(t, err)
@@ -368,8 +368,8 @@ func TestTracerBodyUnread(t *testing.T) {
 	}))
 	defer server.Close()
 
-	os.Setenv("ELASTIC_APM_SERVER_URLS", server.URL)
-	defer os.Unsetenv("ELASTIC_APM_SERVER_URLS")
+	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
+	defer os.Unsetenv("ELASTIC_APM_SERVER_URL")
 
 	httpTransport, err := transport.NewHTTPTransport()
 	require.NoError(t, err)

--- a/transport/http.go
+++ b/transport/http.go
@@ -91,11 +91,9 @@ type HTTPTransport struct {
 // streaming data to the APM Server. The returned HTTPTransport will be
 // initialized using the following environment variables:
 //
-// - ELASTIC_APM_SERVER_URLS: a comma-separated list of APM Server URLs.
-//   The transport will use this list of URLs for sending requests,
-//   switching to the next URL in the list upon error. The list will be
-//   shuffled first. If no URLs are specified, then the transport will
-//   use the default URL "http://localhost:8200".
+// - ELASTIC_APM_SERVER_URL: the APM Server URL used for sending
+//   requests. If no URL is specified, then the transport will use the
+//   default URL "http://localhost:8200".
 //
 // - ELASTIC_APM_SERVER_TIMEOUT: timeout for requests to the APM Server.
 //   If not specified, defaults to 30 seconds.

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -78,7 +78,7 @@ func TestHTTPTransportUserAgent(t *testing.T) {
 	var h recordingHandler
 	server := httptest.NewServer(&h)
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 
 	transport, err := transport.NewHTTPTransport()
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestHTTPTransportSecretToken(t *testing.T) {
 	var h recordingHandler
 	server := httptest.NewServer(&h)
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 
 	transport, err := transport.NewHTTPTransport()
 	transport.SetSecretToken("hunter2")
@@ -114,7 +114,7 @@ func TestHTTPTransportEnvSecretToken(t *testing.T) {
 	var h recordingHandler
 	server := httptest.NewServer(&h)
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 	defer patchEnv("ELASTIC_APM_SECRET_TOKEN", "hunter2")()
 
 	transport, err := transport.NewHTTPTransport()
@@ -129,7 +129,7 @@ func TestHTTPTransportAPIKey(t *testing.T) {
 	var h recordingHandler
 	server := httptest.NewServer(&h)
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 
 	transport, err := transport.NewHTTPTransport()
 	transport.SetAPIKey("hunter2")
@@ -144,7 +144,7 @@ func TestHTTPTransportEnvAPIKey(t *testing.T) {
 	var h recordingHandler
 	server := httptest.NewServer(&h)
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 	defer patchEnv("ELASTIC_APM_API_KEY", "api_key_wins")()
 	defer patchEnv("ELASTIC_APM_SECRET_TOKEN", "secret_token_loses")()
 
@@ -173,7 +173,7 @@ func TestHTTPTransportTLS(t *testing.T) {
 	server.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
 	server.StartTLS()
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 
 	transport, err := transport.NewHTTPTransport()
 	assert.NoError(t, err)
@@ -206,7 +206,7 @@ func TestHTTPTransportEnvVerifyServerCert(t *testing.T) {
 	var h recordingHandler
 	server := httptest.NewTLSServer(&h)
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 	defer patchEnv("ELASTIC_APM_VERIFY_SERVER_CERT", "false")()
 
 	transport, err := transport.NewHTTPTransport()
@@ -237,7 +237,7 @@ func TestHTTPTransportContent(t *testing.T) {
 	var h recordingHandler
 	server := httptest.NewServer(&h)
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 
 	transport, err := transport.NewHTTPTransport()
 	assert.NoError(t, err)
@@ -254,7 +254,7 @@ func TestHTTPTransportServerTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(blockingHandler))
 	defer server.Close()
 	defer close(done)
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 	defer patchEnv("ELASTIC_APM_SERVER_TIMEOUT", "50ms")()
 
 	before := time.Now()
@@ -320,7 +320,7 @@ func TestHTTPTransportServerCert(t *testing.T) {
 	server.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
 	server.StartTLS()
 	defer server.Close()
-	defer patchEnv("ELASTIC_APM_SERVER_URLS", server.URL)()
+	defer patchEnv("ELASTIC_APM_SERVER_URL", server.URL)()
 
 	p := strings.NewReader("")
 


### PR DESCRIPTION
The Go Agent will continue to support SERVER_URLS,
but we will de-epmphasise its use in favour of using
load balancer proxies with agents generally. We never
actually documented SERVER_URLS in the user docs,
so nothing to do there.

Closes #850 