### PR TITLE
transaction: Collect stats about dropped spans

### DIFF
--- a/breakdown.go
+++ b/breakdown.go
@@ -64,6 +64,10 @@ Try to name your transactions so that there are less distinct transaction names.
 type spanTimingsKey struct {
 	spanType    string
 	spanSubtype string
+
+	// These fields are only set for dropped spans.
+	spanDstResource string
+	spanOutcome     string
 }
 
 // spanTiming records the number of times a {spanType, spanSubtype} pair

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -512,6 +512,19 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
+	if v.DroppedSpansStats != nil {
+		w.RawString(",\"dropped_spans_stats\":")
+		w.RawByte('[')
+		for i, v := range v.DroppedSpansStats {
+			if i != 0 {
+				w.RawByte(',')
+			}
+			if err := v.MarshalFastJSON(w); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		w.RawByte(']')
+	}
 	if v.Outcome != "" {
 		w.RawString(",\"outcome\":")
 		w.String(v.Outcome)
@@ -544,6 +557,46 @@ func (v *SpanCount) MarshalFastJSON(w *fastjson.Writer) error {
 	w.Int64(int64(v.Dropped))
 	w.RawString(",\"started\":")
 	w.Int64(int64(v.Started))
+	w.RawByte('}')
+	return nil
+}
+
+func (v *DroppedSpansStats) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
+	w.RawByte('{')
+	w.RawString("\"destination_service_resource\":")
+	w.String(v.DestinationServiceResource)
+	w.RawString(",\"duration\":")
+	if err := v.Duration.MarshalFastJSON(w); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	w.RawString(",\"outcome\":")
+	w.String(v.Outcome)
+	w.RawString(",\"subtype\":")
+	w.String(v.Subtype)
+	w.RawString(",\"type\":")
+	w.String(v.Type)
+	w.RawByte('}')
+	return firstErr
+}
+
+func (v *AggregateDuration) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
+	w.RawByte('{')
+	w.RawString("\"count\":")
+	w.Int64(int64(v.Count))
+	w.RawString(",\"sum\":")
+	if err := v.Sum.MarshalFastJSON(w); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	w.RawByte('}')
+	return firstErr
+}
+
+func (v *DurationSum) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	w.RawString("\"us\":")
+	w.Int64(v.Us)
 	w.RawByte('}')
 	return nil
 }

--- a/model/marshal_test.go
+++ b/model/marshal_test.go
@@ -104,6 +104,20 @@ func TestMarshalTransaction(t *testing.T) {
 			"started": float64(99),
 			"dropped": float64(4),
 		},
+		"dropped_spans_stats": []interface{}{
+			map[string]interface{}{
+				"destination_service_resource": "http://elasticsearch:9200",
+				"duration": map[string]interface{}{
+					"count": float64(4),
+					"sum": map[string]interface{}{
+						"us": float64(1000),
+					},
+				},
+				"outcome": "success",
+				"subtype": "elasticsearch",
+				"type":    "request",
+			},
+		},
 	}
 	assert.Equal(t, expect, decoded)
 }
@@ -626,6 +640,18 @@ func fakeTransaction() model.Transaction {
 		SpanCount: model.SpanCount{
 			Started: 99,
 			Dropped: 4,
+		},
+		DroppedSpansStats: []model.DroppedSpansStats{
+			{
+				Type:                       "request",
+				Subtype:                    "elasticsearch",
+				DestinationServiceResource: "http://elasticsearch:9200",
+				Outcome:                    "success",
+				Duration: model.AggregateDuration{
+					Count: 4,
+					Sum:   model.DurationSum{Us: time.Millisecond.Microseconds()},
+				},
+			},
 		},
 	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -269,6 +269,10 @@ type Transaction struct {
 	// SpanCount holds statistics on spans within a transaction.
 	SpanCount SpanCount `json:"span_count"`
 
+	// DroppedSpansStats holds information about spans that were dropped
+	// (for example due to transaction_max_spans or exit_span_min_duration).
+	DroppedSpansStats []DroppedSpansStats `json:"dropped_spans_stats,omitempty"`
+
 	// Outcome holds the transaction outcome: success, failure, or unknown.
 	Outcome string `json:"outcome,omitempty"`
 }
@@ -282,6 +286,38 @@ type SpanCount struct {
 
 	// Started holds the number of spans started within a transaction.
 	Started int `json:"started"`
+}
+
+// DroppedSpansStats holds information about spans that were dropped
+// (for example due to transaction_max_spans or exit_span_min_duration).
+type DroppedSpansStats struct {
+	// Type holds the dropped span's type, and can have specific keywords
+	// within the service's domain (eg: 'request', 'backgroundjob', etc)
+	Type string `json:"type"`
+	// Subtype is a further sub-division of the type (e.g. postgresql, elasticsearch)
+	Subtype string `json:"subtype"`
+	// DestinationServiceResource identifies the destination service resource
+	// being operated on. e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name'.
+	DestinationServiceResource string `json:"destination_service_resource"`
+	// Outcome of the span: success, failure, or unknown. Outcome may be one of
+	// a limited set of permitted values describing the success or failure of
+	// the span. It can be used for calculating error rates for outgoing requests.
+	Outcome string `json:"outcome"`
+	// Duration holds duration aggregations about the dropped span.
+	Duration AggregateDuration `json:"duration"`
+}
+
+// AggregateDuration duration
+type AggregateDuration struct {
+	// Count holds the number of times the dropped span happened.
+	Count int `json:"count"`
+	// Sum holds dimensions about the dropped span's duration.
+	Sum DurationSum `json:"sum"`
+}
+
+// DurationSum contains units for duration
+type DurationSum struct {
+	Us int64 `json:"us"`
 }
 
 // Span represents a span within a transaction.


### PR DESCRIPTION
## Description
Modifies the span timing reporting function to collect statistics about
dropped spans when they exceed the `transaction_max_spans`. Each dropped
span is now aggregated under the `transaction.dropped_spans_stats` array
with a maximum count of items of `128`.

Each dropped span is aggregated on 4 dimensions: `outcome`. `subtype`,
`type` and `destination_service_resource` and report 2 metrics, their
`duration.sum.us` and the `count` for each of the aggregated dropped
spans.

## Related issues

Closes #1113