### PR TITLE
Instrument RPC calls to amazon SQS

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.11.0...master[View commits]
 - module/apmawssdkgo: add support for instrumenting s3 RPC calls {pull}927[#(927)]
 - module/apmawssdkgo: add support for instrumenting dynamodb RPC calls {pull}928[#(928)]
 - SpanContext.SetDestinationService is a no-op if either Name or Resource is empty {pull}931[#(931)]
+- module/apmawssdkgo: add support for instrumenting sqs RPC calls {pull}933[#(933)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -841,6 +841,7 @@ The following services are supported:
 
 - S3
 - DynamoDB
+- SQS
 
 Passing a `session.Session` wrapped with `apmawssdkgo.WrapSession` to these
 services from the AWS SDK will report spans within the current transaction.

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -295,3 +295,12 @@ https://github.com/aws/aws-sdk-go[AWS SDK Go].
 
 See <<builtin-modules-apmawssdkgo, module/apmawssdkgo>> for more information
 about AWS SDK Go instrumentation.
+
+[float]
+[[supported-tech-messaging-systems]]
+=== Object Storage
+We provide instrumentation for AWS SQS. This is usable with
+https://github.com/aws/aws-sdk-go[AWS SDK Go].
+
+See <<builtin-modules-apmawssdkgo, module/apmawssdkgo>> for more information
+about AWS SDK Go instrumentation.

--- a/module/apmawssdkgo/session.go
+++ b/module/apmawssdkgo/session.go
@@ -105,7 +105,7 @@ func build(req *request.Request) {
 	if req.ClientInfo.ServiceName != serviceSQS {
 		return
 	}
-	addMessageAttributes(req, span)
+	addMessageAttributes(req, span, tx.ShouldPropagateLegacyHeader())
 }
 
 func send(req *request.Request) {

--- a/module/apmawssdkgo/session.go
+++ b/module/apmawssdkgo/session.go
@@ -51,12 +51,14 @@ func WrapSession(s *session.Session) *session.Session {
 const (
 	serviceS3       = "s3"
 	serviceDynamoDB = "dynamodb"
+	serviceSQS      = "sqs"
 )
 
 var (
 	serviceTypeMap = map[string]string{
 		serviceS3:       "storage",
 		serviceDynamoDB: "db",
+		serviceSQS:      "messaging",
 	}
 )
 
@@ -83,12 +85,20 @@ func send(req *request.Request) {
 		return
 	}
 
-	var svc service
+	var (
+		svc service
+		err error
+	)
 	switch spanSubtype {
 	case serviceS3:
 		svc = newS3(req)
 	case serviceDynamoDB:
 		svc = newDynamoDB(req)
+	case serviceSQS:
+		if svc, err = newSQS(req); err != nil {
+			// Unsupported method type or queue name.
+			return
+		}
 	default:
 		// Unsupported type
 		return

--- a/module/apmawssdkgo/sqs.go
+++ b/module/apmawssdkgo/sqs.go
@@ -70,6 +70,7 @@ func (s *apmSQS) resource() string { return s.resourceName }
 
 func (s *apmSQS) setAdditional(span *apm.Span) {
 	span.Action = s.opName
+	// TODO(stn): record `context.message.queue.name`
 }
 
 func operationDirection(operationName string) string {

--- a/module/apmawssdkgo/sqs.go
+++ b/module/apmawssdkgo/sqs.go
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmawssdkgo // import "go.elastic.co/apm/module/apmawssdkgo"
+
+import (
+	"errors"
+	"strings"
+
+	"go.elastic.co/apm"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+var (
+	sqsErrMethodNotSupported = errors.New("method not supported")
+	operationName            = map[string]string{
+		"SendMessage":        "send",
+		"SendMessageBatch":   "send_batch",
+		"DeleteMessage":      "delete",
+		"DeleteMessageBatch": "delete_batch",
+		"ReceiveMessage":     "poll",
+	}
+)
+
+type apmSQS struct {
+	name, opName, resourceName string
+}
+
+func newSQS(req *request.Request) (*apmSQS, error) {
+	opName, ok := operationName[req.Operation.Name]
+	if !ok {
+		return nil, sqsErrMethodNotSupported
+	}
+	name := req.ClientInfo.ServiceID + " " + strings.ToUpper(opName)
+	resourceName := serviceSQS
+
+	queueName := getQueueName(req)
+	if queueName != "" {
+		name += " " + operationDirection(req.Operation.Name) + " " + queueName
+		resourceName += "/" + queueName
+	}
+
+	s := &apmSQS{
+		name:         name,
+		opName:       opName,
+		resourceName: resourceName,
+	}
+
+	return s, nil
+}
+
+func (s *apmSQS) spanName() string { return s.name }
+
+func (s *apmSQS) resource() string { return s.resourceName }
+
+func (s *apmSQS) setAdditional(span *apm.Span) {
+	span.Action = s.opName
+}
+
+func operationDirection(operationName string) string {
+	switch operationName {
+	case "SendMessage", "SendMessageBatch":
+		return "to"
+	default:
+		return "from"
+	}
+}
+
+func getQueueName(req *request.Request) string {
+	parts := strings.Split(req.HTTPRequest.FormValue("QueueUrl"), "/")
+	return parts[len(parts)-1]
+}

--- a/module/apmawssdkgo/sqs.go
+++ b/module/apmawssdkgo/sqs.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	sqsErrMethodNotSupported = errors.New("method not supported")
+	errSQSMethodNotSupported = errors.New("method not supported")
 	operationName            = map[string]string{
 		"SendMessage":        "send",
 		"SendMessageBatch":   "send_batch",
@@ -44,7 +44,7 @@ type apmSQS struct {
 func newSQS(req *request.Request) (*apmSQS, error) {
 	opName, ok := operationName[req.Operation.Name]
 	if !ok {
-		return nil, sqsErrMethodNotSupported
+		return nil, errSQSMethodNotSupported
 	}
 	name := req.ClientInfo.ServiceID + " " + strings.ToUpper(opName)
 	resourceName := serviceSQS

--- a/module/apmawssdkgo/sqs_test.go
+++ b/module/apmawssdkgo/sqs_test.go
@@ -1,0 +1,176 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build go1.13
+
+package apmawssdkgo // import "go.elastic.co/apm/module/apmawssdkgo"
+
+import (
+	"context"
+	"testing"
+
+	"go.elastic.co/apm/apmtest"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQS(t *testing.T) {
+	region := "us-west-2"
+	addr := "sqs.testing.invalid"
+	cfg := aws.NewConfig().
+		WithEndpoint(addr).
+		WithRegion(region).
+		WithDisableSSL(true).
+		WithCredentials(credentials.AnonymousCredentials)
+
+	session := session.Must(session.NewSession(cfg))
+	wrapped := WrapSession(session)
+	svc := sqs.New(wrapped)
+	for _, tc := range []struct {
+		fn                     func(context.Context, string)
+		name, action, resource string
+		queueURL               string
+		ignored                bool
+	}{
+		{
+			name:     "SQS POLL from MyQueue",
+			action:   "poll",
+			resource: "sqs/MyQueue",
+			queueURL: "https://sqs.testing.invalid/123456789012/MyQueue",
+			fn: func(ctx context.Context, queueURL string) {
+				svc.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
+					QueueUrl: &queueURL,
+					AttributeNames: aws.StringSlice([]string{
+						"SentTimestamp",
+					}),
+					MaxNumberOfMessages: aws.Int64(1),
+					MessageAttributeNames: aws.StringSlice([]string{
+						"All",
+					}),
+					WaitTimeSeconds: aws.Int64(1),
+				})
+			},
+		},
+		{
+			name:     "SQS SEND to OtherQueue",
+			action:   "send",
+			resource: "sqs/OtherQueue",
+			queueURL: "https://sqs.testing.invalid/123456789012/OtherQueue",
+			fn: func(ctx context.Context, queueURL string) {
+				svc.SendMessageWithContext(ctx, &sqs.SendMessageInput{
+					QueueUrl: &queueURL,
+					MessageAttributes: map[string]*sqs.MessageAttributeValue{
+						"attr": &sqs.MessageAttributeValue{
+							DataType:    aws.String("String"),
+							StringValue: aws.String("string attr"),
+						},
+					},
+					MessageBody: aws.String("msg body"),
+				})
+			},
+		},
+		{
+			name:     "SQS SEND_BATCH to OtherQueue",
+			action:   "send_batch",
+			resource: "sqs/OtherQueue",
+			queueURL: "https://sqs.testing.invalid/123456789012/OtherQueue",
+			fn: func(ctx context.Context, queueURL string) {
+				svc.SendMessageBatchWithContext(ctx, &sqs.SendMessageBatchInput{
+					QueueUrl: &queueURL,
+					Entries: []*sqs.SendMessageBatchRequestEntry{
+						{
+							Id: aws.String("1"),
+							MessageAttributes: map[string]*sqs.MessageAttributeValue{
+								"attr": &sqs.MessageAttributeValue{
+									DataType:    aws.String("String"),
+									StringValue: aws.String("string attr"),
+								},
+							},
+							MessageBody: aws.String("msg body"),
+						},
+					},
+				})
+			},
+		},
+		{
+			name:     "SQS DELETE from ThatQueue",
+			action:   "delete",
+			resource: "sqs/ThatQueue",
+			queueURL: "https://sqs.testing.invalid/123456789012/ThatQueue",
+			fn: func(ctx context.Context, queueURL string) {
+				svc.DeleteMessageWithContext(ctx, &sqs.DeleteMessageInput{
+					QueueUrl:      &queueURL,
+					ReceiptHandle: aws.String("receiptHandle"),
+				})
+			},
+		},
+		{
+			name:     "SQS DELETE from ThatQueue",
+			action:   "delete",
+			resource: "sqs/ThatQueue",
+			ignored:  true,
+			fn: func(ctx context.Context, _ string) {
+				svc.CreateQueueWithContext(ctx, &sqs.CreateQueueInput{
+					QueueName: aws.String("SQS_QUEUE_NAME"),
+					Attributes: map[string]*string{
+						"DelaySeconds":           aws.String("60"),
+						"MessageRetentionPeriod": aws.String("86400"),
+					},
+				})
+			},
+		},
+	} {
+		tx, spans, errors := apmtest.WithTransaction(func(ctx context.Context) {
+			tc.fn(ctx, tc.queueURL)
+		})
+
+		if tc.ignored {
+			require.Len(t, spans, 0)
+			require.Len(t, errors, 0)
+			return
+		}
+
+		require.Len(t, spans, 1)
+		require.Len(t, errors, 1)
+
+		span := spans[0]
+		err := errors[0]
+
+		assert.Equal(t, tx.ID, err.TransactionID)
+		assert.Equal(t, span.ID, err.ParentID)
+
+		assert.Equal(t, tc.name, span.Name)
+		assert.Equal(t, "messaging", span.Type)
+		assert.Equal(t, "sqs", span.Subtype)
+		assert.Equal(t, tc.action, span.Action)
+
+		service := span.Context.Destination.Service
+		assert.Equal(t, "sqs", service.Name)
+		assert.Equal(t, "messaging", service.Type)
+		assert.Equal(t, tc.resource, service.Resource)
+		assert.Equal(t, "sqs.testing.invalid", span.Context.Destination.Address)
+
+		assert.Equal(t, region, span.Context.Destination.Cloud.Region)
+
+		assert.Equal(t, tx.ID, span.ParentID)
+	}
+}

--- a/module/apmawssdkgo/sqs_test.go
+++ b/module/apmawssdkgo/sqs_test.go
@@ -124,17 +124,10 @@ func TestSQS(t *testing.T) {
 			},
 		},
 		{
-			name:     "SQS DELETE from ThatQueue",
-			action:   "delete",
-			resource: "sqs/ThatQueue",
-			ignored:  true,
+			ignored: true,
 			fn: func(ctx context.Context, _ string) {
 				svc.CreateQueueWithContext(ctx, &sqs.CreateQueueInput{
 					QueueName: aws.String("SQS_QUEUE_NAME"),
-					Attributes: map[string]*string{
-						"DelaySeconds":           aws.String("60"),
-						"MessageRetentionPeriod": aws.String("86400"),
-					},
 				})
 			},
 		},


### PR DESCRIPTION
Add instrumentation for SQS methods for sending/receiving/deleting messages.

Note: 
Ignoring message queues is part of the [messaging spec](https://github.com/elastic/apm/blob/master/specs/agents/tracing-instrumentation-messaging.md#ignore_message_queues-configuration), but will be included later. This is being tracked in https://github.com/elastic/apm-agent-go/issues/934.

closes https://github.com/elastic/apm-agent-go/issues/883