### PR TITLE
Increase test pipeline timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     SLACK_CHANNEL = '#apm-agent-go'
   }
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 2, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
The original timeout was set three years ago. Since that time, test times have gradually been moving up:

<img width="529" alt="Screen Shot 2021-12-06 at 1 51 01 PM" src="https://user-images.githubusercontent.com/111616/144849174-76d8b503-595c-4adc-a287-8bb87139dc6c.png">

This isn't necessarily due to changes in the time the tests take. Instead, the time it takes to provision workers and prepare them can vary considerably.

Therefore, I'm increasing the timeout for tests from 1 hour to 2 hours just to prevent the recent failures that we've seen where timeouts have been exceeded, causing the test suite not to report a result.