### PR TITLE
span (experimental): Compress short exit spans

### DIFF
--- a/apmtest/debug.go
+++ b/apmtest/debug.go
@@ -1,0 +1,158 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmtest // import "go.elastic.co/apm/apmtest"
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"text/tabwriter"
+	"time"
+	"unicode/utf8"
+
+	"go.elastic.co/apm/model"
+)
+
+// PrintTraces displays the trace as a table which can be used on tests to aid
+// debugging.
+func PrintTraces(writer io.Writer, tx model.Transaction, spans []model.Span) {
+	w := tabwriter.NewWriter(writer, 2, 4, 2, ' ', tabwriter.TabIndent)
+	fmt.Fprintln(w, "#\tNAME\tTYPE\tCOMP\tN\tDURATION\tOFFSET\tSPAN ID\tPARENT ID\tTRACE ID")
+
+	fmt.Fprintf(w, "TX\t%s\t%s\t-\t-\t%f\t%d\t%x\t%x\t%x\n", tx.Name,
+		tx.Type, tx.Duration,
+		0,
+		tx.ID, tx.ParentID, tx.TraceID,
+	)
+
+	sort.SliceStable(spans, func(i, j int) bool {
+		return time.Time(spans[i].Timestamp).Before(time.Time(spans[j].Timestamp))
+	})
+	for i, span := range spans {
+		count := 1
+		if span.Composite != nil {
+			count = span.Composite.Count
+		}
+
+		fmt.Fprintf(w, "%d\t%s\t%s\t%v\t%d\t%f\t+%d\t%x\t%x\t%x\n", i, span.Name,
+			span.Type, span.Composite != nil, count, span.Duration,
+			time.Time(span.Timestamp).Sub(time.Time(tx.Timestamp))/1e3,
+			span.ID, span.ParentID, span.TraceID,
+		)
+	}
+	w.Flush()
+}
+
+// WriteTraceWaterfall the trace waterfall "console output" to the specified
+// writer sorted by timestamp.
+func WriteTraceWaterfall(w io.Writer, tx model.Transaction, spans []model.Span) {
+	maxDuration := time.Duration(tx.Duration * float64(time.Millisecond))
+	if maxDuration == 0 {
+		for _, span := range spans {
+			maxDuration += time.Duration(span.Duration * float64(time.Millisecond))
+		}
+	}
+
+	maxWidth := int64(220)
+	buf := new(bytes.Buffer)
+	if tx.Duration > 0.0 {
+		writeSpan(buf, int(maxWidth), 0, fmt.Sprintf("transaction (%x) - %s", tx.ID, maxDuration.String()))
+	}
+
+	sort.SliceStable(spans, func(i, j int) bool {
+		return time.Time(spans[i].Timestamp).Before(time.Time(spans[j].Timestamp))
+	})
+
+	for _, span := range spans {
+		pos := int(math.Round(
+			float64(time.Time(span.Timestamp).Sub(time.Time(tx.Timestamp))) /
+				float64(maxDuration) * float64(maxWidth),
+		))
+		tDur := time.Duration(span.Duration * float64(time.Millisecond))
+		dur := float64(tDur) / float64(maxDuration)
+		width := int(math.Round(dur * float64(maxWidth)))
+		if width == int(maxWidth) {
+			width = int(maxWidth) - 1
+		}
+
+		spancontent := fmt.Sprintf("%s %s - %s",
+			span.Type, span.Name,
+			time.Duration(span.Duration*float64(time.Millisecond)).String(),
+		)
+		if span.Composite != nil {
+			spancontent = fmt.Sprintf("%d*%s", span.Composite.Count, spancontent)
+		}
+		writeSpan(buf, width, pos, spancontent)
+	}
+
+	io.Copy(w, buf)
+}
+
+func writeSpan(buf *bytes.Buffer, width, pos int, content string) {
+	spaceRune := ' '
+	fillRune := ' '
+	startRune := '['
+	endRune := ']'
+
+	// Prevent the spans from going out of bounds.
+	if pos == width {
+		pos = pos - 2
+	} else if pos >= width {
+		pos = pos - 1
+	}
+
+	for i := 0; i < int(pos); i++ {
+		buf.WriteRune(spaceRune)
+	}
+
+	if width <= 1 {
+		width = 1
+		// Write the first letter of the span type when the width is too small.
+		startRune, _ = utf8.DecodeRuneInString(content)
+	}
+
+	var written int
+	written, _ = buf.WriteRune(startRune)
+	if len(content) >= int(width)-1 {
+		content = content[:int(width)-1]
+	}
+
+	spacing := (width - len(content) - 2) / 2
+	for i := 0; i < spacing; i++ {
+		n, _ := buf.WriteRune(fillRune)
+		written += n
+	}
+
+	n, _ := buf.WriteString(content)
+	written += n
+	for i := 0; i < spacing; i++ {
+		n, _ := buf.WriteRune(fillRune)
+		written += n
+	}
+
+	if written < width {
+		buf.WriteRune(fillRune)
+	}
+	if width > 1 {
+		buf.WriteRune(endRune)
+	}
+
+	buf.WriteString("\n")
+}

