### PR TITLE
tracer: Drop unsampled txs when APM Server >= 8.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.15.0...main[View commits]
 - Add service name and version to User-Agent header {pull}1196[#(1196)]
 - Remove WarningLogger, add Warningf methe to Logger {pull}1205[#(1205)]
 - Replace Sampler with ExtendedSampler {pull}1206[#(1206)]
+- Drop unsampled txs when connected to an APM Server >= 8.0 {pull}1208[#(1208)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/config_test.go
+++ b/config_test.go
@@ -267,6 +267,9 @@ func testTracerCentralConfigUpdate(t *testing.T, logger apm.Logger, serverRespon
 func TestTracerCentralConfigUpdateDisabled(t *testing.T) {
 	responded := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/config/v1/agents" {
+			return
+		}
 		select {
 		case responded <- struct{}{}:
 		case <-req.Context().Done():

--- a/config_test.go
+++ b/config_test.go
@@ -203,6 +203,9 @@ func testTracerCentralConfigUpdate(t *testing.T, logger apm.Logger, serverRespon
 	}
 	responses := make(chan response)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/" {
+			return
+		}
 		assert.Equal(t, "/config/v1/agents", req.URL.Path)
 		w.Header().Set("Cache-Control", "max-age=1")
 		select {

--- a/tracer.go
+++ b/tracer.go
@@ -1357,12 +1357,12 @@ func (t *Tracer) gatherMetrics(ctx context.Context, gatherers []MetricsGatherer,
 // is non-sampled and the target server version is 8.0 or greater.
 // maybeDropTransaction returns true if the transaction is dropped, false otherwise.
 func (t *Tracer) maybeDropTransaction(ctx context.Context, td *TransactionData, sampled bool) bool {
-	if t.versionGetter == nil {
+	if sampled || t.versionGetter == nil {
 		return false
 	}
 
 	v := t.versionGetter.MajorServerVersion(ctx, false)
-	dropUnsampled := v >= 8 && !sampled
+	dropUnsampled := v >= 8
 	if dropUnsampled {
 		td.reset(t)
 	}

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -753,7 +753,7 @@ func TestSetServerURL(t *testing.T) {
 	})
 }
 
-func TestGetVersion(t *testing.T) {
+func TestMajorServerVersion(t *testing.T) {
 	newTransport := func(t *testing.T, u string) *transport.HTTPTransport {
 		validURL, err := url.Parse(u)
 		require.NoError(t, err)
@@ -782,13 +782,13 @@ func TestGetVersion(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		version, err := transport.GetVersion(ctx)
+		version, err := transport.MajorServerVersion(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "", version)
+		assert.Equal(t, 0, version)
 
-		version, err = transport.GetVersion(ctx)
+		version, err = transport.MajorServerVersion(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "7.17.0", version)
+		assert.Equal(t, 7, version)
 	})
 	t.Run("failure_timeout", func(t *testing.T) {
 		var count uint32
@@ -807,18 +807,16 @@ func TestGetVersion(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
 
-		println(count)
-		version, err := transport.GetVersion(ctx)
+		version, err := transport.MajorServerVersion(ctx)
 		require.EqualError(t, err, fmt.Sprintf(
 			`failed querying apm-server version: Get "%s/": context deadline exceeded`, srv.URL,
 		))
-		assert.Equal(t, "", version)
+		assert.Equal(t, 0, version)
 
 		<-time.After(time.Second)
-		version, err = transport.GetVersion(context.Background())
-		println(count)
+		version, err = transport.MajorServerVersion(context.Background())
 		require.NoError(t, err)
-		assert.Equal(t, "7.16.3", version)
+		assert.Equal(t, 7, version)
 	})
 	t.Run("success", func(t *testing.T) {
 		var count int
@@ -841,9 +839,9 @@ func TestGetVersion(t *testing.T) {
 		// Run GetVersion a few times and ensure that the same version is
 		// returned on subsequent calls
 		for i := 0; i < 5; i++ {
-			version, err := transport.GetVersion(ctx)
+			version, err := transport.MajorServerVersion(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, "8.0.0", version, fmt.Sprintf("iteration %d", i))
+			assert.Equal(t, 8, version, fmt.Sprintf("iteration %d", i))
 		}
 	})
 }

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -788,28 +788,29 @@ func TestMajorServerVersion(t *testing.T) {
 	})
 	t.Run("failure_timeout", func(t *testing.T) {
 		var count uint32
-		c := make(chan struct{})
+		wait := make(chan struct{})
 		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
-			if atomic.LoadUint32(&count) > 0 {
-				rw.WriteHeader(200)
-				rw.Write([]byte(`{"version":"7.16.3"}`))
-			} else {
-				<-c
-			}
+			c := atomic.LoadUint32(&count)
 			atomic.AddUint32(&count, 1)
+			if c == 0 {
+				<-wait
+				return
+			}
+			rw.WriteHeader(200)
+			rw.Write([]byte(`{"version":"7.16.3"}`))
 		}))
 		defer srv.Close()
 
 		transport := newTransport(t, srv.URL)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-
 		version := transport.MajorServerVersion(ctx, true)
+		close(wait)
 		assert.Zero(t, version)
 		assert.Error(t, ctx.Err())
-		close(c)
 
 		version = transport.MajorServerVersion(context.Background(), true)
+		assert.Equal(t, uint32(2), count, "count == 1 means that the first request context was cancelled before the http test server received it")
 		assert.Equal(t, uint32(7), version)
 	})
 	t.Run("success", func(t *testing.T) {

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -52,10 +52,9 @@ func NewRecorderTracer() (*apm.Tracer, *RecorderTransport) {
 // streams sent. The streams can be retrieved using the Payloads
 // method.
 type RecorderTransport struct {
-	mu            sync.Mutex
-	metadata      *metadata
-	RemoteVersion string
-	payloads      Payloads
+	mu       sync.Mutex
+	metadata *metadata
+	payloads Payloads
 }
 
 // ResetPayloads clears out any recorded payloads.
@@ -102,11 +101,6 @@ func (r *RecorderTransport) Payloads() Payloads {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.payloads
-}
-
-// GetVersion returns the injected remoteVersion if any.
-func (r *RecorderTransport) GetVersion(context.Context) (string, error) {
-	return r.RemoteVersion, nil
 }
 
 func (r *RecorderTransport) record(ctx context.Context, stream io.Reader) error {
@@ -221,4 +215,16 @@ type metadata struct {
 	Service model.Service  `json:"service"`
 	Cloud   model.Cloud    `json:"cloud"`
 	Labels  model.IfaceMap `json:"labels,omitempty"`
+}
+
+// ServerVersionRecorderTransport wraps a RecorderTransport providing the
+type ServerVersionRecorderTransport struct {
+	ServerVersionError error
+	*RecorderTransport
+	ServerVersion int
+}
+
+// MajorServerVersion returns the stored version.
+func (r *ServerVersionRecorderTransport) MajorServerVersion(context.Context) (int, error) {
+	return r.ServerVersion, r.ServerVersionError
 }

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -216,15 +216,3 @@ type metadata struct {
 	Cloud   model.Cloud    `json:"cloud"`
 	Labels  model.IfaceMap `json:"labels,omitempty"`
 }
-
-// ServerVersionRecorderTransport wraps a RecorderTransport providing the
-type ServerVersionRecorderTransport struct {
-	ServerVersionError error
-	*RecorderTransport
-	ServerVersion int
-}
-
-// MajorServerVersion returns the stored version.
-func (r *ServerVersionRecorderTransport) MajorServerVersion(context.Context) (int, error) {
-	return r.ServerVersion, r.ServerVersionError
-}

--- a/transport/transporttest/recorder.go
+++ b/transport/transporttest/recorder.go
@@ -52,9 +52,10 @@ func NewRecorderTracer() (*apm.Tracer, *RecorderTransport) {
 // streams sent. The streams can be retrieved using the Payloads
 // method.
 type RecorderTransport struct {
-	mu       sync.Mutex
-	metadata *metadata
-	payloads Payloads
+	mu            sync.Mutex
+	metadata      *metadata
+	RemoteVersion string
+	payloads      Payloads
 }
 
 // ResetPayloads clears out any recorded payloads.
@@ -101,6 +102,11 @@ func (r *RecorderTransport) Payloads() Payloads {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.payloads
+}
+
+// GetVersion returns the injected remoteVersion if any.
+func (r *RecorderTransport) GetVersion(context.Context) (string, error) {
+	return r.RemoteVersion, nil
 }
 
 func (r *RecorderTransport) record(ctx context.Context, stream io.Reader) error {


### PR DESCRIPTION
## Description
Extends the HTTP Transport with a new method that queries the remote APM
Server `/` endpoint to obtain its version. Allowing the tracer to drop
unsampled transactions when the APM Server is version `8.0.0` or higher.

The version will be cached in a local variable until the APM Server URL
changes which will refresh the APM Server's version. The tracer launches
a goroutine to update the version when it is instantiated and refreshes
the remote server version every 10 seconds.

Any SendStream errors will cause the version cache to be invalidated and
will be refreshed the next time the ticker runs. It may cause unsampled
to be sent to the APM Server while the cache is invalid.

## Related Issues

Closes #1153 