### PR TITLE
re-flush until transaction has been closed

### DIFF
--- a/module/apmfasthttp/server_test.go
+++ b/module/apmfasthttp/server_test.go
@@ -67,6 +67,11 @@ func TestServerHTTPResponse(t *testing.T) {
 	tracer.Flush(nil)
 	payloads := transport.Payloads()
 
+	// the transaction is ended after the response body is fully written,
+	// so a single call to `tracer.Flush()` may not have an event yet
+	// enqueued. Continue to call `tracer.Flush()` and wait for the
+	// transaction to have ended.
+	// This is unique to fasthttp's implementation.
 	timer := time.NewTimer(100 * time.Millisecond)
 	defer timer.Stop()
 	for {

--- a/module/apmfasthttp/server_test.go
+++ b/module/apmfasthttp/server_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,8 +65,24 @@ func TestServerHTTPResponse(t *testing.T) {
 	resp.Body.Close()
 	assert.Equal(t, fasthttp.StatusUnauthorized, resp.StatusCode)
 	tracer.Flush(nil)
-
 	payloads := transport.Payloads()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			t.Fatal("timed out waiting for payload")
+		default:
+		}
+		if len(payloads.Transactions) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+		tracer.Flush(nil)
+		payloads = transport.Payloads()
+	}
+
 	transaction := payloads.Transactions[0]
 	assert.Equal(t, "GET /", transaction.Name)
 	assert.Equal(t, "request", transaction.Type)


### PR DESCRIPTION
the transaction is ended after the response body
is fully written, so a single call to
`tracer.Flush()` may not have an event yet
enqueued.

## testing this change

before this change, I was able to get the test to reliably panic with `go test . -count=10000 -failfast`. over several runs on my local machine after this change, I have not gotten the panic.