### PR TITLE
[apmhttp] WithClientSpanType ClientOption

### DIFF
--- a/module/apmhttp/client.go
+++ b/module/apmhttp/client.go
@@ -59,6 +59,7 @@ func WrapRoundTripper(r http.RoundTripper, o ...ClientOption) http.RoundTripper 
 		r:              r,
 		requestName:    ClientRequestName,
 		requestIgnorer: IgnoreNone,
+		spanType:       "external.http",
 	}
 	for _, o := range o {
 		o(rt)
@@ -71,6 +72,7 @@ type roundTripper struct {
 	requestName    RequestNameFunc
 	requestIgnorer RequestIgnorerFunc
 	traceRequests  bool
+	spanType       string
 }
 
 // RoundTrip delegates to r.r, emitting a span if req's context
@@ -102,7 +104,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	name := r.requestName(req)
-	span := tx.StartSpan(name, "external.http", apm.SpanFromContext(ctx))
+	span := tx.StartSpan(name, r.spanType, apm.SpanFromContext(ctx))
 	var rt *requestTracer
 	if !span.Dropped() {
 		traceContext = span.TraceContext()
@@ -209,5 +211,11 @@ func WithClientRequestName(r RequestNameFunc) ClientOption {
 
 	return ClientOption(func(rt *roundTripper) {
 		rt.requestName = r
+	})
+}
+
+func WithClientSpanType(spanType string) ClientOption {
+	return ClientOption(func(rt *roundTripper) {
+		rt.spanType = spanType
 	})
 }


### PR DESCRIPTION
Hi,

This is a pull request to add a `WithClientSpanType` option when wrapping an `http.Client`

I've come across a few instances in the past where I want to better differentiate my HTTP requests. For example when calling into a Varnish cache over HTTP, I'd rather it have the "cache" span type. There are some cases where I have HTTP requests that are better classified as database requests, so I'd like the "db" span type.

Currently the workaround is to grab the span off the context and set the span type before closing the response body. It works, but it's not particularly elegant. That's why I think this new `ClientOption` would be useful.

I did the change before making an issue asking about it since it's a tiny change

Let me know 😄 

----

By the way, `TestFilesystemContextSetter` and `TestFilesystemContextSetterFileNotFound` don't seem to work on my machine. It's a Windows machine. They result in these test failures:

```
=== RUN   TestFilesystemContextSetter
    context_test.go:91: ContextLine differs:   string(
        - 	`	panic("context!")`,
        + 	"\tpanic(\"context!\")\r",
          )
--- FAIL: TestFilesystemContextSetter (0.00s)
```
```
=== RUN   TestFilesystemContextSetterFileNotFound
    context_test.go:91: ContextLine differs:   string(
        - 	`	panic("context!")`,
        + 	"\tpanic(\"context!\")\r",
          )
--- FAIL: TestFilesystemContextSetterFileNotFound (0.00s)
```
