### PR TITLE
add ParseTraceState() fn

### DIFF
--- a/tracecontext.go
+++ b/tracecontext.go
@@ -34,8 +34,9 @@ const (
 )
 
 var (
-	errZeroTraceID = errors.New("zero trace-id is invalid")
-	errZeroSpanID  = errors.New("zero span-id is invalid")
+	errZeroTraceID    = errors.New("zero trace-id is invalid")
+	errZeroSpanID     = errors.New("zero span-id is invalid")
+	errTooManyEntries = errors.New("tracestate contains more than the maximum allowed number of entries, 32")
 )
 
 // tracestateKeyRegexp holds a regular expression used for validating
@@ -204,6 +205,58 @@ func NewTraceState(entries ...TraceStateEntry) TraceState {
 	return out
 }
 
+// ParseTraceState attempts to decode a TraceState from the passed
+// string. It returns an error if the input is invalid according to the W3C
+// Trace Context specification.
+// Adapted from https://github.com/open-telemetry/opentelemetry-go/blob/trace/v1.3.0/trace/tracestate.go.
+func ParseTraceState(tracestate string) (TraceState, error) {
+	if tracestate == "" {
+		return TraceState{}, nil
+	}
+
+	wrapErr := func(err error) error {
+		return fmt.Errorf("failed to parse tracestate: %w", err)
+	}
+
+	members := strings.Split(tracestate, ",")
+	entries := make([]TraceStateEntry, 0, len(members))
+	found := make(map[string]struct{}, len(members))
+	for _, str := range members {
+		if len(str) == 0 {
+			continue
+		}
+
+		entry, err := parseEntry(str)
+		if err != nil {
+			return TraceState{}, wrapErr(err)
+		}
+
+		if _, ok := found[entry.Key]; ok {
+			return TraceState{}, wrapErr(fmt.Errorf("duplicate key found: %s", entry.Key))
+		}
+		found[entry.Key] = struct{}{}
+
+		entries = append(entries, entry)
+		if len(entries) > 32 {
+			return TraceState{}, wrapErr(errTooManyEntries)
+		}
+	}
+
+	return NewTraceState(entries...), nil
+}
+
+func parseEntry(m string) (TraceStateEntry, error) {
+	kv := strings.SplitN(m, "=", 2)
+	if len(kv) != 2 {
+		return TraceStateEntry{}, fmt.Errorf("invalid tracestate entry: %s", m)
+	}
+	tse := TraceStateEntry{
+		Key:   kv[0],
+		Value: kv[1],
+	}
+	return tse, tse.Validate()
+}
+
 // parseElasticTracestate parses an Elastic ("es") tracestate entry.
 //
 // Per https://github.com/elastic/apm/blob/main/specs/agents/tracing-distributed-tracing.md,
@@ -268,7 +321,7 @@ func (s TraceState) Validate() error {
 	var i int
 	for e := s.head; e != nil; e = e.next {
 		if i == 32 {
-			return errors.New("tracestate contains more than the maximum allowed number of entries, 32")
+			return errTooManyEntries
 		}
 		if e.Key == elasticTracestateVendorKey {
 			// s.parseElasticTracestateError holds a general e.Validate error if any

--- a/tracecontext_test.go
+++ b/tracecontext_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.elastic.co/apm/v2"
 )
@@ -103,6 +104,21 @@ func TestTraceStateElasticEntryFirst(t *testing.T) {
 	)
 	assert.NoError(t, ts.Validate())
 	assert.Equal(t, "es=s:1;a:b,z=w,a=d", ts.String())
+}
+
+func TestParseTraceState(t *testing.T) {
+	s := "es=s:1;a:b,z=w,a=d"
+	ts, err := apm.ParseTraceState(s)
+	require.NoError(t, err)
+	assert.NoError(t, ts.Validate())
+
+	assert.Equal(t, s, ts.String())
+
+	_, err = apm.ParseTraceState("~")
+	assert.Error(t, err)
+
+	_, err = apm.ParseTraceState("oy=" + strings.Repeat("*", 257))
+	assert.Error(t, err)
 }
 
 func TestTraceStateInvalidKey(t *testing.T) {


### PR DESCRIPTION
for setting TraceState when bridging another
tracing library implementation, for example
OpenTelemetry.

cf. https://github.com/elastic/apm-agent-go/pull/1203/commits/e27194e12120c865addece26b85fd7188fe5901d