### PR TITLE
ci: go master version stage is not triggered

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,32 +283,36 @@ pipeline {
 
 def generateStep(version){
   return {
-    node('linux && immutable'){
-      try {
-        echo "${version}"
-        withEnv(["GO_VERSION=${version}"]) {
-          // Another retry in case there are any environmental issues
-          // See https://issuetracker.google.com/issues/146072599 for more context
-          retry(3) {
-            deleteDir()
-            unstash 'source'
-          }
-          retry(3) {
-            dir("${BASE_DIR}"){
-              sh script: './scripts/jenkins/build.sh', label: 'Build'
-            }
-          }
+    runStep(version)
+  }
+}
+
+def runStep(version) {
+	node('linux && immutable'){
+    try {
+      echo "${version}"
+      withEnv(["GO_VERSION=${version}"]) {
+        // Another retry in case there are any environmental issues
+        // See https://issuetracker.google.com/issues/146072599 for more context
+        retry(3) {
+          deleteDir()
+          unstash 'source'
+        }
+        retry(3) {
           dir("${BASE_DIR}"){
-            sh script: './scripts/jenkins/test.sh', label: 'Test'
+            sh script: './scripts/jenkins/build.sh', label: 'Build'
           }
         }
-      } catch(e){
-        error(e.toString())
-      } finally {
-        junit(allowEmptyResults: true,
-          keepLongStdio: true,
-          testResults: "${BASE_DIR}/build/junit-*.xml")
+        dir("${BASE_DIR}"){
+          sh script: './scripts/jenkins/test.sh', label: 'Test'
+        }
       }
+    } catch(e){
+      error(e.toString())
+    } finally {
+      junit(allowEmptyResults: true,
+        keepLongStdio: true,
+        testResults: "${BASE_DIR}/build/junit-*.xml")
     }
   }
 }
@@ -316,7 +320,7 @@ def generateStep(version){
 def generateStepAndCatchError(version){
   return {
     catchError(buildResult: 'SUCCESS', message: 'Cutting Edge Tests', stageResult: 'UNSTABLE') {
-      generateStep(version)
+      runStep(version)
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -288,7 +288,7 @@ def generateStep(version){
 }
 
 def runStep(version) {
-	node('linux && immutable'){
+  node('linux && immutable'){
     try {
       echo "${version}"
       withEnv(["GO_VERSION=${version}"]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -307,8 +307,6 @@ def runStep(version) {
           sh script: './scripts/jenkins/test.sh', label: 'Test'
         }
       }
-    } catch(e){
-      error(e.toString())
     } finally {
       junit(allowEmptyResults: true,
         keepLongStdio: true,


### PR DESCRIPTION
### What

Fixes an issue with the `master` stage since a return closure within another return closure doesn't work

Simplify the try/finally and avoid to use the artificial error step, there is no need


<img width="806" alt="image" src="https://user-images.githubusercontent.com/2871786/154157819-ac44d44f-8edc-44c2-a0da-8904393b3835.png">
