### PR TITLE
Unexport all of Tracer's fields

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/apm-agent-go/compare/v1.15.0...main[View commits]
 - Remove WarningLogger, add Warningf methe to Logger {pull}1205[#(1205)]
 - Replace Sampler with ExtendedSampler {pull}1206[#(1206)]
 - Drop unsampled txs when connected to an APM Server >= 8.0 {pull}1208[#(1208)]
+- Unexport Tracer's fields -- TracerOptions must be used instead {pull}1219[#(1219)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,7 +40,6 @@ https://github.com/elastic/apm-agent-go/compare/v1.15.0...main[View commits]
 - Removed SetTag {pull}1218[(#1218)]
 - Unexport Tracer's fields -- TracerOptions must be used instead {pull}1219[#(1219)]
 
-
 [[release-notes-1.x]]
 === Go Agent version 1.x
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -33,7 +33,6 @@ import (
 	"go.elastic.co/apm/v2"
 	"go.elastic.co/apm/v2/apmtest"
 	"go.elastic.co/apm/v2/model"
-	"go.elastic.co/apm/v2/transport"
 	"go.elastic.co/apm/v2/transport/transporttest"
 )
 
@@ -551,11 +550,7 @@ func TestTransactionOutcome(t *testing.T) {
 }
 
 func BenchmarkTransaction(b *testing.B) {
-	tracer, err := apm.NewTracer("service", "")
-	require.NoError(b, err)
-
-	tracer.Transport = transport.Discard
-	defer tracer.Close()
+	tracer := apmtest.DiscardTracer
 
 	names := []string{}
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
All options should be set at construction time, and should be immutable there on.

This used to be safe when the Tracer did not actively make requests to APM Server until events were enqueued, but this is no longer the case.