### PR TITLE
Replace DefaultTracer with initialization func

### DIFF
--- a/apmtest/discard.go
+++ b/apmtest/discard.go
@@ -45,8 +45,7 @@ func NewDiscardTracer() *apm.Tracer {
 }
 
 func init() {
-	apm.DefaultTracer.Close()
 	tracer := NewDiscardTracer()
 	DiscardTracer = tracer
-	apm.DefaultTracer = DiscardTracer
+	apm.SetDefaultTracer(DiscardTracer)
 }

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -15,10 +15,13 @@ The initial point of contact your application will have with the Go agent
 is the `apm.Tracer` type, which provides methods for reporting
 transactions and errors.
 
-To make instrumentation simpler, the Go agent provides a pre-initialized
-tracer, `apm.DefaultTracer`. This tracer is always initialized and
-available for use. This tracer is configured with environment variables;
-see <<configuration>> for details.
+To make instrumentation simpler, the Go agent provides an initialization
+function, `apm.DefaultTracer()`. This tracer is initialized the first time
+`apm.DefaultTracer()` is called, and returned on subsequent calls. The tracer
+returned by this function can be modified using `apm.SetDefaultTracer(tracer)`.
+Calling this will close the previous default tracer, if any exists.  This
+tracer is configured with environment variables; see <<configuration>> for
+details.
 
 [source,go]
 ----
@@ -27,7 +30,7 @@ import (
 )
 
 func main() {
-	tracer := apm.DefaultTracer
+	tracer := apm.DefaultTracer()
 	...
 }
 ----
@@ -52,7 +55,7 @@ or RPC request. e.g.:
 
 [source,go]
 ----
-transaction := apm.DefaultTracer.StartTransaction("GET /", "request")
+transaction := apm.DefaultTracer().StartTransaction("GET /", "request")
 ----
 
 Transactions will be grouped by type and name in the Elastic APM app.
@@ -82,7 +85,7 @@ opts := apm.TransactionOptions{
 	Start: time.Now(),
 	TraceContext: parentTraceContext,
 }
-transaction := apm.DefaultTracer.StartTransactionOptions("GET /", "request", opts)
+transaction := apm.DefaultTracer().StartTransactionOptions("GET /", "request", opts)
 ----
 
 [float]
@@ -424,7 +427,7 @@ same definition as given by https://github.com/pkg/errors[github.com/pkg/errors]
 
 [source,go]
 ----
-e := apm.DefaultTracer.NewError(err)
+e := apm.DefaultTracer().NewError(err)
 ...
 e.Send()
 ----
@@ -509,7 +512,7 @@ The resulting Error's log stacktrace will not be set. Call the SetStacktrace met
 
 [source,go]
 ----
