### PR TITLE
Fix TestHTTPTransportWatchConfigContextCancelled

### DIFF
--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -552,6 +552,7 @@ func TestHTTPTransportWatchConfigQueryParams(t *testing.T) {
 func TestHTTPTransportWatchConfigContextCancelled(t *testing.T) {
 	transport, server := newHTTPTransport(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		<-req.Context().Done()
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
This test fails very rarely on my machine, but occasionally in CI. It can apparently happen that the (200 OK) response from the server is received by the client, despite the context having been cancelled. Make sure the handler returns an error to prevent this from leading to a change being delivered.