### PR TITLE
Make `log_level` centrally configurable

### DIFF
--- a/internal/apmcloudutil/provider.go
+++ b/internal/apmcloudutil/provider.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"time"
 
-	"go.elastic.co/apm/internal/apmlog"
 	"go.elastic.co/apm/model"
 )
 
@@ -81,11 +80,11 @@ func ParseProvider(s string) (Provider, error) {
 //
 // It is the caller's responsibility to set a reasonable timeout, to ensure
 // requests do not block normal operation in non-cloud environments.
-func (p Provider) GetCloudMetadata(ctx context.Context, logger apmlog.Logger, out *model.Cloud) bool {
+func (p Provider) GetCloudMetadata(ctx context.Context, logger Logger, out *model.Cloud) bool {
 	return p.getCloudMetadata(ctx, defaultClient, logger, out)
 }
 
-func (p Provider) getCloudMetadata(ctx context.Context, client *http.Client, logger apmlog.Logger, out *model.Cloud) bool {
+func (p Provider) getCloudMetadata(ctx context.Context, client *http.Client, logger Logger, out *model.Cloud) bool {
 	if p == None {
 		return false
 	}
@@ -116,4 +115,9 @@ func (p Provider) getCloudMetadata(ctx context.Context, client *http.Client, log
 		}
 	}
 	return false
+}
+
+// Logger defines the interface for logging while fetching cloud metadata.
+type Logger interface {
+	Warningf(format string, args ...interface{})
 }

--- a/internal/apmcloudutil/provider_test.go
+++ b/internal/apmcloudutil/provider_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"go.elastic.co/apm/internal/apmlog"
 	"go.elastic.co/apm/model"
 )
 
@@ -86,8 +85,8 @@ func (rt *targetedRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 }
 
 type testLogger struct {
-	apmlog.Logger // panic on unexpected method calls
-	buf           bytes.Buffer
+	Logger // panic on unexpected method calls
+	buf    bytes.Buffer
 }
 
 func (tl *testLogger) Warningf(format string, args ...interface{}) {

--- a/internal/apmlog/logger.go
+++ b/internal/apmlog/logger.go
@@ -42,12 +42,15 @@ var (
 )
 
 func init() {
-	initDefaultLogger()
+	InitDefaultLogger()
 }
 
-func initDefaultLogger() {
+// InitDefaultLogger initialises DefaultLogger using the environment variables
+// ELASTIC_APM_LOG_FILE and ELASTIC_APM_LOG_LEVEL.
+func InitDefaultLogger() {
 	fileStr := strings.TrimSpace(os.Getenv("ELASTIC_APM_LOG_FILE"))
 	if fileStr == "" {
+		DefaultLogger = nil
 		return
 	}
 

--- a/internal/apmlog/logger.go
+++ b/internal/apmlog/logger.go
@@ -31,8 +31,13 @@ import (
 )
 
 const (
-	EnvLogFile         = "ELASTIC_APM_LOG_FILE"
-	EnvLogLevel        = "ELASTIC_APM_LOG_LEVEL"
+	// EnvLogFile is the environment variable that controls where the default logger writes.
+	EnvLogFile = "ELASTIC_APM_LOG_FILE"
+
+	// EnvLogLevel is the environment variable that controls the default logger's level.
+	EnvLogLevel = "ELASTIC_APM_LOG_LEVEL"
+
+	// DefaultLevel holds the default log level, if EnvLogLevel is not specified.
 	DefaultLevel Level = ErrorLevel
 )
 
@@ -87,6 +92,7 @@ func InitDefaultLogger() {
 	DefaultLogger = &LevelLogger{w: logWriter, level: logLevel}
 }
 
+// Log levels.
 const (
 	DebugLevel Level = iota
 	InfoLevel
@@ -96,6 +102,7 @@ const (
 	OffLevel
 )
 
+// Level represents a log level.
 type Level uint32
 
 func (l Level) String() string {

--- a/internal/apmlog/logger.go
+++ b/internal/apmlog/logger.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	// DefaultLogger is the default Logger to use, if ELASTIC_APM_LOG_* are specified.
-	DefaultLogger Logger
+	DefaultLogger *LevelLogger
 
 	fastjsonPool = &sync.Pool{
 		New: func() interface{} {
@@ -74,7 +74,7 @@ func initDefaultLogger() {
 			logLevel = level
 		}
 	}
-	DefaultLogger = levelLogger{w: logWriter, level: logLevel}
+	DefaultLogger = &LevelLogger{w: logWriter, level: logLevel}
 }
 
 const (
@@ -115,34 +115,27 @@ func parseLogLevel(s string) (logLevel, error) {
 	return noLevel, fmt.Errorf("invalid log level string %q", s)
 }
 
-// Logger provides methods for logging.
-type Logger interface {
-	Debugf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Warningf(format string, args ...interface{})
-}
-
-type levelLogger struct {
-	w     io.Writer
+type LevelLogger struct {
 	level logLevel
+	w     io.Writer
 }
 
 // Debugf logs a message with log.Printf, with a DEBUG prefix.
-func (l levelLogger) Debugf(format string, args ...interface{}) {
+func (l *LevelLogger) Debugf(format string, args ...interface{}) {
 	l.logf(debugLevel, format, args...)
 }
 
 // Errorf logs a message with log.Printf, with an ERROR prefix.
-func (l levelLogger) Errorf(format string, args ...interface{}) {
+func (l *LevelLogger) Errorf(format string, args ...interface{}) {
 	l.logf(errorLevel, format, args...)
 }
 
 // Warningf logs a message with log.Printf, with a WARNING prefix.
-func (l levelLogger) Warningf(format string, args ...interface{}) {
+func (l *LevelLogger) Warningf(format string, args ...interface{}) {
 	l.logf(warnLevel, format, args...)
 }
 
-func (l levelLogger) logf(level logLevel, format string, args ...interface{}) {
+func (l *LevelLogger) logf(level logLevel, format string, args ...interface{}) {
 	if level < l.level {
 		return
 	}

--- a/internal/apmlog/logger.go
+++ b/internal/apmlog/logger.go
@@ -30,6 +30,11 @@ import (
 	"go.elastic.co/fastjson"
 )
 
+const (
+	EnvLogFile  = "ELASTIC_APM_LOG_FILE"
+	EnvLogLevel = "ELASTIC_APM_LOG_LEVEL"
+)
+
 var (
 	// DefaultLogger is the default Logger to use, if ELASTIC_APM_LOG_* are specified.
 	DefaultLogger *LevelLogger
@@ -48,7 +53,7 @@ func init() {
 // InitDefaultLogger initialises DefaultLogger using the environment variables
 // ELASTIC_APM_LOG_FILE and ELASTIC_APM_LOG_LEVEL.
 func InitDefaultLogger() {
-	fileStr := strings.TrimSpace(os.Getenv("ELASTIC_APM_LOG_FILE"))
+	fileStr := strings.TrimSpace(os.Getenv(EnvLogFile))
 	if fileStr == "" {
 		DefaultLogger = nil
 		return
@@ -70,10 +75,10 @@ func InitDefaultLogger() {
 	}
 
 	logLevel := errorLevel
-	if levelStr := strings.TrimSpace(os.Getenv("ELASTIC_APM_LOG_LEVEL")); levelStr != "" {
+	if levelStr := strings.TrimSpace(os.Getenv(EnvLogLevel)); levelStr != "" {
 		level, err := ParseLogLevel(levelStr)
 		if err != nil {
-			log.Printf("invalid ELASTIC_APM_LOG_LEVEL %q, falling back to %q", levelStr, logLevel)
+			log.Printf("invalid %s %q, falling back to %q", EnvLogLevel, levelStr, logLevel)
 		} else {
 			logLevel = level
 		}

--- a/internal/apmlog/logger_test.go
+++ b/internal/apmlog/logger_test.go
@@ -37,7 +37,7 @@ func init() {
 
 func TestInitDefaultLoggerNoEnv(t *testing.T) {
 	DefaultLogger = nil
-	initDefaultLogger()
+	InitDefaultLogger()
 	assert.Nil(t, DefaultLogger)
 }
 
@@ -48,7 +48,7 @@ func TestInitDefaultLoggerInvalidFile(t *testing.T) {
 	DefaultLogger = nil
 	os.Setenv("ELASTIC_APM_LOG_FILE", ".")
 	defer os.Unsetenv("ELASTIC_APM_LOG_FILE")
-	initDefaultLogger()
+	InitDefaultLogger()
 
 	assert.Nil(t, DefaultLogger)
 	assert.Regexp(t, `failed to create "\.": .* \(disabling logging\)`, logbuf.String())
@@ -62,7 +62,7 @@ func TestInitDefaultLoggerFile(t *testing.T) {
 	DefaultLogger = nil
 	os.Setenv("ELASTIC_APM_LOG_FILE", filepath.Join(dir, "log.json"))
 	defer os.Unsetenv("ELASTIC_APM_LOG_FILE")
-	initDefaultLogger()
+	InitDefaultLogger()
 
 	require.NotNil(t, DefaultLogger)
 	DefaultLogger.Debugf("debug message")
@@ -95,7 +95,7 @@ func TestInitDefaultLoggerStdio(t *testing.T) {
 	for _, filename := range []string{"stdout", "stderr"} {
 		DefaultLogger = nil
 		os.Setenv("ELASTIC_APM_LOG_FILE", filename)
-		initDefaultLogger()
+		InitDefaultLogger()
 		require.NotNil(t, DefaultLogger)
 		DefaultLogger.Errorf("%s", filename)
 	}
@@ -122,7 +122,7 @@ func TestInitDefaultLoggerInvalidLevel(t *testing.T) {
 	os.Setenv("ELASTIC_APM_LOG_LEVEL", "panic")
 	defer os.Unsetenv("ELASTIC_APM_LOG_FILE")
 	defer os.Unsetenv("ELASTIC_APM_LOG_LEVEL")
-	initDefaultLogger()
+	InitDefaultLogger()
 
 	require.NotNil(t, DefaultLogger)
 	DefaultLogger.Debugf("debug message")
@@ -147,7 +147,7 @@ func TestInitDefaultLoggerLevel(t *testing.T) {
 	os.Setenv("ELASTIC_APM_LOG_LEVEL", "debug")
 	defer os.Unsetenv("ELASTIC_APM_LOG_FILE")
 	defer os.Unsetenv("ELASTIC_APM_LOG_LEVEL")
-	initDefaultLogger()
+	InitDefaultLogger()
 
 	require.NotNil(t, DefaultLogger)
 	DefaultLogger.Debugf("debug message")
@@ -169,7 +169,7 @@ func BenchmarkDefaultLogger(b *testing.B) {
 	DefaultLogger = nil
 	os.Setenv("ELASTIC_APM_LOG_FILE", filepath.Join(dir, "log.json"))
 	defer os.Unsetenv("ELASTIC_APM_LOG_FILE")
-	initDefaultLogger()
+	InitDefaultLogger()
 	require.NotNil(b, DefaultLogger)
 
 	b.ResetTimer()

--- a/tracer.go
+++ b/tracer.go
@@ -426,6 +426,14 @@ func newTracer(opts TracerOptions) *Tracer {
 	t.setLocalInstrumentationConfig(envSanitizeFieldNames, func(cfg *instrumentationConfigValues) {
 		cfg.sanitizedFieldNames = opts.sanitizedFieldNames
 	})
+	if apmlog.DefaultLogger != nil {
+		defaultLogLevel := apmlog.DefaultLogger.Level()
+		t.setLocalInstrumentationConfig(apmlog.EnvLogLevel, func(cfg *instrumentationConfigValues) {
+			// Revert to the original, local, log level when
+			// the centrally defined log level is removed.
+			apmlog.DefaultLogger.SetLevel(defaultLogLevel)
+		})
+	}
 
 	if !opts.active {
 		t.active = 0

--- a/utils.go
+++ b/utils.go
@@ -178,7 +178,7 @@ func getCloudMetadata() *model.Cloud {
 			var err error
 			provider, err = apmcloudutil.ParseProvider(str)
 			if err != nil && logger != nil {
-				logger.Warningf("disabling cloud metadata: %s", envCloudProvider, err)
+				logger.Warningf("disabling %q cloud metadata: %s", envCloudProvider, err)
 			}
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
`$ELASTIC_APM_LOG_LEVEL` now defines the local value, and this can be overridden via central config. If central config is updated and then removed, we'll revert back to the local value like with other config.

If a custom logger is defined, or no log file is specified, the `log_level` attribute is ignored regardless of whether central config is used. If a custom logger is defined we will log a warning to it about the central config change being ineffective.

Closes #829