### PR TITLE
Add context message queue name

### DIFF
--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -660,6 +660,18 @@ func (v *SpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
+	if v.Message != nil {
+		const prefix = ",\"message\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.Message.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if !v.Tags.isZero() {
 		const prefix = ",\"tags\":"
 		if first {
@@ -770,6 +782,29 @@ func (v *DestinationCloudSpanContext) MarshalFastJSON(w *fastjson.Writer) error 
 	if v.Region != "" {
 		w.RawString("\"region\":")
 		w.String(v.Region)
+	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *MessageSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
+	w.RawByte('{')
+	if v.Queue != nil {
+		w.RawString("\"queue\":")
+		if err := v.Queue.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	w.RawByte('}')
+	return firstErr
+}
+
+func (v *MessageQueueSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	if v.Name != "" {
+		w.RawString("\"name\":")
+		w.String(v.Name)
 	}
 	w.RawByte('}')
 	return nil

--- a/model/model.go
+++ b/model/model.go
@@ -341,6 +341,9 @@ type SpanContext struct {
 	// operation spans.
 	Database *DatabaseSpanContext `json:"db,omitempty"`
 
+	// Message holds contextual information for message operation spans.
+	Message *MessageSpanContext `json:"message,omitempty"`
+
 	// HTTP holds contextual information for HTTP client request spans.
 	HTTP *HTTPSpanContext `json:"http,omitempty"`
 
@@ -384,6 +387,18 @@ type DestinationServiceSpanContext struct {
 type DestinationCloudSpanContext struct {
 	// Region holds the destination cloud region.
 	Region string `json:"region,omitempty"`
+}
+
+// MessageSpanContext holds contextual information about a message.
+type MessageSpanContext struct {
+	// Queue holds the destination cloud region.
+	Queue *MessageQueueSpanContext `json:"queue,omitempty"`
+}
+
+// MessageQueueSpanContext holds contextual information about a message queue.
+type MessageQueueSpanContext struct {
+	// Name holds the message queue name.
+	Name string `json:"name,omitempty"`
 }
 
 // DatabaseSpanContext holds contextual information for database

--- a/module/apmawssdkgo/sns.go
+++ b/module/apmawssdkgo/sns.go
@@ -29,7 +29,7 @@ import (
 )
 
 type apmSNS struct {
-	name, opName, resourceName string
+	name, opName, resourceName, topicName string
 }
 
 func newSNS(req *request.Request) (*apmSNS, error) {
@@ -49,6 +49,7 @@ func newSNS(req *request.Request) (*apmSNS, error) {
 		name:         name,
 		opName:       "publish",
 		resourceName: resourceName,
+		topicName:    topicName,
 	}
 
 	return s, nil
@@ -60,6 +61,14 @@ func (s *apmSNS) resource() string { return s.resourceName }
 
 func (s *apmSNS) setAdditional(span *apm.Span) {
 	span.Action = s.opName
+	// According to the spec:
+	// Wherever the broker terminology uses "topic", this field will
+	// contain the topic name.
+	if s.topicName != "" {
+		span.Context.SetMessage(apm.MessageSpanContext{
+			QueueName: s.topicName,
+		})
+	}
 }
 
 func getTopicName(req *request.Request) string {

--- a/module/apmawssdkgo/sns_test.go
+++ b/module/apmawssdkgo/sns_test.go
@@ -42,13 +42,14 @@ import (
 func TestSNS(t *testing.T) {
 	for _, tc := range []struct {
 		fn                                 func(context.Context, *sns.SNS)
-		name, action, resource             string
+		name, action, resource, topicName  string
 		ignored, hasTraceContext, hasError bool
 	}{
 		{
 			name:            "SNS PUBLISH myTopic",
 			action:          "publish",
 			resource:        "sns/myTopic",
+			topicName:       "myTopic",
 			hasError:        true,
 			hasTraceContext: true,
 			fn: func(ctx context.Context, svc *sns.SNS) {
@@ -62,6 +63,7 @@ func TestSNS(t *testing.T) {
 			name:            "SNS PUBLISH myTopic",
 			action:          "publish",
 			resource:        "sns/myTopic",
+			topicName:       "myTopic",
 			hasTraceContext: true,
 			fn: func(ctx context.Context, svc *sns.SNS) {
 				svc.PublishWithContext(ctx, &sns.PublishInput{
@@ -137,6 +139,9 @@ func TestSNS(t *testing.T) {
 		assert.Equal(t, "sns", service.Name)
 		assert.Equal(t, "messaging", service.Type)
 		assert.Equal(t, tc.resource, service.Resource)
+
+		queue := span.Context.Message.Queue
+		assert.Equal(t, tc.topicName, queue.Name)
 
 		host, port, err := net.SplitHostPort(ts.URL[7:])
 		require.NoError(t, err)

--- a/module/apmawssdkgo/sqs.go
+++ b/module/apmawssdkgo/sqs.go
@@ -41,7 +41,7 @@ var (
 )
 
 type apmSQS struct {
-	name, opName, resourceName string
+	name, opName, resourceName, queueName string
 }
 
 func newSQS(req *request.Request) (*apmSQS, error) {
@@ -62,6 +62,7 @@ func newSQS(req *request.Request) (*apmSQS, error) {
 		name:         name,
 		opName:       opName,
 		resourceName: resourceName,
+		queueName:    queueName,
 	}
 
 	return s, nil
@@ -73,7 +74,11 @@ func (s *apmSQS) resource() string { return s.resourceName }
 
 func (s *apmSQS) setAdditional(span *apm.Span) {
 	span.Action = s.opName
-	// TODO(stn): record `context.message.queue.name`
+	if s.queueName != "" {
+		span.Context.SetMessage(apm.MessageSpanContext{
+			QueueName: s.queueName,
+		})
+	}
 }
 
 // addMessageAttributesSQS adds message attributes to `SendMessage` and

--- a/spancontext.go
+++ b/spancontext.go
@@ -33,6 +33,7 @@ type SpanContext struct {
 	destination          model.DestinationSpanContext
 	destinationService   model.DestinationServiceSpanContext
 	destinationCloud     model.DestinationCloudSpanContext
+	message              model.MessageSpanContext
 	databaseRowsAffected int64
 	database             model.DatabaseSpanContext
 	http                 model.HTTPSpanContext
@@ -68,8 +69,14 @@ type DestinationServiceSpanContext struct {
 // DestinationCloudSpanContext holds contextual information about a
 // destination cloud.
 type DestinationCloudSpanContext struct {
-	// Type holds the destination cloud region.
+	// Region holds the destination cloud region.
 	Region string
+}
+
+// MessageSpanContext holds contextual information about a message.
+type MessageSpanContext struct {
+	// QueueName holds the message queue name.
+	QueueName string
 }
 
 func (c *SpanContext) build() *model.SpanContext {
@@ -194,6 +201,19 @@ func (c *SpanContext) SetDestinationAddress(addr string, port int) {
 		c.destination.Port = port
 		c.model.Destination = &c.destination
 	}
+}
+
+// SetMessage sets the message info in the context.
+//
+// message.Name is required. If it is empty, then SetMessage is a no-op.
+func (c *SpanContext) SetMessage(message MessageSpanContext) {
+	if message.QueueName == "" {
+		return
+	}
+	c.message.Queue = &model.MessageQueueSpanContext{
+		Name: truncateString(message.QueueName),
+	}
+	c.model.Message = &c.message
 }
 
 // SetDestinationService sets the destination service info in the context.

--- a/spancontext.go
+++ b/spancontext.go
@@ -82,6 +82,7 @@ type MessageSpanContext struct {
 func (c *SpanContext) build() *model.SpanContext {
 	switch {
 	case len(c.model.Tags) != 0:
+	case c.model.Message != nil:
 	case c.model.Database != nil:
 	case c.model.HTTP != nil:
 	case c.model.Destination != nil:


### PR DESCRIPTION
Looping back to this, since it was a TODO from when first implementing `sqs` instrumentation.