### PR TITLE
apmot: Handle `http.host` tag as `url.Host`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.11.0...master[View commits]
 - Parse "//" comments in SQL/CQL {pull}937[#(937)]
 - Fix CaptureError to capture the request body when ELASTIC_APM_CAPTURE_BODY is enabled {pull}906[#(906)]
 - module/apmgrpc: record underlying HTTP/2 context {pull}904[#(904)]
+- module/apmot: handle http.host tag as url.Host {pull}954[#(954)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x


### PR DESCRIPTION
## Description

Handles the `http.host` tag and treats it as the `url.Host` value when
the `url.Host` hasn't been set and that OpenTelemetry tag is set to a
value.

## Related issues

Closes #917