### PR TITLE
release 1.13

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,7 +36,6 @@ https://github.com/elastic/apm-agent-go/compare/v1.13.0...master[View commits]
 - add fasthttp support {pull}957[#(957)]
 - module/apmgin: support multiple routes using the same handler {pull}983[#(983)]
 - add apm-server CA cert functionality {pull}982[#(982)]
-- module/apmgin: fix support for Go 1.8-1.9 {pull}948[#(984)]
 
 https://github.com/elastic/apm-agent-go/releases/tag/v1.12.0[View release]
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -21,14 +21,24 @@ endif::[]
 [[unreleased]]
 === Unreleased
 
-https://github.com/elastic/apm-agent-go/compare/v1.12.0...master[View commits]
+https://github.com/elastic/apm-agent-go/compare/v1.13.0...master[View commits]
+
+[[release-notes-1.x]]
+=== Go Agent version 1.x
+
+[[release-notes-1.13.0]]
+==== 1.13.0 - 2021/07/28
 
 - Prefer w3c traceparent header over legacy elastic-apm-traceparent {pull}963[#(963)]
 - Context.SetUsername now takes precedence over HTTP user info from Context.SetHTTPRequest {pull}973[#(973)]
 - module/apmhttp: fix a potential panic in WithClientTrace {pull}989[#(989)]
+- add support for go-restful v3 {pull}968[#(968)]
+- add fasthttp support {pull}957[#(957)]
+- support multiple routes using the same handler {pull}983[#(983)]
+- add apm-server CA cert functionality {pull}982[#(982)]
+- module/apmgin: fix support for Go 1.8-1.9 {pull}948[#(984)]
 
-[[release-notes-1.x]]
-=== Go Agent version 1.x
+https://github.com/elastic/apm-agent-go/releases/tag/v1.12.0[View release]
 
 [[release-notes-1.12.0]]
 ==== 1.12.0 - 2021/05/25

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,7 +34,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.13.0...master[View commits]
 - module/apmhttp: fix a potential panic in WithClientTrace {pull}989[#(989)]
 - add support for go-restful v3 {pull}968[#(968)]
 - add fasthttp support {pull}957[#(957)]
-- support multiple routes using the same handler {pull}983[#(983)]
+- module/apmgin: support multiple routes using the same handler {pull}983[#(983)]
 - add apm-server CA cert functionality {pull}982[#(982)]
 - module/apmgin: fix support for Go 1.8-1.9 {pull}948[#(984)]
 

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -21,6 +21,7 @@ The table below is a simplified description of this policy.
 [options="header"]
 |====
 |Agent version |EOL Date |Maintained until
+|1.13.x |2023/02/28 |1.14.0
 |1.12.x |2022/11/25 |1.13.0
 |1.11.x |2022/08/01 |1.12.0
 |1.10.x |2022/07/20 |1.11.0

--- a/internal/apmgodog/go.mod
+++ b/internal/apmgodog/go.mod
@@ -4,9 +4,9 @@ go 1.13
 
 require (
 	github.com/cucumber/godog v0.8.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmgrpc v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmgrpc v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 	go.elastic.co/fastjson v1.1.0
 	google.golang.org/grpc v1.17.0
 )

--- a/internal/apmversion/version.go
+++ b/internal/apmversion/version.go
@@ -19,5 +19,5 @@ package apmversion
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "1.12.0"
+	AgentVersion = "1.13.0"
 )

--- a/internal/tracecontexttest/go.mod
+++ b/internal/tracecontexttest/go.mod
@@ -1,6 +1,6 @@
 module tracecontexttest
 
-require go.elastic.co/apm/module/apmhttp v1.12.0
+require go.elastic.co/apm/module/apmhttp v1.13.0
 
 replace go.elastic.co/apm => ../..
 

--- a/module/apmawssdkgo/go.mod
+++ b/module/apmawssdkgo/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/aws/aws-sdk-go v1.38.14
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmbeego/go.mod
+++ b/module/apmbeego/go.mod
@@ -3,9 +3,9 @@ module go.elastic.co/apm/module/apmbeego
 require (
 	github.com/astaxie/beego v1.11.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
-	go.elastic.co/apm/module/apmsql v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
+	go.elastic.co/apm/module/apmsql v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmchi/go.mod
+++ b/module/apmchi/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmchi
 require (
 	github.com/go-chi/chi v1.5.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmchiv5/go.mod
+++ b/module/apmchiv5/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmchiv5
 require (
 	github.com/go-chi/chi/v5 v5.0.2
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmecho/go.mod
+++ b/module/apmecho/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 )
 

--- a/module/apmechov4/go.mod
+++ b/module/apmechov4/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/labstack/echo/v4 v4.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 )
 

--- a/module/apmelasticsearch/go.mod
+++ b/module/apmelasticsearch/go.mod
@@ -2,8 +2,8 @@ module go.elastic.co/apm/module/apmelasticsearch
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 )
 

--- a/module/apmelasticsearch/internal/integration/go.mod
+++ b/module/apmelasticsearch/internal/integration/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 // indirect
 	github.com/olivere/elastic v6.2.16+incompatible
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmelasticsearch v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmelasticsearch v1.13.0
 )
 
 replace go.elastic.co/apm => ../../../..

--- a/module/apmfasthttp/go.mod
+++ b/module/apmfasthttp/go.mod
@@ -5,8 +5,8 @@ go 1.13
 require (
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.26.0
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace (

--- a/module/apmgin/go.mod
+++ b/module/apmgin/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmgocql/go.mod
+++ b/module/apmgocql/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/gocql/gocql v0.0.0-20181124151448-70385f88b28b
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 

--- a/module/apmgokit/go.mod
+++ b/module/apmgokit/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmgrpc v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmgrpc v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	google.golang.org/grpc v1.17.0
 )

--- a/module/apmgometrics/go.mod
+++ b/module/apmgometrics/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmgometrics
 require (
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 

--- a/module/apmgopg/go.mod
+++ b/module/apmgopg/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmsql v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmsql v1.13.0
 	mellium.im/sasl v0.2.1 // indirect
 )
 

--- a/module/apmgopgv10/go.mod
+++ b/module/apmgopgv10/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/go-pg/pg/v10 v10.7.3
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmsql v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmsql v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmgoredis/go.mod
+++ b/module/apmgoredis/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 

--- a/module/apmgoredisv8/go.mod
+++ b/module/apmgoredisv8/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/go-redis/redis/v8 v8.0.0-beta.2
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmgorilla/go.mod
+++ b/module/apmgorilla/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmgorm/go.mod
+++ b/module/apmgorm/go.mod
@@ -5,8 +5,8 @@ require (
 	github.com/jinzhu/gorm v1.9.10
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmsql v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmsql v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmgormv2/go.mod
+++ b/module/apmgormv2/go.mod
@@ -2,8 +2,8 @@ module go.elastic.co/apm/module/apmgormv2
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmsql v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmsql v1.13.0
 	gorm.io/driver/mysql v1.0.2
 	gorm.io/driver/postgres v1.0.2
 	gorm.io/driver/sqlite v1.1.4-0.20200928065301-698e250a3b0d

--- a/module/apmgrpc/go.mod
+++ b/module/apmgrpc/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	google.golang.org/grpc v1.17.0
 )

--- a/module/apmhttp/go.mod
+++ b/module/apmhttp/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmhttp
 require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/module/apmhttprouter/go.mod
+++ b/module/apmhttprouter/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmhttprouter
 require (
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmlambda/go.mod
+++ b/module/apmlambda/go.mod
@@ -2,7 +2,7 @@ module go.elastic.co/apm/module/apmlambda
 
 require (
 	github.com/aws/aws-lambda-go v1.8.0
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmlogrus/go.mod
+++ b/module/apmlogrus/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.2.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/module/apmmongo/go.mod
+++ b/module/apmmongo/go.mod
@@ -2,7 +2,7 @@ module go.elastic.co/apm/module/apmmongo
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	go.mongodb.org/mongo-driver v1.5.1
 )
 

--- a/module/apmnegroni/go.mod
+++ b/module/apmnegroni/go.mod
@@ -5,8 +5,8 @@ go 1.13
 require (
 	github.com/stretchr/testify v1.6.1
 	github.com/urfave/negroni v1.0.0
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmot/go.mod
+++ b/module/apmot/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmot
 require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmprometheus/go.mod
+++ b/module/apmprometheus/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 

--- a/module/apmredigo/go.mod
+++ b/module/apmredigo/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmredigo
 require (
 	github.com/gomodule/redigo v1.8.2
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmrestful/go.mod
+++ b/module/apmrestful/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmrestfulv3/go.mod
+++ b/module/apmrestfulv3/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/emicklei/go-restful/v3 v3.5.1
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
-	go.elastic.co/apm/module/apmhttp v1.12.0
+	go.elastic.co/apm v1.13.0
+	go.elastic.co/apm/module/apmhttp v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmsql/go.mod
+++ b/module/apmsql/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/module/apmzap/go.mod
+++ b/module/apmzap/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmzap
 require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1

--- a/module/apmzerolog/go.mod
+++ b/module/apmzerolog/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.14.3
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 

--- a/scripts/genmod/go.mod
+++ b/scripts/genmod/go.mod
@@ -2,7 +2,7 @@ module genmod
 
 require (
 	github.com/pkg/errors v0.8.1
-	go.elastic.co/apm v1.12.0
+	go.elastic.co/apm v1.13.0
 )
 
 replace go.elastic.co/apm => ../..

--- a/version.go
+++ b/version.go
@@ -19,5 +19,5 @@ package apm // import "go.elastic.co/apm"
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "1.12.0"
+	AgentVersion = "1.13.0"
 )


### PR DESCRIPTION
Following steps at https://github.com/elastic/apm-agent-go/blob/f62afdfda01d0cbe73f477c357d5b8a3017e5144/CONTRIBUTING.md#release-procedure to upgrade v1.12->v1.13