### PR TITLE
CI: use withGoEnv and remove gimme for the CI

### DIFF
--- a/scripts/jenkins/setenv.sh
+++ b/scripts/jenkins/setenv.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
-
 # Install tools used only in CI using a local go.mod file when using Go 1.14+.
 GO_GET_FLAGS=
 if [ "$(go run ./scripts/mingoversion.go -print 1.14)" = "true" ]; then


### PR DESCRIPTION
### What

Simplify the CI to use the `withGoEnv` step and remove the `gimme` references to configure the CI builds.

### Reason

Remove the go configuration in the CI