### PR TITLE
Stop recording `http.request.socket.encrypted`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ endif::[]
 
 https://github.com/elastic/apm-agent-go/compare/v1.14.0...master[View commits]
 
+- Deprecate `http.request.socket.encrypted` and stop recording it in `module/apmhttp`, `module/apmgrpc` and `module/apmfiber`. {pull}1129[#(1129)]
+
 [[release-notes-1.x]]
 === Go Agent version 1.x
 

--- a/context.go
+++ b/context.go
@@ -197,7 +197,6 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 	}
 
 	c.requestSocket = model.RequestSocket{
-		Encrypted:     req.TLS != nil,
 		RemoteAddress: apmhttputil.RemoteAddr(req),
 	}
 	if c.requestSocket != (model.RequestSocket{}) {

--- a/gofuzz.go
+++ b/gofuzz.go
@@ -81,9 +81,6 @@ func Fuzz(data []byte) int {
 			capturedBody := tracer.CaptureHTTPRequestBody(req)
 			if in.Request.Socket != nil {
 				req.RemoteAddr = in.Request.Socket.RemoteAddress
-				if in.Request.Socket.Encrypted {
-					req.TLS = new(tls.ConnectionState)
-				}
 			}
 			req.PostForm = postForm
 			if in.User != nil && in.User.Username != "" {

--- a/gofuzz.go
+++ b/gofuzz.go
@@ -23,7 +23,6 @@ package apm // import "go.elastic.co/apm"
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1299,16 +1299,6 @@ func (v *Request) MarshalFastJSON(w *fastjson.Writer) error {
 func (v *RequestSocket) MarshalFastJSON(w *fastjson.Writer) error {
 	w.RawByte('{')
 	first := true
-	if v.Encrypted != false {
-		const prefix = ",\"encrypted\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.Bool(v.Encrypted)
-	}
 	if v.RemoteAddress != "" {
 		const prefix = ",\"remote_address\":"
 		if first {

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -83,7 +83,6 @@ func TestMarshalTransaction(t *testing.T) {
 					"random":  "junk",
 				},
 				"socket": map[string]interface{}{
-					"encrypted":      true,
 					"remote_address": "[::1]",
 				},
 			},
@@ -594,7 +593,6 @@ func fakeTransaction() model.Transaction {
 					{Name: "random", Value: "junk"},
 				},
 				Socket: &model.RequestSocket{
-					Encrypted:     true,
 					RemoteAddress: "[::1]",
 				},
 			},

--- a/model/model.go
+++ b/model/model.go
@@ -666,7 +666,7 @@ type Header struct {
 // RequestSocket holds transport-level information relating to an HTTP request.
 type RequestSocket struct {
 	// Encrypted indicates whether or not the request was sent
-	// as an SSL/HTTPS request.
+	// as an SSL/HTTPS request. Deprecated.
 	Encrypted bool `json:"encrypted,omitempty"`
 
 	// RemoteAddress holds the remote address for the request.

--- a/module/apmfiber/middleware_test.go
+++ b/module/apmfiber/middleware_test.go
@@ -129,7 +129,6 @@ func TestMiddleware(t *testing.T) {
 		},
 		Request: &model.Request{
 			Socket: &model.RequestSocket{
-				Encrypted:     false,
 				RemoteAddress: "remote-addr",
 			},
 			URL: model.URL{

--- a/module/apmgrpc/server_test.go
+++ b/module/apmgrpc/server_test.go
@@ -335,7 +335,6 @@ func TestServerTLS(t *testing.T) {
 			Values: []string{"grpc-go/" + grpc.Version},
 		}},
 		Socket: &model.RequestSocket{
-			Encrypted: true,
 			// Server is listening on loopback, so the client
 			// should have the same IP address. RemoteAddress
 			// does not record the port.

--- a/module/apmhttp/handler_http2_test.go
+++ b/module/apmhttp/handler_http2_test.go
@@ -73,7 +73,6 @@ func TestHandlerHTTP2(t *testing.T) {
 	assert.Equal(t, &model.Context{
 		Request: &model.Request{
 			Socket: &model.RequestSocket{
-				Encrypted: true,
 				// 127.0.0.1 or ::1.
 				RemoteAddress: srvAddr.IP.String(),
 			},


### PR DESCRIPTION
## Description
Deprecates the `http.request.socket.encrypted` field in the apm agent,
and stops recording it in the modules that populated that field:

- `module/apmhttp`
- `module/apmgrpc`
- `module/apmfiber`

## Related issues

Closes elastic/apm-agent-go#1122
