### PR TITLE
use updated default service name

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -283,10 +281,7 @@ func initialService() (name, version, environment string) {
 	version = os.Getenv(envServiceVersion)
 	environment = os.Getenv(envEnvironment)
 	if name == "" {
-		name = filepath.Base(os.Args[0])
-		if runtime.GOOS == "windows" {
-			name = strings.TrimSuffix(name, filepath.Ext(name))
-		}
+		name = "unknown-go-service"
 	}
 	name = sanitizeServiceName(name)
 	return name, version, environment

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -141,16 +141,15 @@ your communications using HTTPS. Unless you do so, your API Key could be observe
 [options="header"]
 |============
 | Environment                | Default         | Example
-| `ELASTIC_APM_SERVICE_NAME` | Executable name | `my-app`
+| `ELASTIC_APM_SERVICE_NAME` | unknown-go-service | `my-app`
 |============
 
 The name of your service or application.  This is used to keep all the errors and
 transactions of your service together and is the primary filter in the Elastic APM
 user interface.
 
-If you do not specify `ELASTIC_APM_SERVICE_NAME`, the Go agent will use the
-executable name. e.g. if your executable is called "my-app.exe", then your
-service will be identified as "my-app".
+If you do not specify `ELASTIC_APM_SERVICE_NAME`, the Go agent will use
+`unknown-go-service`.
 
 NOTE: The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.
 In other words: your service name must only contain characters from the ASCII

--- a/env_test.go
+++ b/env_test.go
@@ -197,9 +197,9 @@ func TestTracerServiceNameEnvSanitizationSpecified(t *testing.T) {
 	assert.Equal(t, "foo_bar", service.Name)
 }
 
-func TestTracerServiceNameEnvSanitizationExecutableName(t *testing.T) {
+func TestTracerServiceNameDefault(t *testing.T) {
 	_, _, service, _ := getSubprocessMetadata(t)
-	assert.Equal(t, "apm_test", service.Name) // .test -> _test
+	assert.Equal(t, "unknown-go-service", service.Name)
 }
 
 func TestTracerGlobalLabelsUnspecified(t *testing.T) {

--- a/tracer.go
+++ b/tracer.go
@@ -90,7 +90,7 @@ type TracerOptions struct {
 	//
 	// If ServiceName is empty, the service name will be defined using the
 	// ELASTIC_APM_SERVICE_NAME environment variable, or if that is not set,
-	// the executable name.
+	// unknown-go-service will be used.
 	ServiceName string
 
 	// ServiceVersion holds the service version.


### PR DESCRIPTION
default service name is
`unknown-${service.agent.name}-service`, as
described in https://github.com/elastic/apm/blob/34f54c7b177ada87162f92595317edae5216311e/specs/agents/configuration.md#zero-configuration-support

closes #1162