### PR TITLE
CI: use apm-integration-testing/7.x for v1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     GOPROXY = 'https://proxy.golang.org'
     HOME = "${env.WORKSPACE}"
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/7.x'
     OPBEANS_REPO = 'opbeans-go'
     SLACK_CHANNEL = '#apm-agent-go'
   }

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -37,6 +37,7 @@ pin golang.org/x/net 5f58ad60dda6 https://github.com/golang/net
 pin github.com/santhosh-tekuri/jsonschema v4.0.0
 pin go.uber.org/zap v1.16.0 https://github.com/uber-go/zap
 pin github.com/mattn/go-sqlite3 2b780b4a7fb3
+pin github.com/olivere/elastic v7.0.29
 
 # Go 1.8-1.9
 if (! go run scripts/mingoversion.go 1.10 &>/dev/null); then
@@ -51,6 +52,5 @@ fi
 # Go 1.8 only.
 if (! go run scripts/mingoversion.go 1.9 &>/dev/null); then
   pin github.com/golang/protobuf v1.3.5
-  pin github.com/olivere/elastic release-branch.v6
   pin golang.org/x/sys fc99dfbffb4e https://go.googlesource.com/sys
 fi

--- a/tracecontext_test.go
+++ b/tracecontext_test.go
@@ -72,13 +72,37 @@ func TestTraceStateInvalidLength(t *testing.T) {
 }
 
 func TestTraceStateDuplicateKey(t *testing.T) {
+	// This test asserts:
+	// 1. Accept a tracestate with duplicate keys.
+	// 2. Use the last reference.
+	// 3. Discard any duplicate 'es' entries.
+	// 4. Keep any duplicate 3rd party system keys as is.
 	ts := apm.NewTraceState(
 		apm.TraceStateEntry{Key: "x", Value: "b"},
 		apm.TraceStateEntry{Key: "a", Value: "b"},
 		apm.TraceStateEntry{Key: "y", Value: "b"},
-		apm.TraceStateEntry{Key: "a", Value: "b"},
+		apm.TraceStateEntry{Key: "a", Value: "c"},
+		apm.TraceStateEntry{Key: "es", Value: "s:1;a:b"},
+		apm.TraceStateEntry{Key: "z", Value: "w"},
+		apm.TraceStateEntry{Key: "a", Value: "d"},
+		apm.TraceStateEntry{Key: "es", Value: "s:0.5;k:v"},
+		apm.TraceStateEntry{Key: "c", Value: "first"},
+		apm.TraceStateEntry{Key: "r", Value: "first"},
+		apm.TraceStateEntry{Key: "es", Value: "s:0.1;k:v"},
+		apm.TraceStateEntry{Key: "c", Value: "second"},
 	)
-	assert.EqualError(t, ts.Validate(), `duplicate tracestate key "a" at positions 1 and 3`)
+	assert.NoError(t, ts.Validate())
+	assert.Equal(t, "es=s:0.1;k:v,x=b,a=b,y=b,a=c,z=w,a=d,c=first,r=first,c=second", ts.String())
+}
+
+func TestTraceStateElasticEntryFirst(t *testing.T) {
+	ts := apm.NewTraceState(
+		apm.TraceStateEntry{Key: "es", Value: "s:1;a:b"},
+		apm.TraceStateEntry{Key: "z", Value: "w"},
+		apm.TraceStateEntry{Key: "a", Value: "d"},
+	)
+	assert.NoError(t, ts.Validate())
+	assert.Equal(t, "es=s:1;a:b,z=w,a=d", ts.String())
 }
 
 func TestTraceStateInvalidKey(t *testing.T) {


### PR DESCRIPTION
Use apm-integration-testing 7.x branch for testing apm-agent-go v1.
We'll update apm-integration-testing's main branch to test v2.

See https://github.com/elastic/apm-agent-go/issues/1184