### PR TITLE
module/apmhttp: fix panic in WithClientTrace

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.12.0...master[View commits]
 
 - Prefer w3c traceparent header over legacy elastic-apm-traceparent {pull}963[#(963)]
 - Context.SetUsername now takes precedence over HTTP user info from Context.SetHTTPRequest {pull}973[#(973)]
+- module/apmhttp: fix a potential panic in WithClientTrace {pull}989[#(989)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/module/apmhttp/clienttrace.go
+++ b/module/apmhttp/clienttrace.go
@@ -86,7 +86,11 @@ func withClientTrace(ctx context.Context, tx *apm.Transaction, parent *apm.Span)
 		},
 
 		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
-			r.TLS.End()
+			// It is possible for TLSHandshakeDone to be called even if
+			// TLSHandshakeStart has not, in case a timeout occurs first.
+			if r.TLS != nil {
+				r.TLS.End()
+			}
 		},
 
 		GotFirstResponseByte: func() {


### PR DESCRIPTION
If TLSHandshakeTimeout is something extremely low, like 1ns,
then it can happen that TLSHandshakeDone is called without
TLSHandshakeStart having been called. Check the TLS span is
non-nil before ending it.

Closes https://github.com/elastic/apm-agent-go/issues/981