### PR TITLE
[1.x] Fix doc links

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -361,7 +361,7 @@ String values longer than 1024 characters will be truncated. Labels are
 indexed in Elasticsearch as keyword fields.
 
 TIP: Before using labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
@@ -383,7 +383,7 @@ to help you quickly debug performance issues or errors.
 The value can be of any type that can be encoded using `encoding/json`.
 
 TIP: Before using custom context, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 [float]
 [[context-set-username]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -129,7 +129,7 @@ could be observed by an attacker.
 |============
 
 This base64-encoded string is used to ensure that only your agents can send data to your APM server.
-The API key must be created using the APM Server {apm-server-ref-v}/api-key.html[command line tool].
+The API key must be created using the APM Server {apm-guide-ref}/api-key.html[command line tool].
 
 WARNING: The API Key is sent as plain-text in every request to the server, so you should also secure
 your communications using HTTPS. Unless you do so, your API Key could be observed by an attacker.
@@ -604,7 +604,7 @@ NOTE: This feature requires APM Server v7.3 or later and that the APM Server is 
 | `ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER` | `true`
 |============
 
-To enable {apm-overview-ref-v}/distributed-tracing.html[distributed tracing], the agent
+To enable {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing], the agent
 adds trace context headers to outgoing HTTP requests made with <<builtin-modules-apmhttp>>.
 These headers (`traceparent` and `tracestate`) are defined in the
 https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -39,5 +39,5 @@ This collection happens in a background goroutine that is automatically started 
 === Additional Components
 
 APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -38,6 +38,6 @@ This collection happens in a background goroutine that is automatically started 
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,7 +6,7 @@ Upgrades that involve a major version bump often come with some backwards incomp
 Before upgrading the agent, be sure to review the:
 
 * <<release-notes,Agent release notes>>
-* {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility chart]
+* {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility chart]
 
 [float]
 [[end-of-life-dates]]


### PR DESCRIPTION
Backports https://github.com/elastic/apm-agent-go/pull/1199 to 1.x