### PR TITLE
docs: make API_KEY variable to appear in the right menu

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -121,7 +121,7 @@ could be observed by an attacker.
 
 [float]
 [[config-api-key]]
-==== `ELASTIC_APM_API_KEY`
+=== `ELASTIC_APM_API_KEY`
 
 [options="header"]
 |============


### PR DESCRIPTION
## What does this PR do?
It moves `ELASTIC_APM_API_KEY` from `H4` to `H3`, so that it appears in the right menu.

## Why is it important?
While looking up the docs, I found this variable is not in the right pane menu, which was weird. Please see https://github.com/elastic/docs/blob/799be2ba9c4cdd926ade46964c18b61b7b16cc80/resources/web/docs_js/index.js#L34, where only H1, H2 and H3 are candidates to be items in the right panel.

## Screenshots
<img width="1174" alt="Screenshot 2021-02-12 at 08 25 58" src="https://user-images.githubusercontent.com/951580/107740718-15efbc00-6d0c-11eb-9acf-e2b7f1917284.png">


Please discard this PR if this variable is a child element of `ELASTIC_APM_SECRET_TOKEN`.