### PR TITLE
Tidy up modelwriter

### DIFF
--- a/error.go
+++ b/error.go
@@ -148,6 +148,7 @@ func (t *Tracer) newError() *Error {
 	if e.recording {
 		e.Timestamp = time.Now()
 		e.Context.captureHeaders = instrumentationConfig.captureHeaders
+		e.Context.sanitizedFieldNames = instrumentationConfig.sanitizedFieldNames
 		e.stackTraceLimit = instrumentationConfig.stackTraceLimit
 	}
 

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -125,15 +125,6 @@ func (w *modelWriter) buildModelTransaction(out *model.Transaction, tx *Transact
 	if sampled {
 		out.Context = td.Context.build()
 	}
-
-	if len(td.sanitizedFieldNames) != 0 && out.Context != nil {
-		if out.Context.Request != nil {
-			sanitizeRequest(out.Context.Request, td.sanitizedFieldNames)
-		}
-		if out.Context.Response != nil {
-			sanitizeResponse(out.Context.Response, td.sanitizedFieldNames)
-		}
-	}
 }
 
 func (w *modelWriter) buildModelSpan(out *model.Span, span *Span, sd *SpanData) {

--- a/transaction.go
+++ b/transaction.go
@@ -23,8 +23,6 @@ import (
 	"math/rand"
 	"sync"
 	"time"
-
-	"go.elastic.co/apm/internal/wildcard"
 )
 
 // StartTransaction returns a new Transaction with the specified
@@ -68,7 +66,7 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	tx.stackTraceLimit = instrumentationConfig.stackTraceLimit
 	tx.Context.captureHeaders = instrumentationConfig.captureHeaders
 	tx.propagateLegacyHeader = instrumentationConfig.propagateLegacyHeader
-	tx.sanitizedFieldNames = instrumentationConfig.sanitizedFieldNames
+	tx.Context.sanitizedFieldNames = instrumentationConfig.sanitizedFieldNames
 	tx.breakdownMetricsEnabled = t.breakdownMetrics.enabled
 
 	var root bool
@@ -346,7 +344,6 @@ type TransactionData struct {
 	stackTraceLimit         int
 	breakdownMetricsEnabled bool
 	propagateLegacyHeader   bool
-	sanitizedFieldNames     wildcard.Matchers
 	timestamp               time.Time
 
 	mu            sync.Mutex


### PR DESCRIPTION
Some light refactoring to move "context" model building
logic out of modelwriter and into the Context.build method.

There remains some context model building in modelwriter
(related to setting destination service type) because it
requires additional information outside of "context", i.e.
the span type.