### PR TITLE
Fix TestHTTPTransportWatchConfigContextCancelled

### DIFF
--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -550,14 +550,14 @@ func TestHTTPTransportWatchConfigQueryParams(t *testing.T) {
 }
 
 func TestHTTPTransportWatchConfigContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	transport, server := newHTTPTransport(t, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cancel() // cancel client-side request context
 		<-req.Context().Done()
-		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
 
 	var watchParams apmconfig.WatchParams
 	watchParams.Service.Name = "name"


### PR DESCRIPTION
For real this time. It was still intermittently failing due to an i/o timeout being returned before the context was cancelled. Presumably some code is pulling the deadline out of the context, and returning an error with it has expired but the context cancellation timer hasn't yet fired.