### PR TITLE
Concurrency fixes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ endif::[]
 
 https://github.com/elastic/apm-agent-go/compare/v1.13.0...master[View commits]
 
+- Fix concurrency bugs in breakdown metrics and module/apmhttp.WithClientTrace {pull}997[#(997)]
+
 [[release-notes-1.x]]
 === Go Agent version 1.x
 


### PR DESCRIPTION
Fix a deadlock that can occur when concurrently ending a parent and child span, due to the parent waiting for the child to release the transaction lock, and the child waiting to lock the parent. Locks are now taken in a consistent order.

Add synchronisation to the httptrace handlers implemented by the `module/apmhttp.WithClientTrace` option. Sayeth the httptrace docs:

> Functions may be called concurrently from different goroutines and
some may be called after the request has completed or failed.

There's a minor enhancement to the handlers to set the Connect span outcome to "failure" if an error occurred.

Fixes https://github.com/elastic/apm-agent-go/issues/994