### PR TITLE
scripts/jenkins: fix CI builds on 1.16

### DIFF
--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,19 +1,3 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-go get -v -u github.com/jstemmer/go-junit-report
-go get -v -u github.com/t-yuki/gocover-cobertura
-go get -v -t ./...
-
-export COV_FILE="build/coverage/coverage.cov"
-export OUT_FILE="build/test-report.out"
-mkdir -p build/coverage
-
-echo "W3C Distributed Tracing Validation"
-./scripts/docker-compose-testing run -T --rm trace-context-harness
-
-./scripts/docker-compose-testing up -d --build
-./scripts/docker-compose-testing run -T --rm go-agent-tests make coverage GOFLAGS=-v 2> >(tee ${OUT_FILE} 1>&2) > ${COV_FILE}
-
-gocover-cobertura < "${COV_FILE}" > build/coverage/coverage-apm-agent-go-docker-report.xml
-go-junit-report > build/junit-apm-agent-go-docker.xml < ${OUT_FILE}

--- a/scripts/jenkins/before_install.sh
+++ b/scripts/jenkins/before_install.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
+set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
-
+source ./scripts/jenkins/setenv.sh
 ./scripts/before_install.sh

--- a/scripts/jenkins/bench.sh
+++ b/scripts/jenkins/bench.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
-
-go get -v -u github.com/jstemmer/go-junit-report
+source ./scripts/jenkins/setenv.sh
 
 export GOFLAGS='-run=NONE -benchmem -bench=.'
 export OUT_FILE="build/bench.out"

--- a/scripts/jenkins/build.sh
+++ b/scripts/jenkins/build.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+source ./scripts/jenkins/setenv.sh
 
 make install precheck check-modules

--- a/scripts/jenkins/docker-test.sh
+++ b/scripts/jenkins/docker-test.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+source ./scripts/jenkins/setenv.sh
 
-./scripts/docker-test.sh
+
+export COV_FILE="build/coverage/coverage.cov"
+export OUT_FILE="build/test-report.out"
+mkdir -p build/coverage
+
+echo "W3C Distributed Tracing Validation"
+./scripts/docker-compose-testing run -T --rm trace-context-harness
+
+./scripts/docker-compose-testing up -d --build
+./scripts/docker-compose-testing run -T --rm go-agent-tests make coverage GOFLAGS=-v 2> >(tee ${OUT_FILE} 1>&2) > ${COV_FILE}
+
+gocover-cobertura < "${COV_FILE}" > build/coverage/coverage-apm-agent-go-docker-report.xml
+go-junit-report > build/junit-apm-agent-go-docker.xml < ${OUT_FILE}

--- a/scripts/jenkins/jenkins.go.mod
+++ b/scripts/jenkins/jenkins.go.mod
@@ -1,0 +1,8 @@
+module go.elastic.co/apm/scripts/jenkins
+
+go 1.15
+
+require (
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c // indirect
+)

--- a/scripts/jenkins/jenkins.go.sum
+++ b/scripts/jenkins/jenkins.go.sum
@@ -1,0 +1,4 @@
+github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
+github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c h1:+aPplBwWcHBo6q9xrfWdMrT9o4kltkmmvpemgIjep/8=
+github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c/go.mod h1:SbErYREK7xXdsRiigaQiQkI9McGRzYMvlKYaP3Nimdk=

--- a/scripts/jenkins/setenv.sh
+++ b/scripts/jenkins/setenv.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Install Go using the same travis approach
+echo "Installing ${GO_VERSION} with gimme."
+eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+
+# Install tools used only in CI using a local go.mod file when using Go 1.14+.
+GO_GET_FLAGS=
+if [ "$(go run ./scripts/mingoversion.go -print 1.14)" = "true" ]; then
+  GO_GET_FLAGS="-modfile=$PWD/scripts/jenkins/jenkins.go.mod"
+fi
+
+go get $GO_GET_FLAGS -v github.com/jstemmer/go-junit-report
+go get $GO_GET_FLAGS -v github.com/t-yuki/gocover-cobertura

--- a/scripts/jenkins/test.sh
+++ b/scripts/jenkins/test.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+source ./scripts/jenkins/setenv.sh
 
 # Run the tests
 set +e
@@ -12,7 +10,6 @@ mkdir -p build
 make test 2>&1 | tee ${OUT_FILE}
 status=$?
 
-go get -v -u github.com/jstemmer/go-junit-report
 go-junit-report > "build/junit-apm-agent-go-${GO_VERSION}.xml" < ${OUT_FILE}
 
 exit ${status}

--- a/scripts/moduledirs.sh
+++ b/scripts/moduledirs.sh
@@ -6,5 +6,5 @@
 if test -z "$(go env GOMOD)"; then
     pwd
 else
-    find . -type f -name go.mod \! -path './vendor/*' -exec dirname '{}' \;
+    find . -type f -name go.mod -exec dirname '{}' \;
 fi


### PR DESCRIPTION
In 1.16, by default go will complain if go.mod
is missing dependencies. In CI this is occurring
due to the installation of tools that are not
present in the top-level go.mod.

To avoid adding dependencies for agent consumers,
introduce a go.mod specifically for installing
tools used only in CI.