### PR TITLE
Set default outcome according to spec

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.14.0...master[View commits]
 - module/apmprometheus: add support for mapping prometheus histograms. {pull}1145[#(1145)]
 - Fixed a bug where errors in cloud metadata discovery could lead to the process aborting during initialisation {pull}1158[#(1158)]
 - Fixed a data race related to HTTP request header sanitisation {pull}1159[#(1159)]
+- `apm.CaptureError`, `apm.Error.SetTransaction`, and `apm.Error.SetSpan` will now set the associated transaction or span's default outcome to "failure" {pull}1160[#(1160)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/error.go
+++ b/error.go
@@ -247,6 +247,9 @@ func (e *Error) Error() string {
 //
 // If any custom context has been recorded in tx, it will also be carried across
 // to e, but will not override any custom context already recorded on e.
+//
+// SetTransaction also has the effect of setting tx's default outcome to "failure",
+// unless it is explicitly specified by the instrumentation.
 func (e *Error) SetTransaction(tx *Transaction) {
 	tx.mu.RLock()
 	traceContext := tx.traceContext
@@ -255,6 +258,9 @@ func (e *Error) SetTransaction(tx *Transaction) {
 	if !tx.ended() {
 		txType = tx.Type
 		custom = tx.Context.model.Custom
+		tx.TransactionData.mu.Lock()
+		tx.TransactionData.errorCaptured = true
+		tx.TransactionData.mu.Unlock()
 	}
 	tx.mu.RUnlock()
 	e.setSpanData(traceContext, traceContext.Span, txType, custom)
@@ -277,8 +283,19 @@ func (e *Error) SetSpan(s *Span) {
 		if !s.tx.ended() {
 			txType = s.tx.Type
 			custom = s.tx.Context.model.Custom
+			s.tx.TransactionData.mu.Lock()
+			s.tx.TransactionData.errorCaptured = true
+			s.tx.TransactionData.mu.Unlock()
 		}
 		s.tx.mu.RUnlock()
+
+		s.mu.RLock()
+		if !s.ended() {
+			s.SpanData.mu.Lock()
+			s.SpanData.errorCaptured = true
+			s.SpanData.mu.Unlock()
+		}
+		s.mu.RUnlock()
 	}
 	e.setSpanData(s.traceContext, s.transactionID, txType, custom)
 }

--- a/internal/apmgodog/suitecontext_test.go
+++ b/internal/apmgodog/suitecontext_test.go
@@ -144,10 +144,26 @@ func (c *featureContext) initScenario(s *godog.ScenarioContext) {
 	s.Step("^user sets transaction outcome to '(.*)'$", c.userSetsTransactionOutcome)
 	s.Step("^span terminates with outcome '(.*)'$", c.spanTerminatesWithOutcome)
 	s.Step("^transaction terminates with outcome '(.*)'$", c.transactionTerminatesWithOutcome)
-	s.Step("^span terminates with an error$", func() error { return c.spanTerminatesWithOutcome("failure") })
-	s.Step("^span terminates without error$", func() error { return c.spanTerminatesWithOutcome("success") })
-	s.Step("^transaction terminates with an error$", func() error { return c.transactionTerminatesWithOutcome("failure") })
-	s.Step("^transaction terminates without error$", func() error { return c.transactionTerminatesWithOutcome("success") })
+	s.Step("^span terminates with an error$", func() error {
+		e := c.tracer.NewError(errors.New("an error"))
+		e.SetSpan(c.span)
+		c.span.End()
+		return nil
+	})
+	s.Step("^span terminates without error$", func() error {
+		c.span.End()
+		return nil
+	})
+	s.Step("^transaction terminates with an error$", func() error {
+		e := c.tracer.NewError(errors.New("an error"))
+		e.SetTransaction(c.transaction)
+		c.transaction.End()
+		return nil
+	})
+	s.Step("^transaction terminates without error$", func() error {
+		c.transaction.End()
+		return nil
+	})
 	s.Step("^span outcome is '(.*)'$", c.spanOutcomeIs)
 	s.Step("^span outcome is \"(.*)\"$", c.spanOutcomeIs)
 	s.Step("^transaction outcome is '(.*)'$", c.transactionOutcomeIs)

--- a/transaction.go
+++ b/transaction.go
@@ -287,6 +287,13 @@ func (tx *Transaction) End() {
 		}
 		if tx.Outcome == "" {
 			tx.Outcome = tx.Context.outcome()
+			if tx.Outcome == "" {
+				if tx.errorCaptured {
+					tx.Outcome = "failure"
+				} else {
+					tx.Outcome = "success"
+				}
+			}
 		}
 		// Hold the transaction data lock to check if the transaction has any
 		// compressed spans in its cache, if so, evict cache and end the span.
@@ -370,6 +377,7 @@ type TransactionData struct {
 	timestamp               time.Time
 
 	mu                sync.Mutex
+	errorCaptured     bool
 	spansCreated      int
 	spansDropped      int
 	childrenTimer     childrenTimer


### PR DESCRIPTION
Apart from HTTP and gRPC, which set outcome based on the status code, set the default outcome to "success" by default, or "failure" if any errors were captured within the transaction or span.

This brings us into line with the agent spec for transaction and span outcome:
 - https://github.com/elastic/apm/blob/master/specs/agents/tracing-transactions.md#transaction-outcome
 - https://github.com/elastic/apm/blob/master/specs/agents/tracing-spans.md#span-outcome

> For other protocols, we can default to the following behavior:
>
> - failure when an error is reported
> - success otherwise