### PR TITLE
error: Record `transaction.name` when available

### DIFF
--- a/error.go
+++ b/error.go
@@ -177,6 +177,7 @@ type ErrorData struct {
 	log                ErrorLogRecord
 	logStacktrace      []stacktrace.Frame
 	transactionSampled bool
+	transactionName    string
 	transactionType    string
 
 	// ID is the unique identifier of the error. This is set by
@@ -249,17 +250,18 @@ func (e *Error) Error() string {
 func (e *Error) SetTransaction(tx *Transaction) {
 	tx.mu.RLock()
 	traceContext := tx.traceContext
-	var txType string
+	var txType, txName string
 	var custom model.IfaceMap
 	if !tx.ended() {
 		txType = tx.Type
+		txName = tx.Name
 		custom = tx.Context.model.Custom
 		tx.TransactionData.mu.Lock()
 		tx.TransactionData.errorCaptured = true
 		tx.TransactionData.mu.Unlock()
 	}
 	tx.mu.RUnlock()
-	e.setSpanData(traceContext, traceContext.Span, txType, custom)
+	e.setSpanData(traceContext, traceContext.Span, txType, txName, custom)
 }
 
 // SetSpan sets TraceID, TransactionID, and ParentID to the span's IDs.
@@ -272,12 +274,13 @@ func (e *Error) SetTransaction(tx *Transaction) {
 // also be carried across to e, but will not override any custom context
 // already recorded on e.
 func (e *Error) SetSpan(s *Span) {
-	var txType string
+	var txType, txName string
 	var custom model.IfaceMap
 	if s.tx != nil {
 		s.tx.mu.RLock()
 		if !s.tx.ended() {
 			txType = s.tx.Type
+			txName = s.tx.Name
 			custom = s.tx.Context.model.Custom
 			s.tx.TransactionData.mu.Lock()
 			s.tx.TransactionData.errorCaptured = true
@@ -293,13 +296,13 @@ func (e *Error) SetSpan(s *Span) {
 		}
 		s.mu.RUnlock()
 	}
-	e.setSpanData(s.traceContext, s.transactionID, txType, custom)
+	e.setSpanData(s.traceContext, s.transactionID, txType, txName, custom)
 }
 
 func (e *Error) setSpanData(
 	traceContext TraceContext,
 	transactionID SpanID,
-	transactionType string,
+	transactionType, transactionName string,
 	customContext model.IfaceMap,
 ) {
 	e.TraceID = traceContext.Trace
@@ -307,6 +310,7 @@ func (e *Error) setSpanData(
 	e.TransactionID = transactionID
 	e.transactionSampled = traceContext.Options.Recorded()
 	if e.transactionSampled {
+		e.transactionName = transactionName
 		e.transactionType = transactionType
 	}
 	if n := len(customContext); n != 0 {

--- a/error_test.go
+++ b/error_test.go
@@ -331,7 +331,10 @@ func TestErrorTransactionSampled(t *testing.T) {
 	assertErrorTransactionSampled(t, errors[0], true)
 	assertErrorTransactionSampled(t, errors[1], true)
 	assert.Equal(t, "foo", errors[0].Transaction.Type)
+	assert.Equal(t, "name", errors[0].Transaction.Name)
 	assert.Equal(t, "foo", errors[1].Transaction.Type)
+	assert.Equal(t, "name", errors[1].Transaction.Name)
+
 }
 
 func TestErrorTransactionNotSampled(t *testing.T) {

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1114,6 +1114,16 @@ func (v *ErrorTransaction) MarshalFastJSON(w *fastjson.Writer) error {
 		}
 		w.String(v.Type)
 	}
+	if v.Name != "" {
+		const prefix = ",\"name\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Name)
+	}
 	w.RawByte('}')
 	return nil
 }

--- a/model/model.go
+++ b/model/model.go
@@ -561,6 +561,9 @@ type ErrorTransaction struct {
 
 	// Type holds the transaction type.
 	Type string `json:"type,omitempty"`
+
+	// Name holds the transaction name.
+	Name string `json:"name,omitempty"`
 }
 
 // Exception represents an exception: an error or panic.

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -178,6 +178,7 @@ func (w *modelWriter) buildModelError(out *model.Error, e *ErrorData) {
 		out.Transaction.Sampled = &e.transactionSampled
 		if e.transactionSampled {
 			out.Transaction.Type = e.transactionType
+			out.Transaction.Name = e.transactionName
 		}
 	}
 

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -37,6 +37,7 @@ pin golang.org/x/net 5f58ad60dda6 https://github.com/golang/net
 pin github.com/santhosh-tekuri/jsonschema v4.0.0
 pin go.uber.org/zap v1.16.0 https://github.com/uber-go/zap
 pin github.com/mattn/go-sqlite3 2b780b4a7fb3
+pin github.com/olivere/elastic v7.0.29
 
 # Go 1.8-1.9
 if (! go run scripts/mingoversion.go 1.10 &>/dev/null); then

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -37,7 +37,6 @@ pin golang.org/x/net 5f58ad60dda6 https://github.com/golang/net
 pin github.com/santhosh-tekuri/jsonschema v4.0.0
 pin go.uber.org/zap v1.16.0 https://github.com/uber-go/zap
 pin github.com/mattn/go-sqlite3 2b780b4a7fb3
-pin github.com/olivere/elastic v7.0.29
 
 # Go 1.8-1.9
 if (! go run scripts/mingoversion.go 1.10 &>/dev/null); then


### PR DESCRIPTION
## Description
Adds a new `transaction.name` field which is recorded when a transaction
is set for the error.

## Related issues

Closes #1154 