### PR TITLE
model: add "classname" to stacktrace frames

### DIFF
--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1097,6 +1097,10 @@ func (v *StacktraceFrame) MarshalFastJSON(w *fastjson.Writer) error {
 		w.RawString(",\"abs_path\":")
 		w.String(v.AbsolutePath)
 	}
+	if v.Classname != "" {
+		w.RawString(",\"classname\":")
+		w.String(v.Classname)
+	}
 	if v.Column != nil {
 		w.RawString(",\"colno\":")
 		w.Int64(int64(*v.Column))

--- a/model/model.go
+++ b/model/model.go
@@ -541,6 +541,9 @@ type StacktraceFrame struct {
 	// use the package path (e.g. "net/http").
 	Module string `json:"module,omitempty"`
 
+	// Classname holds the name of the class to which the frame belongs.
+	Classname string `json:"classname,omitempty"`
+
 	// Function holds the name of the function to which the frame belongs.
 	Function string `json:"function,omitempty"`
 


### PR DESCRIPTION
This will be used by the OpenTelemetry exporter.
We should probably be using this for named type
methods in the Go Agent too, but that can come
later.