### PR TITLE
fix: panic on gocql

### DIFF
--- a/module/apmgocql/apmgocql_test.go
+++ b/module/apmgocql/apmgocql_test.go
@@ -230,15 +230,11 @@ func TestQueryObserverWithoutTransaction(t *testing.T) {
 	session := newSession(t)
 	defer session.Close()
 
-	var queryError error
 	_, spans, errors := apmtest.WithTransaction(func(ctx context.Context) {
-		queryError = execQuery(context.TODO(), session, "ZINGA")
+		_ = execQuery(context.TODO(), session, "ZINGA")
 	})
-	require.Len(t, errors, 1)
-	require.Len(t, spans, 1)
-
-	assert.Equal(t, errors[0].Culprit, "execQuery")
-	assert.EqualError(t, queryError, errors[0].Exception.Message)
+	require.Len(t, errors, 0)
+	require.Len(t, spans, 0)
 }
 
 func execQuery(ctx context.Context, session *gocql.Session, query string) error {

--- a/module/apmgocql/apmgocql_test.go
+++ b/module/apmgocql/apmgocql_test.go
@@ -226,6 +226,21 @@ func TestQueryObserverErrorIntegration(t *testing.T) {
 	assert.EqualError(t, queryError, errors[0].Exception.Message)
 }
 
+func TestQueryObserverWithoutTransaction(t *testing.T) {
+	session := newSession(t)
+	defer session.Close()
+
+	var queryError error
+	_, spans, errors := apmtest.WithTransaction(func(ctx context.Context) {
+		queryError = execQuery(context.TODO(), session, "ZINGA")
+	})
+	require.Len(t, errors, 1)
+	require.Len(t, spans, 1)
+
+	assert.Equal(t, errors[0].Culprit, "execQuery")
+	assert.EqualError(t, queryError, errors[0].Exception.Message)
+}
+
 func execQuery(ctx context.Context, session *gocql.Session, query string) error {
 	return session.Query(query).WithContext(ctx).Exec()
 }

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -80,7 +80,7 @@ func (o *Observer) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) 
 		span.End()
 	}
 
-	if e := apm.CaptureError(ctx, batch.Err); e != nil {
+	if e := apm.CaptureError(ctx, batch.Err); e != nil && e.ErrorData != nil {
 		e.Timestamp = batch.End
 		e.Send()
 	}
@@ -97,7 +97,7 @@ func (o *Observer) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) 
 		Instance:  query.Keyspace,
 		Statement: query.Statement,
 	})
-	if e := apm.CaptureError(ctx, query.Err); e != nil {
+	if e := apm.CaptureError(ctx, query.Err); e != nil && e.ErrorData != nil {
 		e.Timestamp = query.End
 		e.Send()
 	}


### PR DESCRIPTION
Currently there is a possibility to receive a panic, while using apmgocql module, this situation can occur while passing context which does not have apm transaction attached