--- a/config.go
+++ b/config.go
@@ -63,6 +63,14 @@ const (
 	envUseElasticTraceparentHeader = "ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER"
 	envCloudProvider               = "ELASTIC_APM_CLOUD_PROVIDER"
 
+	// NOTE(marclop) Experimental settings
+	// span_compression (default `false`)
+	envSpanCompressionEnabled = "ELASTIC_APM_SPAN_COMPRESSION_ENABLED"
+	// span_compression_exact_match_max_duration (default `50ms`)
+	envSpanCompressionExactMatchMaxDuration = "ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION"
+	// span_compression_same_kind_max_duration (default `5ms`)
+	envSpanCompressionSameKindMaxDuration = "ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION"
+
 	// NOTE(axw) profiling environment variables are experimental.
 	// They may be removed in a future minor version without being
 	// considered a breaking change.
@@ -87,6 +95,11 @@ const (
 	maxAPIRequestSize    = 5 * configutil.MByte
 	minMetricsBufferSize = 10 * configutil.KByte
 	maxMetricsBufferSize = 100 * configutil.MByte
+
+	// Experinmental Span Compressions default setting values
+	defaultSpanCompressionEnabled               = false
+	defaultSpanCompressionExactMatchMaxDuration = 50 * time.Millisecond
+	defaultSpanCompressionSameKindMaxDuration   = 5 * time.Millisecond
 )
 
 var (
@@ -296,6 +309,26 @@ func initialBreakdownMetricsEnabled() (bool, error) {
 
 func initialUseElasticTraceparentHeader() (bool, error) {
 	return configutil.ParseBoolEnv(envUseElasticTraceparentHeader, true)
+}
+
+func initialSpanCompressionEnabled() (bool, error) {
+	return configutil.ParseBoolEnv(envSpanCompressionEnabled,
+		defaultSpanCompressionEnabled,
+	)
+}
+
+func initialSpanCompressionExactMatchMaxDuration() (time.Duration, error) {
+	return configutil.ParseDurationEnv(
+		envSpanCompressionExactMatchMaxDuration,
+		defaultSpanCompressionExactMatchMaxDuration,
+	)
+}
+
+func initialSpanCompressionSameKindMaxDuration() (time.Duration, error) {
+	return configutil.ParseDurationEnv(
+		envSpanCompressionSameKindMaxDuration,
+		defaultSpanCompressionSameKindMaxDuration,
+	)
 }
 
 func initialCPUProfileIntervalDuration() (time.Duration, time.Duration, error) {
@@ -532,4 +565,9 @@ type instrumentationConfigValues struct {
 	propagateLegacyHeader bool
 	sanitizedFieldNames   wildcard.Matchers
 	ignoreTransactionURLs wildcard.Matchers
+
+	// compressed spans.
+	spanCompressionEnabled               bool
+	spanCompressionExactMatchMaxDuration time.Duration
+	spanCompressionSameKindMaxDuration   time.Duration
 }

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -573,6 +573,12 @@ func (v *Span) MarshalFastJSON(w *fastjson.Writer) error {
 		w.RawString(",\"action\":")
 		w.String(v.Action)
 	}
+	if v.Composite != nil {
+		w.RawString(",\"composite\":")
+		if err := v.Composite.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if v.Context != nil {
 		w.RawString(",\"context\":")
 		if err := v.Context.MarshalFastJSON(w); err != nil && firstErr == nil {
@@ -842,6 +848,18 @@ func (v *DatabaseSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 		}
 		w.String(v.User)
 	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *CompositeSpan) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	w.RawString("\"compression_strategy\":")
+	w.String(v.CompressionStrategy)
+	w.RawString(",\"count\":")
+	w.Int64(int64(v.Count))
+	w.RawString(",\"sum\":")
+	w.Float64(v.Sum)
 	w.RawByte('}')
 	return nil
 }

--- a/model/model.go
+++ b/model/model.go
@@ -330,6 +330,10 @@ type Span struct {
 
 	// Outcome holds the span outcome: success, failure, or unknown.
 	Outcome string `json:"outcome,omitempty"`
+
+	// Composite is set when the span is a composite span and represents an
+	// aggregated set of spans as defined by `composite.compression_strategy`.
+	Composite *CompositeSpan `json:"composite,omitempty"`
 }
 
 // SpanContext holds contextual information relating to the span.
@@ -430,6 +434,19 @@ type HTTPSpanContext struct {
 
 	// StatusCode holds the HTTP response status code.
 	StatusCode int `json:"status_code,omitempty"`
+}
+
+// CompositeSpan holds details on a group of spans represented by a single one.
+type CompositeSpan struct {
+	// Count is the number of compressed spans the composite span represents.
+	// The minimum count is 2, as a composite span represents at least two spans.
+	Count int `json:"count"`
+	// Sum is the durations of all compressed spans this composite span
+	// represents in milliseconds.
+	Sum float64 `json:"sum"`
+	// A string value indicating which compression strategy was used. The valid
+	// values are `exact_match` and `same_kind`.
+	CompressionStrategy string `json:"compression_strategy"`
 }
 
 // Context holds contextual information relating to a transaction or error.

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -145,6 +145,9 @@ func (w *modelWriter) buildModelSpan(out *model.Span, span *Span, sd *SpanData) 
 	out.Duration = sd.Duration.Seconds() * 1000
 	out.Outcome = normalizeOutcome(sd.Outcome)
 	out.Context = sd.Context.build()
+	if span.composite.count > 1 {
+		out.Composite = span.composite.build()
+	}
 
 	// Copy the span type to context.destination.service.type.
 	if out.Context != nil && out.Context.Destination != nil && out.Context.Destination.Service != nil {

--- a/span_compressed.go
+++ b/span_compressed.go
@@ -1,0 +1,321 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apm // import "go.elastic.co/apm"
+
+import (
+	"time"
+
+	"go.elastic.co/apm/model"
+)
+
+const (
+	_ int = iota
+	compressedStrategyExactMatch
+	compressedStrategySameKind
+)
+
+type compositeSpan struct {
+	// this internal representation should be set in Nanoseconds, although
+	// the model unit is set in Milliseconds.
+	sum                 int64
+	count               int
+	compressionStrategy int
+	lastSiblingEndTime  time.Time
+}
+
+func (cs compositeSpan) build() *model.CompositeSpan {
+	var out model.CompositeSpan
+	switch cs.compressionStrategy {
+	case compressedStrategyExactMatch:
+		out.CompressionStrategy = "exact_match"
+	case compressedStrategySameKind:
+		out.CompressionStrategy = "same_kind"
+	}
+	out.Count = cs.count
+	out.Sum = float64(cs.sum) / float64(time.Millisecond)
+	return &out
+}
+
+func (cs compositeSpan) empty() bool {
+	return cs.count < 1
+}
+
+//
+// Span //
+//
+
+// attemptCompress tries to compress a span into a "composite span" when:
+// * Compression is enabled on agent.
+// * The buffered span and the incoming span:
+//   * Share the same parent (are siblings).
+//   * Are consecutive spans.
+//   * Are both exit spans, outcome == success and are short enough (See
+//     `ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION` and
+//     `ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION` for more info).
+//   * Represent the same exact operation or the same kind of operation:
+//     * Are an exact match (same name, kind and destination service).
+//       OR
+//     * Are the same kind match (same kind and destination service).
+//     When a span has already been compressed using a particular strategy, it
+//     CANNOT continue to compress spans using a different strategy.
+// The compression algorithm is fairly simple and only compresses spans into a
+// composite span when the conditions listed above are met for all consecutive
+// spans, when a span comes in that doesn't meet any of the conditions, the
+// buffer will be flushed (buffered span will be enqueued) and:
+// * When the incoming span is compressible, it will replace the buffered span.
+// * When the incoming span is not compressible, it will be enqueued as well.
+//
+// Returns `true` when the span has been buffered, thus the caller should not
+// reportSelfTime and enqueue the span. When `false` is returned, the buffer is
+// flushed and the called should reportSelfTime and enqueue.
+func (s *Span) attemptCompress(compressionEnabled bool) bool {
+	if !compressionEnabled {
+		return false
+	}
+
+	// There are two distinct places where the span can be buffered; the parent
+	// span and the transaction (when a transaction is the span's parent).
+	if s.parent != nil {
+		// Flush the buffer, have the caller report the span.
+		if !s.isCompressionEligible() {
+			if !s.buffer.empty() {
+				s.buffer.flush(nil)
+			}
+			return false
+		}
+
+		// An incoming span (s) is compressable, check if the buffer is empty,
+		// if so, store the the event and report the span as compressed.
+		if s.parent.buffer.empty() {
+			s.parent.buffer.store(s)
+			return true
+		}
+
+		// When the span is compressable, try to compress it, report back true:
+		// On success: store it.
+		// On failure: flush and swap the cache with the current span.
+		if s.compress(s.parent.buffer.span) {
+			s.parent.buffer.store(s)
+		} else {
+			s.parent.buffer.flush(s)
+		}
+		return true
+	}
+	// If the span has not parent and no transaction, it should be reported by
+	// the caller.
+	if s.tx == nil {
+		return false
+	}
+
+	if !s.isCompressionEligible() {
+		// At this point, the span isn't compressable which is likely to be a
+		// parent or non-compressable sibling, either way, the transaction or
+		// the span's buffer needs to be flushed and `false` is returned.
+		if !s.tx.buffer.empty() {
+			s.tx.buffer.flush(nil)
+		}
+		if !s.buffer.empty() {
+			s.buffer.flush(nil)
+		}
+		return false
+	}
+
+	// The span is compressable and we need to store in the parent's cache.
+	if s.tx.buffer.empty() {
+		s.tx.buffer.store(s)
+		return true
+	}
+
+	// When the span is compressable, try to compress it, report back true:
+	// On success: store it.
+	// On failure: flush and swap the cache with the current span.
+	if s.tx.buffer.span.compress(s) {
+		s.tx.buffer.span.buffer.store(s)
+	} else {
+		s.tx.buffer.flush(s)
+	}
+	return true
+}
+
+func (s *Span) isCompressionEligible() bool {
+	if s == nil {
+		return false
+	}
+	return s.exit && !s.ctxPropagated &&
+		(s.Outcome == "" || s.Outcome == "success")
+}
+
+// A span is eligible for compression if all the following conditions are met
+// 1. It's an exit span
+// 2. The trace context has not been propagated to a downstream service
+// 3. If the span has outcome (i.e., outcome is present and it's not null) then
+//    it should be success. It means spans with outcome indicating an issue of
+//    potential interest should not be compressed.
+// The second condition is important so that we don't remove (compress) a span
+// that may be the parent of a downstream service. This would orphan the sub-
+// graph started by the downstream service and cause it to not appear in the
+// waterfall view.
+func (s *Span) compress(sibling *Span) bool {
+	strategy := s.canCompressComposite(sibling)
+	if strategy == 0 {
+		strategy = s.canCompressStandard(sibling)
+	}
+
+	// If the span cannot be compressed using any strategy.
+	if strategy == 0 {
+		return false
+	}
+
+	if s.composite.empty() {
+		s.composite = compositeSpan{
+			count:               1,
+			sum:                 int64(s.Duration),
+			compressionStrategy: strategy,
+		}
+	}
+
+	s.composite.count++
+	s.composite.sum += int64(sibling.Duration)
+	siblingTimestamp := sibling.timestamp.Add(sibling.Duration)
+	if siblingTimestamp.After(s.composite.lastSiblingEndTime) {
+		s.composite.lastSiblingEndTime = siblingTimestamp
+	}
+	return true
+}
+
+func (s *Span) canCompressStandard(sibling *Span) int {
+	if !s.isSameKind(sibling) {
+		return 0
+	}
+
+	if s.isExactMatch(sibling) {
+		if s.durationLowerOrEq(sibling,
+			s.tx.compressedSpans.exactMatchMaxDuration,
+		) {
+			return compressedStrategyExactMatch
+		}
+		return 0
+	}
+	if s.isSameKind(sibling) {
+		if s.durationLowerOrEq(sibling,
+			s.tx.compressedSpans.sameKindMaxDuration,
+		) {
+			s.Name = "Calls to " + s.Context.destinationService.Resource
+			return compressedStrategyExactMatch
+		}
+	}
+	return 0
+}
+
+func (s *Span) canCompressComposite(sibling *Span) int {
+	if s.composite.empty() {
+		return 0
+	}
+	switch s.composite.compressionStrategy {
+	case compressedStrategyExactMatch:
+		if s.isExactMatch(sibling) && s.durationLowerOrEq(sibling,
+			s.tx.compressedSpans.exactMatchMaxDuration,
+		) {
+			return compressedStrategyExactMatch
+		}
+	case compressedStrategySameKind:
+		if s.isSameKind(sibling) && s.durationLowerOrEq(sibling,
+			s.tx.compressedSpans.sameKindMaxDuration,
+		) {
+			return compressedStrategySameKind
+		}
+	}
+	return 0
+}
+
+func (s *Span) durationLowerOrEq(sibling *Span, max time.Duration) bool {
+	return s.Duration <= max && sibling.Duration <= max
+}
+
+// spanBuffer acts as an intermediary buffer that stores compressable spans on
+// their parents to compress with other compression eligible siblings.
+//
+// Not concurrently safe.
+type spanBuffer struct {
+	span *Span
+}
+
+func (b *spanBuffer) empty() bool { return b.span == nil }
+
+func (b *spanBuffer) store(s *Span) { preserveSpanData(s, b) }
+
+// flush enqueues a span to the tracer event queue, but first, it reports the
+// parent and tx timers when the breakdown metrics are enabled and when it's
+// a compressed span, the duration is adjusted to end when the last sibling
+// ended - first span event timestamp.
+func (b *spanBuffer) flush(s *Span) {
+	// When the span is a composite span, we need to adjust the duration
+	// just before it is reported and no more spans will be compressed into
+	// the composite. If we did this any time before, the duration of the span
+	// would potentially grow over the compressable threshold and result in
+	// compressable span not being compressed and reported separately.
+	if !b.span.composite.empty() {
+		b.span.Duration = b.span.composite.lastSiblingEndTime.Sub(b.span.timestamp)
+	}
+	if !b.span.tx.ended() && b.span.tx.breakdownMetricsEnabled {
+		b.span.reportSelfTimeLockless(b.span.timestamp.Add(b.span.Duration))
+	}
+
+	b.span.enqueue()
+	b.span = s
+	if s != nil {
+		preserveSpanData(s, b)
+	}
+}
+
+func preserveSpanData(from *Span, to *spanBuffer) {
+	te := struct {
+		*Span
+		*SpanData
+	}{
+		Span:     from,
+		SpanData: from.SpanData,
+	}
+	to.span = te.Span
+	to.span.SpanData = te.SpanData
+}
+
+//
+// SpanData //
+//
+
+// isExactMatch is used for compression purposes, two spans are considered an
+// exact match if the have the same name and are of the same kind (see
+// isSameKind for more details).
+func (s *SpanData) isExactMatch(span *Span) bool {
+	return s.Name == span.Name && s.isSameKind(span)
+}
+
+// isSameKind is used for compression purposes, two spans are considered to be
+// of the same kind if they have the same values for type, subtype, and
+// `destination.service.resource`.
+func (s *SpanData) isSameKind(span *Span) bool {
+	sameType := s.Type == span.Type
+	sameSubType := s.Subtype == span.Subtype
+	dstSrv := s.Context.destination.Service
+	otherDstSrv := span.Context.destination.Service
+	sameDstSrvRs := dstSrv != nil && otherDstSrv != nil &&
+		dstSrv.Resource == otherDstSrv.Resource
+
+	return sameType && sameSubType && sameDstSrvRs
+}

--- a/span_test.go
+++ b/span_test.go
@@ -19,6 +19,8 @@ package apm_test
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -188,6 +190,259 @@ func TestStartExitSpan(t *testing.T) {
 	// Spans should still be marked as an exit span after they've been
 	// ended.
 	assert.True(t, span.IsExitSpan())
+}
+
+func TestCompressSpanExactMatch(t *testing.T) {
+	tests := []struct {
+		name               string
+		compressionEnabled bool
+		setup              func(t *testing.T) func()
+		assertFunc         func(t *testing.T, tx model.Transaction, spans []model.Span)
+	}{
+		{
+			name:               "CompressFalse",
+			compressionEnabled: false,
+			assertFunc: func(t *testing.T, tx model.Transaction, spans []model.Span) {
+				require.NotEmpty(t, tx)
+				require.Equal(t, 14, len(spans))
+				for _, span := range spans {
+					require.Nil(t, span.Composite)
+				}
+			},
+		},
+		{
+			name:               "CompressTrueSettingTweak",
+			compressionEnabled: true,
+			setup: func(t *testing.T) func() {
+				envVarName := "ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION"
+				og := os.Getenv(envVarName)
+				os.Setenv(envVarName, "1ms")
+				return func() { os.Setenv(envVarName, og) }
+			},
+			assertFunc: func(t *testing.T, tx model.Transaction, spans []model.Span) {
+				require.NotEmpty(t, tx)
+				// This setting
+				require.Equal(t, 5, len(spans))
+				for _, span := range spans[1:] {
+					require.Nil(t, span.Composite)
+				}
+			},
+		},
+		{
+			name:               "CompressSpanCount4",
+			compressionEnabled: true,
+			assertFunc: func(t *testing.T, tx model.Transaction, spans []model.Span) {
+				var composite = spans[0]
+				assert.Equal(t, composite.Context.Destination.Service.Resource, "mysql")
+				compositeSpanCount := 11
+				assert.Equal(t, composite.Composite.Count, compositeSpanCount)
+				assert.Equal(t, composite.Composite.CompressionStrategy, "exact_match")
+				// Sum should be at least the time that each span ran for.
+				assert.Greater(t, composite.Composite.Sum,
+					float64(int64(compositeSpanCount)*100*time.Nanosecond.Milliseconds()),
+				)
+
+				for _, span := range spans {
+					if span.Type == "mysql" {
+						continue
+					}
+					assert.Nil(t, span.Composite)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				t.Cleanup(test.setup(t))
+			}
+
+			tracer := apmtest.NewRecordingTracer()
+			tracer.SetSpanCompressionEnabled(test.compressionEnabled)
+
+			// When compression is enabled:
+			// Compress 10 spans into 1 and add another span with a different type
+			// [                    Transaction                    ]
+			//  [ mysql (11) ] [ request ] [ internal ] [ request ]
+			//
+			tx, spans, _ := tracer.WithTransaction(func(ctx context.Context) {
+				exitSpanOpt := apm.SpanOptions{ExitSpan: true}
+				for i := 0; i < 10; i++ {
+					span, _ := apm.StartSpanOptions(ctx, "SELECT * FROM users", "mysql", exitSpanOpt)
+					<-time.After(100 * time.Nanosecond)
+					span.End()
+				}
+				{
+					span, _ := apm.StartSpanOptions(ctx, "SELECT * FROM users", "mysql", exitSpanOpt)
+					<-time.After(2 * time.Millisecond)
+					span.End()
+				}
+
+				// None of these should be added to the composite.
+				{
+					span, _ := apm.StartSpanOptions(ctx, "GET /", "request", exitSpanOpt)
+					<-time.After(100 * time.Nanosecond)
+					span.End()
+				}
+				{
+					// Not an exit span, should not be compressed
+					span, _ := apm.StartSpan(ctx, "calculate complex", "internal")
+					<-time.After(100 * time.Nanosecond)
+					span.End()
+				}
+				{
+					// Exit span, this is a good candidate to be compressed, but
+					// since it can't be compressed with the last request type ("internal")
+					span, _ := apm.StartSpanOptions(ctx, "GET /", "request", exitSpanOpt)
+					<-time.After(100 * time.Nanosecond)
+					span.End()
+				}
+			})
+			defer func() {
+				if t.Failed() {
+					apmtest.WriteTraceWaterfall(os.Stdout, tx, spans)
+				}
+			}()
+
+			if test.assertFunc != nil {
+				test.assertFunc(t, tx, spans)
+			}
+		})
+	}
+}
+
+func TestCompressSpanSameKind(t *testing.T) {
+	tracer := apmtest.NewRecordingTracer()
+	tracer.SetSpanCompressionEnabled(true)
+
+	// Compress 5 spans into 1 and add another span with a different type
+	// [       Transaction       ]
+	//  [ mysql ] [ request (5) ]
+	//
+	tx, spans, _ := tracer.WithTransaction(func(ctx context.Context) {
+		exitSpanOpt := apm.SpanOptions{ExitSpan: true}
+		path := []string{"/a", "/b", "/c", "/d", "/e"}
+		// Span is compressable, but cannot be compressed since the next span
+		// is not the same kind. It gets published.
+		{
+			span, _ := apm.StartSpanOptions(ctx, "SELECT * FROM users", "mysql", exitSpanOpt)
+			<-time.After(100 * time.Nanosecond)
+			span.End()
+		}
+		// These spans should be compressed into 1.
+		for i := 0; i < 5; i++ {
+			uri := fmt.Sprint("GET ", path[i])
+			span, _ := apm.StartSpanOptions(ctx, uri, "request", exitSpanOpt)
+			<-time.After(100 * time.Nanosecond)
+			span.End()
+		}
+	})
+
+	defer func() {
+		if t.Failed() {
+			apmtest.WriteTraceWaterfall(os.Stdout, tx, spans)
+		}
+	}()
+
+	assert.NotNil(t, tx)
+	assert.Equal(t, 2, len(spans))
+
+	mysqlSpan := spans[0]
+	assert.Equal(t, mysqlSpan.Context.Destination.Service.Resource, "mysql")
+	assert.Nil(t, mysqlSpan.Composite)
+
+	requestSpan := spans[1]
+	assert.Equal(t, requestSpan.Context.Destination.Service.Resource, "request")
+	assert.NotNil(t, requestSpan.Composite)
+	assert.Equal(t, requestSpan.Composite.Count, 5)
+	assert.Equal(t, requestSpan.Name, "Calls to request")
+	// Check that the aggregate sum is at least the duration of the time we
+	// we waited for.
+	assert.Greater(t, requestSpan.Composite.Sum, float64(5*100/time.Millisecond))
+
+	// Check that the total composite span duration is at least 5 milliseconds.
+	assert.Greater(t, requestSpan.Duration, float64(5*100/time.Millisecond))
+}
+
+func TestCompressSpanSameKindParentSpan(t *testing.T) {
+	tracer := apmtest.NewRecordingTracer()
+	tracer.SetSpanCompressionEnabled(true)
+
+	// This test case covers spans that have other spans as parents.
+	tx, spans, _ := tracer.WithTransaction(func(ctx context.Context) {
+		{
+			// Doesn't compress any spans since none meet the necessary conditions
+			// the "request" type are both the same type but the parent
+			// [       Transaction       ...snip
+			//  [       internal op     ]
+			//   [        request      ]
+			//          [   request   ]
+			//
+			parent, ctx := apm.StartSpan(ctx, "internal op", "internal")
+			// Have span propagate context downstream, this should not allow for
+			// compression
+			child, ctx := apm.StartSpan(ctx, "GET /resource", "request")
+			grandChild, _ := apm.StartSpanOptions(ctx, "GET /different", "request", apm.SpanOptions{
+				ExitSpan: true,
+				Parent:   child.TraceContext(),
+			})
+			<-time.After(500 * time.Nanosecond)
+			grandChild.End()
+			child.End()
+			parent.End()
+		}
+		{
+			// Compresses the last two spans together since they are both exit
+			// spans, same "request" type, don't propagate ctx and succeed.
+			// ..continued  Transaction   ]
+			//  [       internal op     ]
+			//       [  request (2)   ]  ( [GET /res] [GET /diff] )
+			//
+			exitSpanOpts := apm.SpanOptions{ExitSpan: true}
+			parent, ctx := apm.StartSpan(ctx, "another op", "internal")
+			child, _ := apm.StartSpanOptions(ctx, "GET /res", "request", exitSpanOpts)
+			<-time.After(300 * time.Nanosecond)
+
+			otherChild, _ := apm.StartSpanOptions(ctx, "GET /diff", "request", exitSpanOpts)
+			<-time.After(300 * time.Nanosecond)
+
+			otherChild.End()
+			child.End()
+
+			parent.End()
+		}
+	})
+
+	defer func() {
+		if t.Failed() {
+			apmtest.WriteTraceWaterfall(os.Stdout, tx, spans)
+		}
+	}()
+	assert.NotNil(t, tx)
+	assert.Equal(t, 5, len(spans))
+
+	// Since the spans are started very close together, even a time.Sleep
+	// doesn't return the spans in a deterministic order, which is OK.
+	var compositeSpan model.Span
+	var compositeParent model.Span
+	for _, span := range spans {
+		if span.Name == "another op" && span.Type == "internal" {
+			compositeParent = span
+		}
+	}
+	for _, span := range spans {
+		if span.Composite != nil {
+			compositeSpan = span
+			assert.Equal(t, "Calls to request", span.Name)
+			assert.Equal(t, "request", span.Type)
+		}
+	}
+
+	assert.NotNil(t, compositeSpan)
+	assert.NotNil(t, compositeSpan.Composite)
+	assert.Equal(t, compositeSpan.Composite.Count, 2)
+	assert.Equal(t, compositeSpan.ParentID, compositeParent.ID)
+	assert.GreaterOrEqual(t, compositeParent.Duration, compositeSpan.Duration)
 }
 
 func TestExitSpanDoesNotOverwriteDestinationServiceResource(t *testing.T) {

--- a/tracer.go
+++ b/tracer.go
@@ -117,6 +117,8 @@ type TracerOptions struct {
 	cpuProfileInterval    time.Duration
 	cpuProfileDuration    time.Duration
 	heapProfileInterval   time.Duration
+
+	compressionOptions compressionOptions
 }
 
 // initDefaults updates opts with default values.
@@ -162,6 +164,21 @@ func (opts *TracerOptions) initDefaults(continueOnError bool) error {
 	maxSpans, err := initialMaxSpans()
 	if failed(err) {
 		maxSpans = defaultMaxSpans
+	}
+
+	spanCompressionEnabled, err := initialSpanCompressionEnabled()
+	if failed(err) {
+		spanCompressionEnabled = defaultSpanCompressionEnabled
+	}
+
+	spanCompressionExactMatchMaxDuration, err := initialSpanCompressionExactMatchMaxDuration()
+	if failed(err) {
+		spanCompressionExactMatchMaxDuration = defaultSpanCompressionExactMatchMaxDuration
+	}
+
+	spanCompressionSameKindMaxDuration, err := initialSpanCompressionSameKindMaxDuration()
+	if failed(err) {
+		spanCompressionSameKindMaxDuration = defaultSpanCompressionSameKindMaxDuration
 	}
 
 	sampler, err := initialSampler()
@@ -244,6 +261,11 @@ func (opts *TracerOptions) initDefaults(continueOnError bool) error {
 	opts.bufferSize = bufferSize
 	opts.metricsBufferSize = metricsBufferSize
 	opts.maxSpans = maxSpans
+	opts.compressionOptions = compressionOptions{
+		enabled:               spanCompressionEnabled,
+		exactMatchMaxDuration: spanCompressionExactMatchMaxDuration,
+		sameKindMaxDuration:   spanCompressionSameKindMaxDuration,
+	}
 	opts.sampler = sampler
 	opts.sanitizedFieldNames = initialSanitizedFieldNames()
 	opts.disabledMetrics = initialDisabledMetrics()
@@ -282,6 +304,12 @@ func (opts *TracerOptions) initDefaults(continueOnError bool) error {
 		opts.ServiceEnvironment = serviceEnvironment
 	}
 	return nil
+}
+
+type compressionOptions struct {
+	enabled               bool
+	exactMatchMaxDuration time.Duration
+	sameKindMaxDuration   time.Duration
 }
 
 // Tracer manages the sampling and sending of transactions to
@@ -411,6 +439,15 @@ func newTracer(opts TracerOptions) *Tracer {
 	})
 	t.setLocalInstrumentationConfig(envMaxSpans, func(cfg *instrumentationConfigValues) {
 		cfg.maxSpans = opts.maxSpans
+	})
+	t.setLocalInstrumentationConfig(envSpanCompressionEnabled, func(cfg *instrumentationConfigValues) {
+		cfg.spanCompressionEnabled = opts.compressionOptions.enabled
+	})
+	t.setLocalInstrumentationConfig(envSpanCompressionExactMatchMaxDuration, func(cfg *instrumentationConfigValues) {
+		cfg.spanCompressionExactMatchMaxDuration = opts.compressionOptions.exactMatchMaxDuration
+	})
+	t.setLocalInstrumentationConfig(envSpanCompressionSameKindMaxDuration, func(cfg *instrumentationConfigValues) {
+		cfg.spanCompressionSameKindMaxDuration = opts.compressionOptions.sameKindMaxDuration
 	})
 	t.setLocalInstrumentationConfig(envTransactionSampleRate, func(cfg *instrumentationConfigValues) {
 		cfg.sampler = opts.sampler
@@ -704,6 +741,29 @@ func (t *Tracer) SetSampler(s Sampler) {
 func (t *Tracer) SetMaxSpans(n int) {
 	t.setLocalInstrumentationConfig(envMaxSpans, func(cfg *instrumentationConfigValues) {
 		cfg.maxSpans = n
+	})
+}
+
+// SetSpanCompressionEnabled enables/disables the span compression feature.
+func (t *Tracer) SetSpanCompressionEnabled(v bool) {
+	t.setLocalInstrumentationConfig(envSpanCompressionEnabled, func(cfg *instrumentationConfigValues) {
+		cfg.spanCompressionEnabled = v
+	})
+}
+
+// SetSpanCompressionExactMatchMaxDuration sets the maximum duration for a span
+// to be compressed with `compression_strategy` == `exact_match`.
+func (t *Tracer) SetSpanCompressionExactMatchMaxDuration(v time.Duration) {
+	t.setLocalInstrumentationConfig(envSpanCompressionExactMatchMaxDuration, func(cfg *instrumentationConfigValues) {
+		cfg.spanCompressionExactMatchMaxDuration = v
+	})
+}
+
+// SetSpanCompressionSameKindMaxDuration sets the maximum duration for a span
+// to be compressed with `compression_strategy` == `same_kind`.
+func (t *Tracer) SetSpanCompressionSameKindMaxDuration(v time.Duration) {
+	t.setLocalInstrumentationConfig(envSpanCompressionSameKindMaxDuration, func(cfg *instrumentationConfigValues) {
+		cfg.spanCompressionSameKindMaxDuration = v
 	})
 }
 


### PR DESCRIPTION
## Description

Implements the span compression algorithm described in elastic/apm#432.
The implementation pretty close to what the spec describes, with a few
modifications due to the differences in the Go agent implementation. The
span compression is an experimental and is disabled by default with the
default thresholds for the different compression strategies set:

- `ELASTIC_APM_SPAN_COMPRESSION_ENABLED=false`
- `ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION=50ms`
- `ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION=5ms`

The implementation uses a `spanBuffer` structure as the storage for span
compression candidates which needs to be present in both Transaction and
Span structures. The algorithm is described in detail with comments on
the code and is well documented there.

Additionally, two helper functions have been added under the `apmtest`:
package: `WriteTraceTable` and `WriteTraceWaterfall`, which help with
understanding why a test is failing if they are and debugging those.

I tried running the tests with higher counts to add pressure to the Go
runtime and have the spans take longer than they otherwise would and
using `apmtest.WriteTraceWaterfall` was extremely helpful.

```
$ go test -count=1000 -run TestCompressSpanSameKindTunedMax .
[             transaction (1757cdb325fd5f4e) - 16.243125ms             ]
m
[          request GET /a - 11.294375ms           ]
                                                 [4*Calls to request - ]
...
```

## Related issues
Closes #972