### PR TITLE
Export gorilla route name resolver to be utilized in another middlewares 

### DIFF
--- a/module/apmgorilla/middleware.go
+++ b/module/apmgorilla/middleware.go
@@ -97,6 +97,8 @@ func Middleware(o ...Option) mux.MiddlewareFunc {
 	}
 }
 
+// RouteRequestName returns the gorilla/mux route that the request matched,
+// or "<METHOD> unknown route" if no route has been matched.
 func RouteRequestName(req *http.Request) string {
 	if route := mux.CurrentRoute(req); route != nil {
 		tpl, err := route.GetPathTemplate()

--- a/module/apmgorilla/middleware.go
+++ b/module/apmgorilla/middleware.go
@@ -86,7 +86,7 @@ func Middleware(o ...Option) mux.MiddlewareFunc {
 	}
 	apmhttpOptions := []apmhttp.ServerOption{
 		apmhttp.WithTracer(opts.tracer),
-		apmhttp.WithServerRequestName(routeRequestName),
+		ServerRequestName(),
 		apmhttp.WithServerRequestIgnorer(opts.requestIgnorer),
 	}
 	if opts.panicPropagation {
@@ -146,4 +146,9 @@ func WithPanicPropagation() Option {
 	return func(o *options) {
 		o.panicPropagation = true
 	}
+}
+
+// ServerRequestName returns a ServerOption to resolve gorilla routes
+func ServerRequestName() apmhttp.ServerOption {
+	return apmhttp.WithServerRequestName(routeRequestName)
 }

--- a/module/apmgorilla/middleware.go
+++ b/module/apmgorilla/middleware.go
@@ -86,7 +86,7 @@ func Middleware(o ...Option) mux.MiddlewareFunc {
 	}
 	apmhttpOptions := []apmhttp.ServerOption{
 		apmhttp.WithTracer(opts.tracer),
-		ServerRequestName(),
+		apmhttp.WithServerRequestName(RouteRequestName),
 		apmhttp.WithServerRequestIgnorer(opts.requestIgnorer),
 	}
 	if opts.panicPropagation {
@@ -97,7 +97,7 @@ func Middleware(o ...Option) mux.MiddlewareFunc {
 	}
 }
 
-func routeRequestName(req *http.Request) string {
+func RouteRequestName(req *http.Request) string {
 	if route := mux.CurrentRoute(req); route != nil {
 		tpl, err := route.GetPathTemplate()
 		if err == nil {
@@ -146,9 +146,4 @@ func WithPanicPropagation() Option {
 	return func(o *options) {
 		o.panicPropagation = true
 	}
-}
-
-// ServerRequestName returns a ServerOption to resolve gorilla routes
-func ServerRequestName() apmhttp.ServerOption {
-	return apmhttp.WithServerRequestName(routeRequestName)
 }


### PR DESCRIPTION
Ex: 
```go
	apmhttpOptions := []apmnegroni.Option{
		apmnegroni.Option(apmhttp.WithTracer(apm.DefaultTracer)),
		apmnegroni.Option(apmgorilla.ServerRequestName())),
	 apmnegroni.Option(apmhttp.WithServerRequestIgnorer(apmhttp.NewDynamicServerRequestIgnorer(apm.DefaultTracer))),
	}

	n := negroni.New()
        n.Use(apmnegroni.Middleware(apmhttpOptions...))
	n.Run(fmt.Sprintf(":8080"))

```