### PR TITLE
Context.SetUsername takes precedence

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ endif::[]
 https://github.com/elastic/apm-agent-go/compare/v1.12.0...master[View commits]
 
 - Prefer w3c traceparent header over legacy elastic-apm-traceparent {pull}963[#(963)]
+- Context.SetUsername now takes precedence over HTTP user info from Context.SetHTTPRequest {pull}973[#(973)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/context.go
+++ b/context.go
@@ -159,7 +159,8 @@ func (c *Context) SetFramework(name, version string) {
 // If the request contains HTTP Basic Authentication, the username
 // from that will be recorded in the context. Otherwise, if the
 // request contains user info in the URL (i.e. a client-side URL),
-// that will be used.
+// that will be used. An explicit call to SetUsername always takes
+// precedence.
 func (c *Context) SetHTTPRequest(req *http.Request) {
 	// Special cases to avoid calling into fmt.Sprintf in most cases.
 	var httpVersion string
@@ -203,13 +204,15 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 		c.request.Socket = &c.requestSocket
 	}
 
-	username, _, ok := req.BasicAuth()
-	if !ok && req.URL.User != nil {
-		username = req.URL.User.Username()
-	}
-	c.user.Username = truncateString(username)
-	if c.user.Username != "" {
-		c.model.User = &c.user
+	if c.model.User == nil {
+		username, _, ok := req.BasicAuth()
+		if !ok && req.URL.User != nil {
+			username = req.URL.User.Username()
+		}
+		c.user.Username = truncateString(username)
+		if c.user.Username != "" {
+			c.model.User = &c.user
+		}
 	}
 }
 


### PR DESCRIPTION
If Context.SetUsername is called explicitly, don't automatically set the username based on HTTP user info (which may or may not exist.)

Fixes https://github.com/elastic/apm-agent-go/issues/970