### PR TITLE
tracer: Remove `statsMu` in favor of `atomic`

### DIFF
--- a/error.go
+++ b/error.go
@@ -333,9 +333,7 @@ func (e *ErrorData) enqueue() {
 	case e.tracer.events <- tracerEvent{eventType: errorEvent, err: e}:
 	default:
 		// Enqueuing an error should never block.
-		e.tracer.statsMu.Lock()
-		e.tracer.stats.ErrorsDropped++
-		e.tracer.statsMu.Unlock()
+		e.tracer.stats.accumulate(TracerStats{ErrorsDropped: 1})
 		e.reset()
 	}
 }

--- a/span.go
+++ b/span.go
@@ -392,9 +392,7 @@ func (s *Span) enqueue() {
 	case s.tracer.events <- event:
 	default:
 		// Enqueuing a span should never block.
-		s.tracer.statsMu.Lock()
-		s.tracer.stats.SpansDropped++
-		s.tracer.statsMu.Unlock()
+		s.tracer.stats.accumulate(TracerStats{SpansDropped: 1})
 		s.reset(s.tracer)
 	}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -327,8 +327,7 @@ type Tracer struct {
 	breakdownMetrics  *breakdownMetrics
 	profileSender     profileSender
 
-	statsMu sync.Mutex
-	stats   TracerStats
+	stats TracerStats
 
 	// instrumentationConfig_ must only be accessed and mutated
 	// using Tracer.instrumentationConfig() and Tracer.setInstrumentationConfig().
@@ -756,10 +755,7 @@ func (t *Tracer) SendMetrics(abort <-chan struct{}) {
 // Stats returns the current TracerStats. This will return the most
 // recent values even after the tracer has been closed.
 func (t *Tracer) Stats() TracerStats {
-	t.statsMu.Lock()
-	stats := t.stats
-	t.statsMu.Unlock()
-	return stats
+	return t.stats.copy()
 }
 
 func (t *Tracer) loop() {
@@ -1054,9 +1050,7 @@ func (t *Tracer) loop() {
 				}
 			}
 			if !stats.isZero() {
-				t.statsMu.Lock()
 				t.stats.accumulate(stats)
-				t.statsMu.Unlock()
 				stats = TracerStats{}
 			}
 			if sentMetrics != nil && requestBufMetricsets > 0 {
@@ -1091,9 +1085,7 @@ func (t *Tracer) loop() {
 		}
 
 		if !stats.isZero() {
-			t.statsMu.Lock()
 			t.stats.accumulate(stats)
-			t.statsMu.Unlock()
 			stats = TracerStats{}
 		}
 

--- a/transaction.go
+++ b/transaction.go
@@ -296,10 +296,7 @@ func (tx *Transaction) enqueue() {
 		// Enqueuing a transaction should never block.
 		tx.tracer.breakdownMetrics.recordTransaction(tx.TransactionData)
 
-		// TODO(axw) use an atomic operation to increment.
-		tx.tracer.statsMu.Lock()
-		tx.tracer.stats.TransactionsDropped++
-		tx.tracer.statsMu.Unlock()
+		tx.tracer.stats.accumulate(TracerStats{TransactionsDropped: 1})
 		tx.reset(tx.tracer)
 	}
 }


### PR DESCRIPTION
## Description
Removes the `statsMu sync.Mutex` and uses the `atomic` package to load
and obtain the values for the stats.
