### PR TITLE
handle special cases for span frames min duration

### DIFF
--- a/span.go
+++ b/span.go
@@ -356,9 +356,17 @@ func (s *Span) End() {
 			}
 		}
 	}
-	if !s.dropped() && len(s.stacktrace) == 0 &&
-		s.Duration >= s.stackFramesMinDuration {
+	switch s.stackFramesMinDuration {
+	case -1:
+		// Always set stacktrace
 		s.setStacktrace(1)
+	case 0:
+		// If s.stackFramesMinDuration == 0, we never set stacktrace.
+	default:
+		if !s.dropped() && len(s.stacktrace) == 0 &&
+			s.Duration >= s.stackFramesMinDuration {
+			s.setStacktrace(1)
+		}
 	}
 	// If this span has a parent span, lock it before proceeding to
 	// prevent deadlocking when concurrently ending parent and child.

--- a/span_test.go
+++ b/span_test.go
@@ -215,6 +215,7 @@ func TestFramesMinDurationSpecialCases(t *testing.T) {
 
 	// verify that stacktraces are always recorded
 	tracer = apmtest.NewRecordingTracer()
+	defer tracer.Close()
 	tracer.SetSpanFramesMinDuration(-1)
 	tx = tracer.StartTransaction("name", "type")
 	span = tx.StartSpan("span2", "span2", nil)

--- a/span_test.go
+++ b/span_test.go
@@ -226,7 +226,7 @@ func TestFramesMinDurationSpecialCases(t *testing.T) {
 
 	spans = tracer.Payloads().Spans
 	require.Len(t, spans, 1)
-	assert.Len(t, spans[0].Stacktrace, 4)
+	assert.NotEmpty(t, spans[0].Stacktrace)
 }
 
 func TestCompressSpanNonSiblings(t *testing.T) {


### PR DESCRIPTION
cases:

0: never capture stacktraces
-1: always capture stacktraces

Closes https://github.com/elastic/apm-agent-go/issues/465