### PR TITLE
send traceparent header to ES

### DIFF
--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -74,6 +74,12 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return r.r.RoundTrip(req)
 	}
 
+	headerValue := apmhttp.FormatTraceparentHeader(tx.TraceContext())
+	req.Header.Set(apmhttp.W3CTraceparentHeader, headerValue)
+	if tx.ShouldPropagateLegacyHeader() {
+		req.Header.Set(apmhttp.ElasticTraceparentHeader, headerValue)
+	}
+
 	statement, req := captureSearchStatement(req)
 	username, _, _ := req.BasicAuth()
 	ctx = apm.ContextWithSpan(ctx, span)

--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -74,10 +74,14 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return r.r.RoundTrip(req)
 	}
 
-	headerValue := apmhttp.FormatTraceparentHeader(tx.TraceContext())
+	traceContext := span.TraceContext()
+	headerValue := apmhttp.FormatTraceparentHeader(traceContext)
 	req.Header.Set(apmhttp.W3CTraceparentHeader, headerValue)
 	if tx.ShouldPropagateLegacyHeader() {
 		req.Header.Set(apmhttp.ElasticTraceparentHeader, headerValue)
+	}
+	if tracestate := traceContext.State.String(); tracestate != "" {
+		req.Header.Set(apmhttp.TracestateHeader, tracestate)
 	}
 
 	statement, req := captureSearchStatement(req)

--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -64,12 +64,12 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 	tx := apm.TransactionFromContext(ctx)
 	traceContext := tx.TraceContext()
-	propagateLegacyHeader := tx.ShouldPropagateLegacyHeader()
-	if !tx.Sampled() {
-		apmhttp.SetHeaders(req, traceContext, propagateLegacyHeader)
+	if tx == nil || !tx.Sampled() {
+		apmhttp.SetHeaders(req, traceContext, false)
 		return r.r.RoundTrip(req)
 	}
 
+	propagateLegacyHeader := tx.ShouldPropagateLegacyHeader()
 	name := requestName(req)
 	span := tx.StartSpan(name, "db.elasticsearch", apm.SpanFromContext(ctx))
 

--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -63,8 +63,11 @@ type roundTripper struct {
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 	tx := apm.TransactionFromContext(ctx)
+	if tx == nil {
+		return r.r.RoundTrip(req)
+	}
 	traceContext := tx.TraceContext()
-	if tx == nil || !tx.Sampled() {
+	if !tx.Sampled() {
 		apmhttp.SetHeaders(req, traceContext, false)
 		return r.r.RoundTrip(req)
 	}

--- a/module/apmelasticsearch/client_test.go
+++ b/module/apmelasticsearch/client_test.go
@@ -331,7 +331,7 @@ func TestTraceHeaders(t *testing.T) {
 
 func TestClientSpanDropped(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte(req.Header.Get("Elastic-Apm-Traceparent")))
+		w.Write([]byte(req.Header.Get("Traceparent")))
 	}))
 	defer server.Close()
 
@@ -369,7 +369,7 @@ func TestClientSpanDropped(t *testing.T) {
 
 func TestClientTransactionUnsampled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte(req.Header.Get("Elastic-Apm-Traceparent")))
+		w.Write([]byte(req.Header.Get("Traceparent")))
 	}))
 	defer server.Close()
 

--- a/module/apmelasticsearch/client_test.go
+++ b/module/apmelasticsearch/client_test.go
@@ -304,7 +304,7 @@ func TestDestination(t *testing.T) {
 	test("http://[2001:db8::1]:80/_search", "2001:db8::1", 80)
 }
 
-func TestTraceparentHeader(t *testing.T) {
+func TestTraceHeaders(t *testing.T) {
 	headers := make(map[string]string)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		for k, vs := range req.Header {
@@ -324,6 +324,7 @@ func TestTraceparentHeader(t *testing.T) {
 
 	assert.Contains(t, headers, apmhttp.ElasticTraceparentHeader)
 	assert.Contains(t, headers, apmhttp.W3CTraceparentHeader)
+	assert.Contains(t, headers, apmhttp.TracestateHeader)
 }
 
 type readCloser struct {

--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -97,7 +97,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	propagateLegacyHeader := tx.ShouldPropagateLegacyHeader()
 	traceContext := tx.TraceContext()
 	if !traceContext.Options.Recorded() {
-		r.setHeaders(req, traceContext, propagateLegacyHeader)
+		SetHeaders(req, traceContext, propagateLegacyHeader)
 		return r.r.RoundTrip(req)
 	}
 
@@ -117,7 +117,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		span = nil
 	}
 
-	r.setHeaders(req, traceContext, propagateLegacyHeader)
+	SetHeaders(req, traceContext, propagateLegacyHeader)
 	resp, err := r.r.RoundTrip(req)
 	if span != nil {
 		if err != nil {
@@ -133,7 +133,8 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func (r *roundTripper) setHeaders(req *http.Request, traceContext apm.TraceContext, propagateLegacyHeader bool) {
+// SetHeaders sets traceparent and tracestate headers on an http request.
+func SetHeaders(req *http.Request, traceContext apm.TraceContext, propagateLegacyHeader bool) {
 	headerValue := FormatTraceparentHeader(traceContext)
 	if propagateLegacyHeader {
 		req.Header.Set(ElasticTraceparentHeader, headerValue)


### PR DESCRIPTION
Send the traceparent header to elasticsearch, now that ES parses it from incoming requests.

Closes https://github.com/elastic/apm-agent-go/issues/987