### PR TITLE
Pin pre-module versions of Go to older Prometheus

### DIFF
--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -34,6 +34,7 @@ if (! go run scripts/mingoversion.go 1.11 &>/dev/null); then
   pin github.com/jinzhu/gorm v1.9.16
   pin github.com/ugorji/go v1.1.10
   pin github.com/go-chi/chi v1.5.1
+  pin github.com/prometheus/client_golang v1.1.0
 fi
 
 if (! go run scripts/mingoversion.go 1.10 &>/dev/null); then
@@ -47,5 +48,4 @@ if (! go run scripts/mingoversion.go 1.9 &>/dev/null); then
   pin github.com/golang/protobuf v1.3.5
   pin github.com/olivere/elastic release-branch.v6
   pin golang.org/x/sys fc99dfbffb4e https://go.googlesource.com/sys
-  pin github.com/prometheus/client_golang v1.1.0
 fi


### PR DESCRIPTION
Fix the build. prometheus/client_golang@master no longer works with older versions of Go, due to use of runtime/debug.ReadBuildInfo:

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-go%2Fapm-agent-go-mbp/detail/PR-914/1/pipeline

> [2021-03-15T01:45:02.535Z] # github.com/prometheus/client_golang/prometheus
> [2021-03-15T01:45:02.535Z] ../../github.com/prometheus/client_golang/prometheus/go_collector.go:388:15: undefined: debug.ReadBuildInfo