### PR TITLE
Include service name and version in User-Agent

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.15.0...master[View commits]
 - Drop support for versions of Go prior to 1.15.0 {pull}1190[#(1190)]
 - Replace apm.DefaultTracer with an initialization function {pull}1189[#(1189)]
 - Remove transport.Default, construct a new Transport in each new tracer {pull}1195[#(1195)]
+- Add service name and version to User-Agent header {pull}1196[#(1196)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@
 package apm // import "go.elastic.co/apm"
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -140,9 +141,14 @@ var (
 )
 
 func initialTransport(serviceName, serviceVersion string) (transport.Transport, error) {
-	// TODO(axw) pass service name and version, to append to the User-Agent header.
+	// User-Agent should be "apm-agent-go/<agent-version> (service-name service-version)".
+	service := serviceName
+	if serviceVersion != "" {
+		service += " " + serviceVersion
+	}
+	userAgent := fmt.Sprintf("%s (%s)", transport.DefaultUserAgent(), service)
 	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{
-		UserAgent: "user-agent",
+		UserAgent: userAgent,
 	})
 	if err != nil {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -141,7 +141,9 @@ var (
 
 func initialTransport(serviceName, serviceVersion string) (transport.Transport, error) {
 	// TODO(axw) pass service name and version, to append to the User-Agent header.
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{
+		UserAgent: "user-agent",
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -140,11 +141,16 @@ var (
 	}()
 )
 
+// Regular expression matching comment characters to escape in the User-Agent header value.
+//
+// See https://httpwg.org/specs/rfc7230.html#field.components
+var httpComment, _ = regexp.Compile("[^\\t \\x21-\\x27\\x2a-\\x5b\\x5d-\\x7e\\x80-\\xff]")
+
 func initialTransport(serviceName, serviceVersion string) (transport.Transport, error) {
 	// User-Agent should be "apm-agent-go/<agent-version> (service-name service-version)".
 	service := serviceName
 	if serviceVersion != "" {
-		service += " " + serviceVersion
+		service += " " + httpComment.ReplaceAllString(serviceVersion, "_")
 	}
 	userAgent := fmt.Sprintf("%s (%s)", transport.DefaultUserAgent(), service)
 	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{

--- a/config.go
+++ b/config.go
@@ -144,7 +144,7 @@ var (
 // Regular expression matching comment characters to escape in the User-Agent header value.
 //
 // See https://httpwg.org/specs/rfc7230.html#field.components
-var httpComment, _ = regexp.Compile("[^\\t \\x21-\\x27\\x2a-\\x5b\\x5d-\\x7e\\x80-\\xff]")
+var httpComment = regexp.MustCompile("[^\\t \\x21-\\x27\\x2a-\\x5b\\x5d-\\x7e\\x80-\\xff]")
 
 func initialTransport(serviceName, serviceVersion string) (transport.Transport, error) {
 	// User-Agent should be "apm-agent-go/<agent-version> (service-name service-version)".

--- a/config_test.go
+++ b/config_test.go
@@ -216,9 +216,8 @@ func testTracerCentralConfigUpdate(t *testing.T, logger apm.Logger, serverRespon
 	defer server.Close()
 	serverURL, _ := url.Parse(server.URL)
 
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{ServerURLs: []*url.URL{serverURL}})
 	require.NoError(t, err)
-	httpTransport.SetServerURL(serverURL)
 
 	tracer := &apmtest.RecordingTracer{}
 	var testTransport struct {
@@ -279,7 +278,7 @@ func TestTracerCentralConfigUpdateDisabled(t *testing.T) {
 	os.Setenv("ELASTIC_APM_CENTRAL_CONFIG", "false")
 	defer os.Unsetenv("ELASTIC_APM_CENTRAL_CONFIG")
 
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{})
 	require.NoError(t, err)
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{Transport: httpTransport})
 	require.NoError(t, err)

--- a/env_test.go
+++ b/env_test.go
@@ -55,7 +55,7 @@ func TestTracerRequestTimeEnv(t *testing.T) {
 	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
 	defer os.Unsetenv("ELASTIC_APM_SERVER_URL")
 
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{})
 	require.NoError(t, err)
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
 		ServiceName: "tracer_testing",

--- a/features/api_key.feature
+++ b/features/api_key.feature
@@ -1,18 +1,24 @@
-Feature: API Key.
+Feature: APM server authentication with API key and secret token
 
-  Scenario: A configured API key is sent in the Authorization header.
-    Given an agent
-    When an api key is set to 'RTNxMjlXNEJt' in the config
-    Then the Authorization header is 'ApiKey RTNxMjlXNEJt'
+  Scenario: A configured API key is sent in the Authorization header
+    Given an agent configured with
+      | setting    | value        |
+      | api_key    | RTNxMjlXNEJt |
+    When the agent sends a request to APM server
+    Then the Authorization header of the request is 'ApiKey RTNxMjlXNEJt'
 
-  Scenario: A configured API key takes precedence over a secret token.
-    Given an agent
-    When an api key is set to 'MjlXNEJasdfDt' in the config
-    And a secret_token is set to 'secr3tT0ken' in the config
-    Then the Authorization header is 'ApiKey MjlXNEJasdfDt'
+  Scenario: A configured secret token is sent in the Authorization header
+    Given an agent configured with
+      | setting       | value         |
+      | secret_token  | secr3tT0ken   |
+    When the agent sends a request to APM server
+    Then the Authorization header of the request is 'Bearer secr3tT0ken'
 
-  Scenario: A configured secret token is sent if no API key is configured.
-    Given an agent
-    When a secret_token is set to 'secr3tT0ken' in the config
-    And an api key is not set in the config
-    Then the Authorization header is 'Bearer secr3tT0ken'
+  Scenario: A configured API key takes precedence over a secret token
+    Given an agent configured with
+      | setting       | value         |
+      | api_key       | MjlXNEJasdfDt |
+      | secret_token  | secr3tT0ken   |
+    When the agent sends a request to APM server
+    Then the Authorization header of the request is 'ApiKey MjlXNEJasdfDt'
+

--- a/features/azure_app_service_metadata.feature
+++ b/features/azure_app_service_metadata.feature
@@ -1,7 +1,9 @@
 Feature: Extracting Metadata for Azure App Service
 
   Background:
-    Given an instrumented application is configured to collect cloud provider metadata for azure
+    Given an agent configured with
+      | setting        | value |
+      | cloud_provider | azure |
 
   Scenario Outline: Azure App Service with all environment variables present in expected format
     Given the following environment variables are present

--- a/features/outcome.feature
+++ b/features/outcome.feature
@@ -1,56 +1,60 @@
 Feature: Outcome
 
+  Background: An agent with default configuration
+    Given an agent
+
   # ---- user set outcome
 
   Scenario: User set outcome on span has priority over instrumentation
-    Given an agent
-    And an active span
-    And user sets span outcome to 'failure'
-    And span terminates with outcome 'success'
-    Then span outcome is 'failure'
+    Given an active span
+    And the agent sets the span outcome to 'success'
+    And a user sets the span outcome to 'failure'
+    When the span ends
+    Then the span outcome is 'failure'
 
   Scenario: User set outcome on transaction has priority over instrumentation
-    Given an agent
-    And an active transaction
-    And user sets transaction outcome to 'unknown'
-    And transaction terminates with outcome 'failure'
-    Then transaction outcome is 'unknown'
+    Given an active transaction
+    And the agent sets the transaction outcome to 'failure'
+    And a user sets the transaction outcome to 'unknown'
+    When the transaction ends
+    Then the transaction outcome is 'unknown'
 
   # ---- span & transaction outcome from reported errors
 
   Scenario: span with error
-    Given an agent
-    And an active span
-    And span terminates with an error
-    Then span outcome is 'failure'
+    Given an active span
+    And an error is reported to the span
+    When the span ends
+    Then the span outcome is 'failure'
 
   Scenario: span without error
-    Given an agent
-    And an active span
-    And span terminates without error
-    Then span outcome is 'success'
+    Given an active span
+    When the span ends
+    Then the span outcome is 'success'
 
   Scenario: transaction with error
-    Given an agent
-    And an active transaction
-    And transaction terminates with an error
-    Then transaction outcome is 'failure'
+    Given an active transaction
+    And an error is reported to the transaction
+    When the transaction ends
+    Then the transaction outcome is 'failure'
 
   Scenario: transaction without error
-    Given an agent
-    And an active transaction
-    And transaction terminates without error
-    Then transaction outcome is 'success'
+    Given an active transaction
+    When the transaction ends
+    Then the transaction outcome is 'success'
 
   # ---- HTTP
 
   @http
   Scenario Outline: HTTP transaction and span outcome
-    Given an agent
-    And an HTTP transaction with <status> response code
-    Then transaction outcome is "<server>"
-    Given an HTTP span with <status> response code
-    Then span outcome is "<client>"
+    Given an active transaction 
+    And a HTTP call is received that returns <status>
+    When the transaction ends
+    Then the transaction outcome is '<server>'
+    Given an active span 
+    And a HTTP call is made that returns <status>
+    When the span ends
+    Then the span outcome is '<client>'
     Examples:
       | status | client  | server  |
       | 100    | success | success |
@@ -69,11 +73,14 @@ Feature: Outcome
 
   @grpc
   Scenario Outline: gRPC transaction and span outcome
-    Given an agent
-    And a gRPC transaction with '<status>' status
-    Then transaction outcome is "<server>"
-    Given a gRPC span with '<status>' status
-    Then span outcome is "<client>"
+    Given an active transaction
+    And a gRPC call is received that returns '<status>'
+    When the transaction ends
+    Then the transaction outcome is '<server>'
+    Given an active span
+    And a gRPC call is made that returns '<status>'
+    When the span ends
+    Then the span outcome is '<client>'
     Examples:
       | status              | client  | server  |
       | OK                  | success | success |

--- a/features/user_agent.feature
+++ b/features/user_agent.feature
@@ -1,0 +1,32 @@
+Feature: Agent Transport User agent Header
+
+  Scenario: Default user-agent
+    Given an agent
+    When the agent sends a request to APM server
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(.*\)'
+
+  Scenario: Default user-agent when setting invalid service
+    Given an agent configured with
+      | setting         | value            |
+      | service_name    | myService/()<>@  |
+    When the agent sends a request to APM server
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(.*\)'
+
+  Scenario: User-agent with service name only
+    Given an agent configured with
+      | setting         | value            |
+      | service_name    | myService        |
+    When the agent sends a request to APM server
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(myService\)'
+
+  Scenario Outline: User-agent with service name and service version
+    Given an agent configured with
+      | setting         | value             |
+      | service_name    | <SERVICE_NAME>    |
+      | service_version | <SERVICE_VERSION> |
+    When the agent sends a request to APM server
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
+    Examples:
+      | SERVICE_NAME   | ESCAPED_SERVICE_NAME  | SERVICE_VERSION   | ESCAPED_SERVICE_VERSION |
+      | myService      | myService             | v42               | v42                     |
+      | myService      | myService             | 123(:\;)456       | 123_:_;_456             |

--- a/internal/apmgodog/suitecontext_test.go
+++ b/internal/apmgodog/suitecontext_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -44,12 +45,15 @@ import (
 )
 
 type featureContext struct {
-	apiKey      string
-	secretToken string
-	env         []string // for subprocesses
+	apiKey         string
+	secretToken    string
+	serviceName    string
+	serviceVersion string
+	env            []string // for subprocesses
 
-	httpServer  *httptest.Server
-	httpHandler *httpHandler
+	httpServer         *httptest.Server
+	httpHandler        *httpHandler
+	httpRequestHeaders http.Header
 
 	grpcServer  *grpc.Server
 	grpcClient  *grpc.ClientConn
@@ -115,6 +119,7 @@ func (c *featureContext) initScenario(s *godog.ScenarioContext) {
 		c.transaction = nil
 		c.httpHandler.panic = false
 		c.httpHandler.statusCode = http.StatusOK
+		c.httpRequestHeaders = nil
 		c.grpcService.panic = false
 		c.grpcService.err = nil
 		c.tracer.ResetPayloads()
@@ -127,51 +132,33 @@ func (c *featureContext) initScenario(s *godog.ScenarioContext) {
 	})
 
 	s.Step("^an agent$", c.anAgent)
-	s.Step("^an api key is not set in the config$", func() error { return nil })
-	s.Step("^an api key is set to '(.*)' in the config$", c.setAPIKey)
-	s.Step("^a secret_token is set to '(.*)' in the config$", c.setSecretToken)
-	s.Step("^the Authorization header is '(.*)'$", c.checkAuthorizationHeader)
+	s.Step("^an agent configured with$", c.anAgentConfiguredWith)
+	s.Step("^the agent sends a request to APM server$", c.sendRequest)
+	s.Step("^the Authorization header of the request is '(.*)'$", c.checkAuthorizationHeader)
+	s.Step("^the User-Agent header of the request matches regex '(.*)'$", c.checkUserAgentHeader)
 
 	s.Step("^an active span$", c.anActiveSpan)
 	s.Step("^an active transaction$", c.anActiveTransaction)
 
 	// Outcome
-	s.Step("^user sets span outcome to '(.*)'$", c.userSetsSpanOutcome)
-	s.Step("^user sets transaction outcome to '(.*)'$", c.userSetsTransactionOutcome)
-	s.Step("^span terminates with outcome '(.*)'$", c.spanTerminatesWithOutcome)
-	s.Step("^transaction terminates with outcome '(.*)'$", c.transactionTerminatesWithOutcome)
-	s.Step("^span terminates with an error$", func() error {
-		e := c.tracer.NewError(errors.New("an error"))
-		e.SetSpan(c.span)
-		c.span.End()
-		return nil
-	})
-	s.Step("^span terminates without error$", func() error {
-		c.span.End()
-		return nil
-	})
-	s.Step("^transaction terminates with an error$", func() error {
-		e := c.tracer.NewError(errors.New("an error"))
-		e.SetTransaction(c.transaction)
-		c.transaction.End()
-		return nil
-	})
-	s.Step("^transaction terminates without error$", func() error {
-		c.transaction.End()
-		return nil
-	})
-	s.Step("^span outcome is '(.*)'$", c.spanOutcomeIs)
-	s.Step("^span outcome is \"(.*)\"$", c.spanOutcomeIs)
-	s.Step("^transaction outcome is '(.*)'$", c.transactionOutcomeIs)
-	s.Step("^transaction outcome is \"(.*)\"$", c.transactionOutcomeIs)
+	s.Step("^a user sets the span outcome to '(.*)'$", c.userSetsSpanOutcome)
+	s.Step("^a user sets the transaction outcome to '(.*)'$", c.userSetsTransactionOutcome)
+	s.Step("^the agent sets the span outcome to '(.*)'$", c.agentSetsSpanOutcome)
+	s.Step("^the agent sets the transaction outcome to '(.*)'$", c.agentSetsTransactionOutcome)
+	s.Step("^an error is reported to the span$", c.anErrorIsReportedToTheSpan)
+	s.Step("^an error is reported to the transaction$", c.anErrorIsReportedToTheTransaction)
+	s.Step("^the span ends$", c.spanEnds)
+	s.Step("^the transaction ends$", c.transactionEnds)
+	s.Step("^the span outcome is '(.*)'$", c.spanOutcomeIs)
+	s.Step("^the transaction outcome is '(.*)'$", c.transactionOutcomeIs)
 
 	// HTTP
-	s.Step("^an HTTP transaction with (.*) response code$", c.anHTTPTransactionWithStatusCode)
-	s.Step("^an HTTP span with (.*) response code$", c.anHTTPSpanWithStatusCode)
+	s.Step("^a HTTP call is received that returns (.*)$", c.anHTTPTransactionWithStatusCode)
+	s.Step("^a HTTP call is made that returns (.*)$", c.anHTTPSpanWithStatusCode)
 
 	// gRPC
-	s.Step("^a gRPC transaction with '(.*)' status$", c.aGRPCTransactionWithStatusCode)
-	s.Step("^a gRPC span with '(.*)' status$", c.aGRPCSpanWithStatusCode)
+	s.Step("^a gRPC call is received that returns '(.*)'$", c.aGRPCTransactionWithStatusCode)
+	s.Step("^a gRPC call is made that returns '(.*)'$", c.aGRPCSpanWithStatusCode)
 
 	// Cloud metadata
 	s.Step("an instrumented application is configured to collect cloud provider metadata for azure", func() error {
@@ -250,20 +237,31 @@ func (c *featureContext) anAgent() error {
 	return nil
 }
 
-func (c *featureContext) setAPIKey(v string) error {
-	c.apiKey = v
+func (c *featureContext) anAgentConfiguredWith(settings *godog.Table) error {
+	for _, row := range settings.Rows[1:] {
+		setting := row.Cells[0].Value
+		value := row.Cells[1].Value
+		switch setting {
+		case "api_key":
+			c.apiKey = value
+		case "cloud_provider":
+			c.env = append(c.env, "ELASTIC_APM_CLOUD_PROVIDER="+value)
+		case "secret_token":
+			c.secretToken = value
+		case "service_name":
+			c.serviceName = value
+		case "service_version":
+			c.serviceVersion = value
+		default:
+			return fmt.Errorf("unhandled setting %q", setting)
+		}
+	}
 	return nil
 }
 
-func (c *featureContext) setSecretToken(v string) error {
-	c.secretToken = v
-	return nil
-}
-
-func (c *featureContext) checkAuthorizationHeader(expected string) error {
-	var authHeader []string
+func (c *featureContext) sendRequest() error {
 	var h http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
-		authHeader = r.Header["Authorization"]
+		c.httpRequestHeaders = r.Header
 	}
 	server := httptest.NewServer(h)
 	defer server.Close()
@@ -271,20 +269,46 @@ func (c *featureContext) checkAuthorizationHeader(expected string) error {
 	os.Setenv("ELASTIC_APM_SECRET_TOKEN", c.secretToken)
 	os.Setenv("ELASTIC_APM_API_KEY", c.apiKey)
 	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
-	tracer, err := apm.NewTracer("godog", "")
+
+	tracer, err := apm.NewTracer(c.serviceName, c.serviceVersion)
+	if err != nil {
+		// The User-Agent tests set a service name with invalid characters, and then
+		// checks that the resulting User-Agent is valid. We prevent invalid service
+		// names from being set, so mimic other agents' behaviour by not using
+		// serviceName and serviceVersion if NewTracer returns an error.
+		tracer, err = apm.NewTracer("godog", "")
+	}
 	if err != nil {
 		return err
 	}
-	defer tracer.Close()
 
 	tracer.StartTransaction("name", "type").End()
 	tracer.Flush(nil)
+	return nil
+}
 
+func (c *featureContext) checkAuthorizationHeader(expected string) error {
+	authHeader := c.httpRequestHeaders["Authorization"]
 	if n := len(authHeader); n != 1 {
 		return fmt.Errorf("got %d Authorization headers, expected 1", n)
 	}
-	if authHeader[0] != expected {
-		return fmt.Errorf("got Authorization header value %q, expected %q", authHeader, expected)
+	return nil
+}
+
+func (c *featureContext) checkUserAgentHeader(expectedRegex string) error {
+	re, err := regexp.Compile(expectedRegex)
+	if err != nil {
+		return err
+	}
+	userAgentHeader := c.httpRequestHeaders["User-Agent"]
+	if n := len(userAgentHeader); n != 1 {
+		return fmt.Errorf("got %d User-Agent headers, expected 1", n)
+	}
+	if !re.MatchString(userAgentHeader[0]) {
+		return fmt.Errorf(
+			"User-Agent header %q does not match regex %q",
+			userAgentHeader[0], expectedRegex,
+		)
 	}
 	return nil
 }
@@ -312,7 +336,7 @@ func (c *featureContext) userSetsTransactionOutcome(outcome string) error {
 	return nil
 }
 
-func (c *featureContext) spanTerminatesWithOutcome(outcome string) error {
+func (c *featureContext) agentSetsSpanOutcome(outcome string) error {
 	switch outcome {
 	case "unknown":
 	case "success":
@@ -320,11 +344,10 @@ func (c *featureContext) spanTerminatesWithOutcome(outcome string) error {
 	case "failure":
 		c.span.Context.SetHTTPStatusCode(400)
 	}
-	c.span.End()
 	return nil
 }
 
-func (c *featureContext) transactionTerminatesWithOutcome(outcome string) error {
+func (c *featureContext) agentSetsTransactionOutcome(outcome string) error {
 	switch outcome {
 	case "unknown":
 	case "success":
@@ -332,7 +355,30 @@ func (c *featureContext) transactionTerminatesWithOutcome(outcome string) error 
 	case "failure":
 		c.transaction.Context.SetHTTPStatusCode(500)
 	}
+	return nil
+}
+
+func (c *featureContext) anErrorIsReportedToTheSpan() error {
+	e := c.tracer.NewError(errors.New("an error"))
+	e.SetSpan(c.span)
+	return nil
+}
+
+func (c *featureContext) anErrorIsReportedToTheTransaction() error {
+	e := c.tracer.NewError(errors.New("an error"))
+	e.SetTransaction(c.transaction)
+	return nil
+}
+
+func (c *featureContext) spanEnds() error {
+	c.span.End()
+	c.tracer.Flush(nil)
+	return nil
+}
+
+func (c *featureContext) transactionEnds() error {
 	c.transaction.End()
+	c.tracer.Flush(nil)
 	return nil
 }
 

--- a/module/apmgin/bench_test.go
+++ b/module/apmgin/bench_test.go
@@ -69,11 +69,12 @@ func newTracer() *apm.Tracer {
 	if err != nil {
 		panic(err)
 	}
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{
+		ServerURLs: []*url.URL{invalidServerURL},
+	})
 	if err != nil {
 		panic(err)
 	}
-	httpTransport.SetServerURL(invalidServerURL)
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
 		ServiceName:    "apmgin_test",
 		ServiceVersion: "0.1",

--- a/module/apmhttp/handler_bench_test.go
+++ b/module/apmhttp/handler_bench_test.go
@@ -74,11 +74,12 @@ func newTracer() *apm.Tracer {
 		panic(err)
 	}
 
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{
+		ServerURLs: []*url.URL{invalidServerURL},
+	})
 	if err != nil {
 		panic(err)
 	}
-	httpTransport.SetServerURL(invalidServerURL)
 
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
 		ServiceName:    "apmhttp_test",

--- a/module/apmsql/apmsql_bench_test.go
+++ b/module/apmsql/apmsql_bench_test.go
@@ -51,9 +51,10 @@ func BenchmarkStmtQueryContext(b *testing.B) {
 		if err != nil {
 			panic(err)
 		}
-		httpTransport, err := transport.NewHTTPTransport()
+		httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{
+			ServerURLs: []*url.URL{invalidServerURL},
+		})
 		require.NoError(b, err)
-		httpTransport.SetServerURL(invalidServerURL)
 
 		tracer, err := apm.NewTracerOptions(apm.TracerOptions{
 			ServiceName:    "apmhttp_test",
@@ -99,9 +100,10 @@ func BenchmarkStmtExecContext(b *testing.B) {
 		if err != nil {
 			panic(err)
 		}
-		httpTransport, err := transport.NewHTTPTransport()
+		httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{
+			ServerURLs: []*url.URL{invalidServerURL},
+		})
 		require.NoError(b, err)
-		httpTransport.SetServerURL(invalidServerURL)
 
 		tracer, err := apm.NewTracerOptions(apm.TracerOptions{
 			ServiceName:    "apmhttp_test",

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -276,7 +276,7 @@ func TestTracerRequestSize(t *testing.T) {
 	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
 	defer os.Unsetenv("ELASTIC_APM_SERVER_URL")
 
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{})
 	require.NoError(t, err)
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
 		ServiceName: "tracer_testing",
@@ -371,7 +371,7 @@ func TestTracerBodyUnread(t *testing.T) {
 	os.Setenv("ELASTIC_APM_SERVER_URL", server.URL)
 	defer os.Unsetenv("ELASTIC_APM_SERVER_URL")
 
-	httpTransport, err := transport.NewHTTPTransport()
+	httpTransport, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{})
 	require.NoError(t, err)
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
 		ServiceName: "tracer_testing",

--- a/transport/http.go
+++ b/transport/http.go
@@ -34,7 +34,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -59,7 +58,7 @@ const (
 	envServerTimeout    = "ELASTIC_APM_SERVER_TIMEOUT"
 	envServerCert       = "ELASTIC_APM_SERVER_CERT"
 	envVerifyServerCert = "ELASTIC_APM_VERIFY_SERVER_CERT"
-	envCACert           = "ELASTIC_APM_SERVER_CA_CERT_FILE"
+	envServerCACert     = "ELASTIC_APM_SERVER_CA_CERT_FILE"
 )
 
 var (
@@ -73,37 +72,71 @@ var (
 
 // HTTPTransportOptions for the HTTPTransport.
 type HTTPTransportOptions struct {
-	// APIKey holds the APIKey base64-encoded string. Specifying an APIKey will
-	// the SecretToken, if set.
+	// APIKey holds the base64-encoded API Key credential string, used for
+	// authenticating the agent. APIKey takes precedence over SecretToken.
+	//
+	// If unspecified, APIKey will be initialized using the
+	// ELASTIC_APM_API_KEY environment variable.
 	APIKey string
 
-	// SecretToken holds the secret token configured in the APM Server.
+	// SecretToken holds the secret token configured in the APM Server, used
+	// for authenticating the agent.
+	//
+	// If unspecified, SecretToken will be initialized using the
+	// ELASTIC_APM_SECRET_TOKEN envirohnment variable.
 	SecretToken string
 
-	// ServerCert can be set if you have configured your APM Server with a
-	// self signed TLS certificate, or you want to verify the server certificate
-	// matches this exact TLS certificate.
+	// ServerCert holds the path to a PEM-encoded TLS certificate that must
+	// match the APM Server-supplied certificate. This can be used to pin a
+	// self signed certificate. If this is set, then SkipServerVerify will be
+	// ignored.
+	//
+	// If unspecified, ServerCert will be initialized using the
+	// ELASTIC_APM_SERVER_CERT environment variable.
 	ServerCert string
 
-	// ServerCACert can be set if you want to specify a path to the PEM-encoded
-	// Certificate Authority to verify the Server TLS certificate.
+	// ServerCACert holds the path to a PEM-encoded Certificate Authority
+	// certificate that will be used for verifying the server's TLS certificate
+	// chain.
+	//
+	// If unspecified, ServerCACert will be initialized using the
+	// ELASTIC_APM_SERVER_CA_CERT_FILE environment variable.
 	ServerCACert string
 
 	// ServerURLs holds the URLs for your Elastic APM Server. The Server
 	// supports both HTTP and HTTPS. If you use HTTPS, then you may need to
 	// configure your client machines so that the server certificate can be
 	// verified. You can disable certificate verification with SkipServerVerify.
-	// If no URL is specified, then the transport will use the default URL
-	// "http://localhost:8200".
+	//
+	// If no URLs are specified, then ServerURLs will be initialized using the
+	// ELASTIC_APM_SERVER_URL environment variable, defaulting to
+	// "http://localhost:8200" if the environment variable is not set.
 	ServerURLs []*url.URL
 
 	// ServerTimeout holds the timeout for requests made to your Elastic APM
-	// server. When set to zero, it will default to 30 seconds. Negative values
+	// server.
+	//
+	// When set to zero, it will default to 30 seconds. Negative values
 	// are not allowed.
+	//
+	// If ServerTimeout is zero, then it will be initialized using the
+	// ELASTIC_APM_SERVER_TIMEOUT environment variable, defaulting to
+	// 30 seconds if the environment variable is not set. Negative values are
+	// not allowed, and will cause NewHTTPTransport to return an error.
 	ServerTimeout time.Duration
 
-	// SkipServerVerify skips TLS certificate validation of the APM Server.
+	// SkipServerVerify skips TLS certificate verification of the APM Server.
+	// By default, the server's TLS certificate will be verified.
+	//
+	// If false, SkipServerVerify will be initialized using the
+	// ELASTIC_APM_VERIFY_SERVER_CERT environment variable.
 	SkipServerVerify bool
+
+	// UserAgent holds the value to use for the User-Agent header.
+	//
+	// If unspecified, UserAgent will be set to the value returned by
+	// DefaultUserAgent().
+	UserAgent string
 }
 
 // Validate ensures the HTTPTransportOptions are valid.
@@ -131,67 +164,46 @@ type HTTPTransport struct {
 	profileURLs []*url.URL
 }
 
-// NewHTTPTransport returns a new HTTPTransport which can be used for
-// streaming data to the APM Server. The returned HTTPTransport will be
-// initialized using the following environment variables:
-//
-// - ELASTIC_APM_SERVER_URL: the APM Server URL used for sending
-//   requests. If no URL is specified, then the transport will use the
-//   default URL "http://localhost:8200".
-//
-// - ELASTIC_APM_SERVER_TIMEOUT: timeout for requests to the APM Server.
-//   If not specified, defaults to 30 seconds.
-//
-// - ELASTIC_APM_API_KEY: base64-encoded string used for authentication.
-//   Setting this environment variable ignores ELASTIC_APM_SECRET_TOKEN.
-//
-// - ELASTIC_APM_SECRET_TOKEN: used to authenticate the agent.
-//
-// - ELASTIC_APM_SERVER_CERT: path to a PEM-encoded certificate that
-//   must match the APM Server-supplied certificate. This can be used
-//   to pin a self signed certificate. If this is set, then
-//   ELASTIC_APM_VERIFY_SERVER_CERT is ignored.
-//
-// - ELASTIC_APM_VERIFY_SERVER_CERT: if set to "false", the transport
-//   will not verify the APM Server's TLS certificate. Only relevant
-//   when using HTTPS. By default, the transport will verify server
-//   certificates.
-//
-func NewHTTPTransport() (*HTTPTransport, error) {
-	verifyServerCert, err := configutil.ParseBoolEnv(envVerifyServerCert, true)
-	if err != nil {
-		return nil, err
+// NewHTTPTransport returns a new HTTPTransport, initialized with opts,
+// which can be used for streaming data to the APM Server.
+func NewHTTPTransport(opts HTTPTransportOptions) (*HTTPTransport, error) {
+	if opts.APIKey == "" {
+		opts.APIKey = os.Getenv(envAPIKey)
 	}
-	serverTimeout, err := configutil.ParseDurationEnv(envServerTimeout, defaultServerTimeout)
-	if err != nil {
-		return nil, err
+	if len(opts.ServerURLs) == 0 {
+		serverURLs, err := initServerURLs()
+		if err != nil {
+			return nil, err
+		}
+		opts.ServerURLs = serverURLs
 	}
-	if serverTimeout < 0 {
-		serverTimeout = 0
+	if opts.ServerCert == "" {
+		opts.ServerCert = os.Getenv(envServerCert)
 	}
-	serverURLs, err := initServerURLs()
-	if err != nil {
-		return nil, err
+	if opts.ServerCACert == "" {
+		opts.ServerCACert = os.Getenv(envServerCACert)
 	}
-
-	opts := HTTPTransportOptions{
-		SkipServerVerify: !verifyServerCert,
-		ServerURLs:       serverURLs,
-		ServerTimeout:    serverTimeout,
-		ServerCert:       os.Getenv(envServerCert),
-		ServerCACert:     os.Getenv(envCACert),
+	if opts.SecretToken == "" && opts.APIKey == "" {
+		opts.SecretToken = os.Getenv(envSecretToken)
 	}
-	if apiKey := os.Getenv(envAPIKey); apiKey != "" {
-		opts.APIKey = apiKey
-	} else if secretToken := os.Getenv(envSecretToken); secretToken != "" {
-		opts.SecretToken = secretToken
+	if opts.ServerTimeout == 0 {
+		serverTimeout, err := configutil.ParseDurationEnv(envServerTimeout, defaultServerTimeout)
+		if err != nil {
+			return nil, err
+		}
+		opts.ServerTimeout = serverTimeout
 	}
-	return NewHTTPTransportOptions(opts)
+	if !opts.SkipServerVerify {
+		verifyServerCert, err := configutil.ParseBoolEnv(envVerifyServerCert, true)
+		if err != nil {
+			return nil, err
+		}
+		opts.SkipServerVerify = !verifyServerCert
+	}
+	return newHTTPTransportOptions(opts)
 }
 
-// NewHTTPTransportOptions returns a customized HTTPTransport which can be used
-// for streaming data to the APM Server.
-func NewHTTPTransportOptions(opts HTTPTransportOptions) (*HTTPTransport, error) {
+func newHTTPTransportOptions(opts HTTPTransportOptions) (*HTTPTransport, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
@@ -239,7 +251,11 @@ func NewHTTPTransportOptions(opts HTTPTransportOptions) (*HTTPTransport, error) 
 	}
 
 	commonHeaders := make(http.Header)
-	commonHeaders.Set("User-Agent", defaultUserAgent())
+
+	if opts.UserAgent == "" {
+		opts.UserAgent = DefaultUserAgent()
+	}
+	commonHeaders.Set("User-Agent", opts.UserAgent)
 
 	intakeHeaders := copyHeaders(commonHeaders)
 	intakeHeaders.Set("Content-Type", "application/x-ndjson")
@@ -678,8 +694,10 @@ func verifyPeerCertificate(rawCerts [][]byte, trusted *x509.Certificate) error {
 	return nil
 }
 
-func defaultUserAgent() string {
-	return fmt.Sprintf("elasticapm-go/%s go/%s", apmversion.AgentVersion, runtime.Version())
+// DefaultUserAgent returns the default value to use for the User-Agent header:
+// apm-agent-go/<agent-version>.
+func DefaultUserAgent() string {
+	return fmt.Sprintf("apm-agent-go/%s", apmversion.AgentVersion)
 }
 
 func copyHeaders(in http.Header) http.Header {


### PR DESCRIPTION
Update User-Agent to match the [agent spec](https://github.com/elastic/apm/blob/main/specs/agents/transport.md#user-agent), including service name and service version if it is specified. User-Agent no longer includes the Go runtime version, but this is still available in `service.runtime.version`.

The `transport.NewHTTPTransportOptions` function is removed, and `transport.NewHTTPTransport` is updated to take HTTPTransportOptions instead now that we can break the API. Use env vars as defaults only if values are not specified in the options struct, aligning with behaviour of `apm.NewTracerOptions`.

Update to the latest shared agents Gherkin spec.

Closes https://github.com/elastic/apm-agent-go/issues/1136