### PR TITLE
remove unnecessary fasthttp import from apmfiber module

### DIFF
--- a/module/apmfiber/middleware.go
+++ b/module/apmfiber/middleware.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/valyala/fasthttp"
 
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmfasthttp"
@@ -69,7 +68,7 @@ func (m *middleware) handle(c *fiber.Ctx) error {
 	name := string(reqCtx.Method()) + " " + c.Path()
 	tx, body, err := apmfasthttp.StartTransactionWithBody(reqCtx, m.tracer, name)
 	if err != nil {
-		reqCtx.Error(err.Error(), fasthttp.StatusInternalServerError)
+		reqCtx.Error(err.Error(), http.StatusInternalServerError)
 
 		return err
 	}


### PR DESCRIPTION
removed fasthttp import from apmfiber because all fasthttp status codes were copied from net/http package. 