### PR TITLE
fix: change build tags for apmrestfulv3 to go1.11

### DIFF
--- a/module/apmrestfulv3/filter.go
+++ b/module/apmrestfulv3/filter.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.14
+// +build go1.11
 
 package apmrestfulv3 // import "go.elastic.co/apm/module/apmrestfulv3"
 

--- a/module/apmrestfulv3/filter_example_test.go
+++ b/module/apmrestfulv3/filter_example_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.14
+// +build go1.11
 
 package apmrestfulv3_test
 

--- a/module/apmrestfulv3/filter_test.go
+++ b/module/apmrestfulv3/filter_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.14
+// +build go1.11
 
 package apmrestfulv3_test
 

--- a/module/apmrestfulv3/route.go
+++ b/module/apmrestfulv3/route.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.14
+// +build go1.11
 
 package apmrestfulv3 // import "go.elastic.co/apm/module/apmrestfulv3"
 

--- a/module/apmrestfulv3/route_test.go
+++ b/module/apmrestfulv3/route_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build go1.14
+// +build go1.11
 
 package apmrestfulv3
 


### PR DESCRIPTION
I think I made a mistake from my  [previous PR](https://github.com/elastic/apm-agent-go/pull/968). The build tag supposed to be `go1.11` instead I set it to `go1.14`, that why [this issue](https://github.com/elastic/apm-agent-go/issues/969) #969  happen where the code won't compile on go1.13