-e := apm.DefaultTracer.NewErrorLog(apm.ErrorLogRecord{
+e := apm.DefaultTracer().NewErrorLog(apm.ErrorLogRecord{
 	Message: "Somebody set up us the bomb.",
 })
 ...
@@ -545,11 +548,11 @@ and then call its `Send` method.
 
 [source,go]
 ----
-tx := apm.DefaultTracer.StartTransaction(...)
+tx := apm.DefaultTracer().StartTransaction(...)
 defer tx.End()
 defer func() {
 	if v := recover(); v != nil {
-		e := apm.DefaultTracer.Recovered(v)
+		e := apm.DefaultTracer().Recovered(v)
 		e.SetTransaction(tx)
 		e.Send()
 	}
@@ -596,9 +599,9 @@ In addition, errors can be associated with an active transaction or span using
 
 [source,go]
 ----
-tx := apm.DefaultTracer.StartTransaction("GET /foo", "request")
+tx := apm.DefaultTracer().StartTransaction("GET /foo", "request")
 defer tx.End()
-e := apm.DefaultTracer.NewError(err)
+e := apm.DefaultTracer().NewError(err)
 e.SetTransaction(tx)
 e.Send()
 ----

--- a/docs/custom-instrumentation.asciidoc
+++ b/docs/custom-instrumentation.asciidoc
@@ -11,14 +11,14 @@ such as a database query, or a request to another service.
  - <<custom-instrumentation-errors,Error>> - May refer to Go errors or panics.
 
 To report these, use a <<tracer-api,apm.Tracer>> -- typically
-`apm.DefaultTracer`, which is configured via environment variables. In the code
-examples below, we will refer to `apm.DefaultTracer`. Please refer to the <<api, API documentation>>
+`apm.DefaultTracer()`, which is configured via environment variables. In the code
+examples below, we will refer to `apm.DefaultTracer()`. Please refer to the <<api, API documentation>>
 for a more thorough description of the types and methods.
 
 [[custom-instrumentation-transactions]]
 ==== Transactions
 
-To report a transaction, call <<tracer-api-start-transaction, apm.DefaultTracer.StartTransaction>>
+To report a transaction, call <<tracer-api-start-transaction, apm.DefaultTracer().StartTransaction>>
 with the transaction name and type. This returns a `Transaction` object; the transaction
 can be customized with additional context before you call its `End` method to indicate
 that the transaction has completed. Once the transaction's `End` method is called, it
@@ -26,7 +26,7 @@ will be enqueued for sending to the Elastic APM server, and made available to th
 
 [source,go]
 ----
-tx := apm.DefaultTracer.StartTransaction("GET /api/v1", "request")
+tx := apm.DefaultTracer().StartTransaction("GET /api/v1", "request")
 defer tx.End()
 ...
 tx.Result = "HTTP 2xx"
@@ -80,7 +80,7 @@ non-panic errors: <<tracer-new-error, Tracer.NewError>>, <<tracer-new-error-log,
 ----
 defer func() {
 	if v := recover(); v != nil {
-		e := apm.DefaultTracer.Recovered()
+		e := apm.DefaultTracer().Recovered()
 		e.SetTransaction(tx) // or e.SetSpan(span)
 		e.Send()
 	}

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -24,7 +24,7 @@ import (
 
 The apmot package exports a function, "New", which returns an implementation of the
 `opentracing.Tracer` interface. If you call `apmot.New()` without any arguments,
-the returned tracer will wrap `apm.DefaultTracer`. If you wish to use a different
+the returned tracer will wrap `apm.DefaultTracer()`. If you wish to use a different
 `apm.Tracer`, then you can pass it with `apmot.New(apmot.WithTracer(t))`.
 
 [source,go]
@@ -67,7 +67,7 @@ native and OpenTracing APIs. e.g.:
 [source,go]
 ----
 // Transaction created through native API.
-transaction := apm.DefaultTracer.StartTransaction("GET /", "request")
+transaction := apm.DefaultTracer().StartTransaction("GET /", "request")
 ctx := apm.ContextWithTransaction(context.Background(), transaction)
 
 // Span created through OpenTracing API will be a child of the transaction.

--- a/example_tracecontext_test.go
+++ b/example_tracecontext_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func ExampleTransaction_EnsureParent() {
-	tx := apm.DefaultTracer.StartTransactionOptions("name", "type", apm.TransactionOptions{
+	tx := apm.DefaultTracer().StartTransactionOptions("name", "type", apm.TransactionOptions{
 		TraceContext: apm.TraceContext{
 			Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 			Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},

--- a/gofuzz.go
+++ b/gofuzz.go
@@ -53,7 +53,7 @@ func Fuzz(data []byte) int {
 		return 0
 	}
 
-	tracer := DefaultTracer
+	tracer := DefaultTracer()
 	tracer.Transport = &gofuzzTransport{}
 	tracer.SetCaptureBody(CaptureBodyAll)
 

--- a/module/apmawssdkgo/session_test.go
+++ b/module/apmawssdkgo/session_test.go
@@ -187,7 +187,7 @@ func TestUnsupportedServices(t *testing.T) {
 	wrapped := WrapSession(session)
 	svc := athena.New(wrapped)
 
-	tx := apm.DefaultTracer.StartTransaction("send-email", "test-tx")
+	tx := apm.DefaultTracer().StartTransaction("send-email", "test-tx")
 	span := tx.StartSpan("test-span", "send-email", nil)
 	defer span.End()
 

--- a/module/apmazure/storage.go
+++ b/module/apmazure/storage.go
@@ -49,7 +49,7 @@ func WrapPipeline(next pipeline.Pipeline, options ...ServerOption) pipeline.Pipe
 		opt(p)
 	}
 	if p.tracer == nil {
-		p.tracer = apm.DefaultTracer
+		p.tracer = apm.DefaultTracer()
 	}
 	return p
 }

--- a/module/apmbeego/filter.go
+++ b/module/apmbeego/filter.go
@@ -42,7 +42,7 @@ func init() {
 // Middleware returns a beego.MiddleWare that traces requests and reports panics to Elastic APM.
 func Middleware(o ...Option) func(http.Handler) http.Handler {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmchi/middleware.go
+++ b/module/apmchi/middleware.go
@@ -32,11 +32,11 @@ import (
 // The server request name will use the fully matched,
 // parametrized route.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Middleware(o ...Option) func(http.Handler) http.Handler {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmchiv5/middleware.go
+++ b/module/apmchiv5/middleware.go
@@ -35,11 +35,11 @@ import (
 // The server request name will use the fully matched,
 // parametrized route.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Middleware(o ...Option) func(http.Handler) http.Handler {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmecho/middleware.go
+++ b/module/apmecho/middleware.go
@@ -36,11 +36,11 @@ import (
 // This middleware will recover and report panics, so it can
 // be used instead of echo/middleware.Recover.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Middleware(o ...Option) echo.MiddlewareFunc {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmechov4/middleware.go
+++ b/module/apmechov4/middleware.go
@@ -39,11 +39,11 @@ import (
 // This middleware will recover and report panics, so it can
 // be used instead of echo/middleware.Recover.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Middleware(o ...Option) echo.MiddlewareFunc {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmfasthttp/recovery.go
+++ b/module/apmfasthttp/recovery.go
@@ -29,13 +29,13 @@ import (
 // NewTraceRecovery returns a RecoveryFunc for use in WithRecovery.
 //
 // The returned RecoveryFunc will report recovered error to Elastic APM
-// using the given Tracer, or apm.DefaultTracer if t is nil. The
+// using the given Tracer, or apm.DefaultTracer() if t is nil. The
 // error will be linked to the given transaction.
 //
 // If headers have not already been written, a 500 response will be sent.
 func NewTraceRecovery(t *apm.Tracer) RecoveryFunc {
 	if t == nil {
-		t = apm.DefaultTracer
+		t = apm.DefaultTracer()
 	}
 
 	return func(ctx *fasthttp.RequestCtx, tx *apm.Transaction, bc *apm.BodyCapturer, recovered interface{}) {

--- a/module/apmfasthttp/server.go
+++ b/module/apmfasthttp/server.go
@@ -29,7 +29,7 @@ import (
 // Wrap returns a fasthttp.RequestHandler wrapping handler, reporting each request as
 // a transaction to Elastic APM.
 //
-// By default, the returned RequestHandler will use apm.DefaultTracer.
+// By default, the returned RequestHandler will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 //
 // By default, the returned RequestHandler will recover panics, reporting
@@ -44,7 +44,7 @@ func Wrap(handler fasthttp.RequestHandler, options ...ServerOption) fasthttp.Req
 	}
 
 	if h.tracer == nil {
-		h.tracer = apm.DefaultTracer
+		h.tracer = apm.DefaultTracer()
 	}
 
 	if h.requestName == nil {

--- a/module/apmfiber/middleware.go
+++ b/module/apmfiber/middleware.go
@@ -37,13 +37,13 @@ import (
 // This middleware will recover and report panics, so it can
 // be used instead of default recover middleware.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 // Use WithPanicPropagation to disable panic recover.
 func Middleware(o ...Option) fiber.Handler {
 	m := &middleware{
-		tracer:           apm.DefaultTracer,
-		requestIgnorer:   apmfasthttp.NewDynamicServerRequestIgnorer(apm.DefaultTracer),
+		tracer:           apm.DefaultTracer(),
+		requestIgnorer:   apmfasthttp.NewDynamicServerRequestIgnorer(apm.DefaultTracer()),
 		panicPropagation: false,
 	}
 

--- a/module/apmgin/middleware.go
+++ b/module/apmgin/middleware.go
@@ -40,12 +40,12 @@ func init() {
 // This middleware will recover and report panics, so it can
 // be used instead of the standard gin.Recovery middleware.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Middleware(engine *gin.Engine, o ...Option) gin.HandlerFunc {
 	m := &middleware{
 		engine: engine,
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(m)

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -46,7 +46,7 @@ type Observer struct {
 // observed gocql queries.
 func NewObserver(o ...Option) *Observer {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmgokit/grpc_test.go
+++ b/module/apmgokit/grpc_test.go
@@ -92,7 +92,7 @@ func Example_grpcClient() {
 		&pb.HelloReply{},
 	)
 
-	tx := apm.DefaultTracer.StartTransaction("name", "type")
+	tx := apm.DefaultTracer().StartTransaction("name", "type")
 	ctx := apm.ContextWithTransaction(context.Background(), tx)
 	defer tx.End()
 

--- a/module/apmgokit/http_test.go
+++ b/module/apmgokit/http_test.go
@@ -68,7 +68,7 @@ func Example_httpClient() {
 		kithttp.SetClient(apmhttp.WrapClient(http.DefaultClient)),
 	)
 
-	tx := apm.DefaultTracer.StartTransaction("name", "type")
+	tx := apm.DefaultTracer().StartTransaction("name", "type")
 	ctx := apm.ContextWithTransaction(context.Background(), tx)
 	defer tx.End()
 

--- a/module/apmgorilla/middleware.go
+++ b/module/apmgorilla/middleware.go
@@ -72,11 +72,11 @@ func WrapMethodNotAllowedHandler(h http.Handler, m mux.MiddlewareFunc) http.Hand
 // MethodNotAllowedHandler fields using the Wrap functions in
 // this package.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Middleware(o ...Option) mux.MiddlewareFunc {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmgrpc/server.go
+++ b/module/apmgrpc/server.go
@@ -51,12 +51,12 @@ var (
 // each incoming request. The transaction will be added to the context,
 // so server methods can use apm.StartSpan with the provided context.
 //
-// By default, the interceptor will trace with apm.DefaultTracer,
+// By default, the interceptor will trace with apm.DefaultTracer(),
 // and will not recover any panics. Use WithTracer to specify an
 // alternative tracer, and WithRecovery to enable panic recovery.
 func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 	opts := serverOptions{
-		tracer:         apm.DefaultTracer,
+		tracer:         apm.DefaultTracer(),
 		recover:        false,
 		requestIgnorer: DefaultServerRequestIgnorer(),
 		streamIgnorer:  DefaultServerStreamIgnorer(),
@@ -108,12 +108,12 @@ func NewUnaryServerInterceptor(o ...ServerOption) grpc.UnaryServerInterceptor {
 // incoming stream request. The transaction will be added to the context, so
 // server methods can use apm.StartSpan with the provided context.
 //
-// By default, the interceptor will trace with apm.DefaultTracer, and will
+// By default, the interceptor will trace with apm.DefaultTracer(), and will
 // not recover any panics. Use WithTracer to specify an alternative tracer,
 // and WithRecovery to enable panic recovery.
 func NewStreamServerInterceptor(o ...ServerOption) grpc.StreamServerInterceptor {
 	opts := serverOptions{
-		tracer:        apm.DefaultTracer,
+		tracer:        apm.DefaultTracer(),
 		recover:       false,
 		streamIgnorer: DefaultServerStreamIgnorer(),
 	}

--- a/module/apmhttp/handler.go
+++ b/module/apmhttp/handler.go
@@ -28,7 +28,7 @@ import (
 // Wrap returns an http.Handler wrapping h, reporting each request as
 // a transaction to Elastic APM.
 //
-// By default, the returned Handler will use apm.DefaultTracer.
+// By default, the returned Handler will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 //
 // By default, the returned Handler will recover panics, reporting
@@ -40,7 +40,7 @@ func Wrap(h http.Handler, o ...ServerOption) http.Handler {
 	}
 	handler := &handler{
 		handler:     h,
-		tracer:      apm.DefaultTracer,
+		tracer:      apm.DefaultTracer(),
 		requestName: ServerRequestName,
 	}
 	for _, o := range o {
@@ -68,7 +68,7 @@ type handler struct {
 }
 
 // ServeHTTP delegates to h.Handler, tracing the transaction with
-// h.Tracer, or apm.DefaultTracer if h.Tracer is nil.
+// h.Tracer, or apm.DefaultTracer() if h.Tracer is nil.
 func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if !h.tracer.Recording() || h.requestIgnorer(req) {
 		h.handler.ServeHTTP(w, req)

--- a/module/apmhttp/recovery.go
+++ b/module/apmhttp/recovery.go
@@ -36,13 +36,13 @@ type RecoveryFunc func(
 // NewTraceRecovery returns a RecoveryFunc for use in WithRecovery.
 //
 // The returned RecoveryFunc will report recovered error to Elastic APM
-// using the given Tracer, or apm.DefaultTracer if t is nil. The
+// using the given Tracer, or apm.DefaultTracer() if t is nil. The
 // error will be linked to the given transaction.
 //
 // If headers have not already been written, a 500 response will be sent.
 func NewTraceRecovery(t *apm.Tracer) RecoveryFunc {
 	if t == nil {
-		t = apm.DefaultTracer
+		t = apm.DefaultTracer()
 	}
 	return func(
 		w http.ResponseWriter,

--- a/module/apmhttprouter/handler.go
+++ b/module/apmhttprouter/handler.go
@@ -29,7 +29,7 @@ import (
 // Wrap wraps h such that it will report requests as transactions
 // to Elastic APM, using route in the transaction name.
 //
-// By default, the returned Handle will use apm.DefaultTracer.
+// By default, the returned Handle will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 //
 // By default, the returned Handle will recover panics, reporting
@@ -95,7 +95,7 @@ func wrapHandlerUnknownRoute(h http.Handler, o ...Option) http.Handler {
 
 func gatherOptions(o ...Option) options {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmlambda/lambda.go
+++ b/module/apmlambda/lambda.go
@@ -158,7 +158,7 @@ func init() {
 	srv := rpc.NewServer()
 	srv.Register(&Function{
 		client: rpcClient,
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	})
 	go srv.Accept(lis)
 

--- a/module/apmlogrus/example_test.go
+++ b/module/apmlogrus/example_test.go
@@ -30,7 +30,7 @@ func ExampleHook() {
 	logger := logrus.New()
 
 	// Report "error", "panic", and "fatal" log messages
-	// to Elastic APM using apm.DefaultTracer.
+	// to Elastic APM using apm.DefaultTracer().
 	logger.AddHook(&apmlogrus.Hook{})
 
 	// Report "error", "panic", and "fatal" log messages
@@ -41,7 +41,7 @@ func ExampleHook() {
 	})
 
 	// Report only "panic" log messages to Elastic APM
-	// using apm.DefaultTracer.
+	// using apm.DefaultTracer().
 	logger.AddHook(&apmlogrus.Hook{
 		LogLevels: []logrus.Level{logrus.PanicLevel},
 	})
@@ -50,7 +50,7 @@ func ExampleHook() {
 func ExampleTraceContext() {
 	logger := logrus.New()
 
-	tx := apm.DefaultTracer.StartTransaction("name", "type")
+	tx := apm.DefaultTracer().StartTransaction("name", "type")
 	defer tx.End()
 
 	ctx := apm.ContextWithTransaction(context.Background(), tx)

--- a/module/apmlogrus/hook.go
+++ b/module/apmlogrus/hook.go
@@ -51,7 +51,7 @@ func init() {
 // with them.
 type Hook struct {
 	// Tracer is the apm.Tracer to use for reporting errors.
-	// If Tracer is nil, then apm.DefaultTracer will be used.
+	// If Tracer is nil, then apm.DefaultTracer() will be used.
 	Tracer *apm.Tracer
 
 	// LogLevels holds the log levels to report as errors.
@@ -70,7 +70,7 @@ type Hook struct {
 func (h *Hook) tracer() *apm.Tracer {
 	tracer := h.Tracer
 	if tracer == nil {
-		tracer = apm.DefaultTracer
+		tracer = apm.DefaultTracer()
 	}
 	return tracer
 }

--- a/module/apmnegroni/middleware.go
+++ b/module/apmnegroni/middleware.go
@@ -40,7 +40,7 @@ func init() {
 // This middleware will recover and report panics, so it can
 // be used instead of the standard negroni.Recovery middleware.
 //
-// By default, the middleware will use apm.DefaultTracer.
+// By default, the middleware will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Middleware(o ...Option) negroni.Handler {
 	m := &middleware{

--- a/module/apmot/tracer.go
+++ b/module/apmot/tracer.go
@@ -32,14 +32,14 @@ import (
 // New returns a new opentracing.Tracer backed by the supplied
 // Elastic APM tracer.
 //
-// By default, the returned tracer will use apm.DefaultTracer.
+// By default, the returned tracer will use apm.DefaultTracer().
 // This can be overridden by using a WithTracer option.
 // The option WithSpanRefValidator allows one to override the
 // set of spans that are recorded. By default only child-of
 // spans are recorded.
 func New(opts ...Option) opentracing.Tracer {
 	t := &otTracer{
-		tracer:         apm.DefaultTracer,
+		tracer:         apm.DefaultTracer(),
 		isValidSpanRef: isChildOfSpanRef,
 	}
 	for _, opt := range opts {

--- a/module/apmrestful/filter.go
+++ b/module/apmrestful/filter.go
@@ -29,11 +29,11 @@ import (
 // Filter returns a new restful.Filter for tracing requests
 // and recovering and reporting panics to Elastic APM.
 //
-// By default, the filter will use apm.DefaultTracer.
+// By default, the filter will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Filter(o ...Option) restful.FilterFunction {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmrestfulv3/filter.go
+++ b/module/apmrestfulv3/filter.go
@@ -32,11 +32,11 @@ import (
 // Filter returns a new restful.Filter for tracing requests
 // and recovering and reporting panics to Elastic APM.
 //
-// By default, the filter will use apm.DefaultTracer.
+// By default, the filter will use apm.DefaultTracer().
 // Use WithTracer to specify an alternative tracer.
 func Filter(o ...Option) restful.FilterFunction {
 	opts := options{
-		tracer: apm.DefaultTracer,
+		tracer: apm.DefaultTracer(),
 	}
 	for _, o := range o {
 		o(&opts)

--- a/module/apmzap/core.go
+++ b/module/apmzap/core.go
@@ -44,7 +44,7 @@ func init() {
 // to the log records, the errors reported will be associated with them.
 type Core struct {
 	// Tracer is the apm.Tracer to use for reporting errors.
-	// If Tracer is nil, then apm.DefaultTracer will be used.
+	// If Tracer is nil, then apm.DefaultTracer() will be used.
 	Tracer *apm.Tracer
 
 	// FatalFlushTimeout is the amount of time to wait while
@@ -58,7 +58,7 @@ type Core struct {
 func (c *Core) tracer() *apm.Tracer {
 	tracer := c.Tracer
 	if tracer == nil {
-		tracer = apm.DefaultTracer
+		tracer = apm.DefaultTracer()
 	}
 	return tracer
 }

--- a/module/apmzerolog/writer.go
+++ b/module/apmzerolog/writer.go
@@ -62,7 +62,7 @@ func init() {
 // convey the complete file location and fully qualified function name.
 type Writer struct {
 	// Tracer is the apm.Tracer to use for reporting errors.
-	// If Tracer is nil, then apm.DefaultTracer will be used.
+	// If Tracer is nil, then apm.DefaultTracer() will be used.
 	Tracer *apm.Tracer
 
 	// FatalFlushTimeout is the amount of time to wait while
@@ -84,7 +84,7 @@ type Writer struct {
 func (w *Writer) tracer() *apm.Tracer {
 	tracer := w.Tracer
 	if tracer == nil {
-		tracer = apm.DefaultTracer
+		tracer = apm.DefaultTracer()
 	}
 	return tracer
 }

--- a/tracer.go
+++ b/tracer.go
@@ -48,20 +48,33 @@ const (
 )
 
 var (
-	// DefaultTracer is the default global Tracer, set at package
-	// initialization time, configured via environment variables.
-	//
-	// This will always be initialized to a non-nil value. If any
-	// of the environment variables are invalid, the corresponding
-	// errors will be logged to stderr and the default values will
-	// be used instead.
-	DefaultTracer *Tracer
+	defaultTracer *Tracer
 )
 
-func init() {
-	var opts TracerOptions
-	opts.initDefaults(true)
-	DefaultTracer = newTracer(opts)
+// DefaultTracer returns the default global Tracer, set the first time the
+// function is called. It is configured via environment variables.
+//
+// This will always be initialized to a non-nil value. If any of the
+// environment variables are invalid, the corresponding errors will be logged
+// to stderr and the default values will be used instead.
+func DefaultTracer() *Tracer {
+	if defaultTracer == nil {
+		var opts TracerOptions
+		opts.initDefaults(true)
+		defaultTracer = newTracer(opts)
+	}
+	return defaultTracer
+}
+
+// SetDefaultTracer sets the tracer returned by DefaultTracer(). If another
+// tracer has already been initialized, any events are flushed and the tracer
+// closed.
+func SetDefaultTracer(t *Tracer) {
+	if defaultTracer != nil {
+		defaultTracer.Flush(nil)
+		defaultTracer.Close()
+	}
+	defaultTracer = t
 }
 
 // TracerOptions holds initial tracer options, for passing to NewTracerOptions.
@@ -378,12 +391,6 @@ type Tracer struct {
 // This is equivalent to calling NewTracerOptions with a
 // TracerOptions having ServiceName and ServiceVersion set to
 // the provided arguments.
-//
-// NOTE when this package is imported, DefaultTracer is initialised
-// using environment variables for configuration. When creating a
-// tracer with NewTracer or NewTracerOptions, you should close
-// apm.DefaultTracer if it is not needed, e.g. by calling
-// apm.DefaultTracer.Close() in an init function.
 func NewTracer(serviceName, serviceVersion string) (*Tracer, error) {
 	return NewTracerOptions(TracerOptions{
 		ServiceName:    serviceName,
@@ -394,12 +401,6 @@ func NewTracer(serviceName, serviceVersion string) (*Tracer, error) {
 // NewTracerOptions returns a new Tracer using the provided options.
 // See TracerOptions for details on the options, and their default
 // values.
-//
-// NOTE when this package is imported, DefaultTracer is initialised
-// using environment variables for configuration. When creating a
-// tracer with NewTracer or NewTracerOptions, you should close
-// apm.DefaultTracer if it is not needed, e.g. by calling
-// apm.DefaultTracer.Close() in an init function.
 func NewTracerOptions(opts TracerOptions) (*Tracer, error) {
 	if err := opts.initDefaults(false); err != nil {
 		return nil, err

--- a/transport/http.go
+++ b/transport/http.go
@@ -382,10 +382,6 @@ func (t *HTTPTransport) sendProfileRequest(req *http.Request) error {
 // WatchConfig polls the APM Server for agent config changes, sending
 // them over the returned channel.
 func (t *HTTPTransport) WatchConfig(ctx context.Context, args apmconfig.WatchParams) <-chan apmconfig.Change {
-	// We have an initial delay to allow application initialisation code
-	// to close apm.DefaultTracer, which would cancel watching config.
-	const initialDelay = 1 * time.Second
-
 	changes := make(chan apmconfig.Change)
 	go func() {
 		defer close(changes)
@@ -393,7 +389,7 @@ func (t *HTTPTransport) WatchConfig(ctx context.Context, args apmconfig.WatchPar
 		var etag string
 		var out chan apmconfig.Change
 		var change apmconfig.Change
-		timer := time.NewTimer(initialDelay)
+		timer := time.NewTimer(0)
 		for {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
Additionally, add `SetDefaultTracer` so users can set the tracer returned by `DefaultTracer()`.

closes #775