### PR TITLE
Fix data race in HTTP request header sanitisation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.14.0...master[View commits]
 - Discard exit spans shorter or equal than `ELASTIC_APM_EXIT_SPAN_MIN_DURATION`. Defaults to `1ms`. {pull}1138[#(1138)]
 - module/apmprometheus: add support for mapping prometheus histograms. {pull}1145[#(1145)]
 - Fixed a bug where errors in cloud metadata discovery could lead to the process aborting during initialisation {pull}1158[#(1158)]
+- Fixed a data race related to HTTP request header sanitisation {pull}1159[#(1159)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x


### PR DESCRIPTION
Don't update the header values slice, replace it. See https://github.com/elastic/apm-agent-go/pull/1156#issuecomment-978751558

Replaces https://github.com/elastic/apm-agent-go/pull/1156