### PR TITLE
BodyCapturer: Fix NPE on benchmark when nil Context.request

### DIFF
--- a/capturebody.go
+++ b/capturebody.go
@@ -137,7 +137,7 @@ func (bc *BodyCapturer) Discard() {
 }
 
 func (bc *BodyCapturer) setContext(out *model.RequestBody, req *http.Request) bool {
-	if req.PostForm != nil {
+	if req != nil && req.PostForm != nil {
 		// We must copy the map in case we need to
 		// sanitize the values. Ideally we should only
 		// copy if sanitization is necessary, but body


### PR DESCRIPTION
## Description
Fixes a nil pointer exception on the benchmark `BenchmarkBodyCapturer`.
The `Context.request` field wasn't set in the benchmark and is being
passed in the `BodyCapturer.setContext()` call as nil, causing an NPE
when `req.PostForm` is accessed.

The bug seems to have been introduced in #906.

This might not be the right fix since I'm not very familiar with the
codebase.

## Related issues

Closes #952 