### PR TITLE
clone request before sanitize in apm context

### DIFF
--- a/context.go
+++ b/context.go
@@ -173,7 +173,7 @@ func (c *Context) SetHTTPRequest(req *http.Request) {
 		httpVersion = fmt.Sprintf("%d.%d", req.ProtoMajor, req.ProtoMinor)
 	}
 
-	c.httpRequest = req
+	c.httpRequest = req.Clone(req.Context())
 
 	c.request = model.Request{
 		Body:        c.request.Body,


### PR DESCRIPTION
I get this really wierd data race error and my asumtions is that the request is modified on multiple places


```
==================
WARNING: DATA RACE
Write at 0x00c0006a2660 by goroutine 7:
  go.elastic.co/apm.sanitizeHeaders()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/sanitizer.go:64 +0x167
  go.elastic.co/apm.sanitizeRequest()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/sanitizer.go:37 +0x1b3
  go.elastic.co/apm.(*Context).build()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/context.go:60 +0x164
  go.elastic.co/apm.(*modelWriter).buildModelError()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/modelwriter.go:165 +0x33b
  go.elastic.co/apm.(*modelWriter).writeError()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/modelwriter.go:74 +0x89
  go.elastic.co/apm.(*Tracer).loop()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/tracer.go:961 +0x1bf9
  go.elastic.co/apm.newTracer·dwrap·17()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/tracer.go:449 +0x39
Previous read at 0x00c0006a2660 by goroutine 300:
  net/textproto.MIMEHeader.Get()
      /usr/local/go/src/net/textproto/header.go:38 +0x9c
  net/http.Header.Get()
      /usr/local/go/src/net/http/header.go:47 +0x50
  net/http.(*Request).BasicAuth()
      /usr/local/go/src/net/http/request.go:940 +0x27
  go.elastic.co/apm.(*Context).SetHTTPRequest()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/context.go:208 +0x6b2
  go.elastic.co/apm/module/apmechov4.setContext()
      /go/pkg/mod/go.elastic.co/apm/module/apmechov4@v1.14.0/middleware.go:146 +0x66
  go.elastic.co/apm/module/apmechov4.(*middleware).handle.func1()
      /go/pkg/mod/go.elastic.co/apm/module/apmechov4@v1.14.0/middleware.go:102 +0x40a
  go.elastic.co/apm/module/apmechov4.(*middleware).handle()
      /go/pkg/mod/go.elastic.co/apm/module/apmechov4@v1.14.0/middleware.go:141 +0x7a6
  go.elastic.co/apm/module/apmechov4.(*middleware).handle-fm()
      /go/pkg/mod/go.elastic.co/apm/module/apmechov4@v1.14.0/middleware.go:68 +0x4d
  gitxxxxxx/xxxxx/xxxx/xxxxxxxxr/pkg/api.(*API).useCorrelationId.func1()
      /app/pkg/api/api.go:225 +0x9b5
  gitxxxxxxx/zzzzz/wen/zzzzzpkg/api.(*API).authorize.func1()
      /app/pkg/api/api.go:203 +0x166
  github.com/labstack/echo/v4.(*Echo).add.func1()
      /go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:552 +0x7a
  github.com/labstack/echo/v4/middleware.CORSWithConfig.func1.1()
      /go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/cors.go:118 +0x573
  github.com/labstack/echo/v4.(*Echo).ServeHTTP.func1()
      /go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:656 +0x289
  github.com/labstack/echo/v4/middleware.AddTrailingSlashWithConfig.func1.1()
      /go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/slash.go:70 +0x283
  github.com/labstack/echo/v4.(*Echo).ServeHTTP()
      /go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:662 +0x844
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·87()
      /usr/local/go/src/net/http/server.go:3033 +0x58
Goroutine 7 (running) created at:
  go.elastic.co/apm.newTracer()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/tracer.go:449 +0x12f6
  go.elastic.co/apm.init.1()
      /go/pkg/mod/go.elastic.co/apm@v1.14.0/tracer.go:64 +0x97
Goroutine 300 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3033 +0x847
  github.com/labstack/echo/v4.(*Echo).Start()
      /go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:679 +0x135

```