### PR TITLE
scripts: Fixup `tagversion.sh` for Darwin

### DIFF
--- a/scripts/tagversion.sh
+++ b/scripts/tagversion.sh
@@ -1,23 +1,26 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 export GO111MODULE=on
 
+SED_BINARY=sed
+if [[ $(uname -s) == "Darwin" ]]; then SED_BINARY=gsed; fi
+
 prefix=go.elastic.co/apm
-version=$(sed 's@^\s*AgentVersion = "\(.*\)"$@\1@;t;d' version.go)
-modules=$(for dir in $(./scripts/moduledirs.sh); do (cd $dir && go list -m); done | grep $prefix/)
+version=$(${SED_BINARY} 's@^\s*AgentVersion = "\(.*\)"$@\1@;t;d' version.go)
+modules=$(for dir in $(./scripts/moduledirs.sh); do (cd $dir && go list -m); done | grep ${prefix}/)
 
 echo "# Create tags"
 for m in "" $modules; do
-	p=$(echo $m | sed "s@^$prefix/\(.\{0,\}\)@\1/@")
-	echo git tag -s ${p}v$version -m v$version
+	p=$(echo $m | ${SED_BINARY} "s@^${prefix}/\(.\{0,\}\)@\1/@")
+	echo git tag -s ${p}v${version} -m v${version}
 done
 
 echo
 echo "# Push tags"
 echo -n git push upstream
 for m in "" $modules; do
-	p=$(echo $m | sed "s@^$prefix/\(.\{0,\}\)@\1/@")
-	echo -n " ${p}v$version"
+	p=$(echo $m | ${SED_BINARY} "s@^${prefix}/\(.\{0,\}\)@\1/@")
+	echo -n " ${p}v${version}"
 done
 echo


### PR DESCRIPTION
## Description
Adds a conditional on `scripts/tagversion.sh` which uses `gsed` as the
`sed` binary. Last, it uses `bash` instead of `sh` since the `echo -n`
wasn't properly working on that shell for macOS.

