### PR TITLE
Fix apmcloudutil logger assignment

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.14.0...master[View commits]
 - Experimental support to compress short exit spans into a composite span. Disabled by default. {pull}1134[#(1134)]
 - Discard exit spans shorter or equal than `ELASTIC_APM_EXIT_SPAN_MIN_DURATION`. Defaults to `1ms`. {pull}1138[#(1138)]
 - module/apmprometheus: add support for mapping prometheus histograms. {pull}1145[#(1145)]
+- Fixed a bug where errors in cloud metadata discovery could lead to the process aborting during initialisation {pull}1158[#(1158)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/utils.go
+++ b/utils.go
@@ -172,7 +172,10 @@ func getCloudMetadata() *model.Cloud {
 	// package initialisation time. Instead, we defer until it is
 	// first requested by the tracer.
 	cloudMetadataOnce.Do(func() {
-		logger := apmlog.DefaultLogger
+		var logger apmcloudutil.Logger
+		if apmlog.DefaultLogger != nil {
+			logger = apmlog.DefaultLogger
+		}
 		provider := apmcloudutil.Auto
 		if str := os.Getenv(envCloudProvider); str != "" {
 			var err error


### PR DESCRIPTION
If logging isn't configured, `apmlog.DefaultLogger` will be nil. `apmlog.DefaultLogger` has a pointer-to-struct type, so converting it to apmcloudutil.Logger results in a non-nil interface value with a nil pointer value.