### PR TITLE
Revert "use updated default service name"

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,7 +46,6 @@ https://github.com/elastic/apm-agent-go/compare/v2.0.0...main[View commits]
 - Removed SetTag {pull}1218[(#1218)]
 - Unexport Tracer's fields -- TracerOptions must be used instead {pull}1219[#(1219)]
 - Replace `authorization` with `*auth*` pattern for sanitizing field names {pull}1230[#(1230)]
-- Default service name is now `unknown-go-service` {pull}1231[#(1231)]
 
 [[release-notes-1.x]]
 === Go Agent version 1.x

--- a/config.go
+++ b/config.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -281,7 +283,10 @@ func initialService() (name, version, environment string) {
 	version = os.Getenv(envServiceVersion)
 	environment = os.Getenv(envEnvironment)
 	if name == "" {
-		name = "unknown-go-service"
+		name = filepath.Base(os.Args[0])
+		if runtime.GOOS == "windows" {
+			name = strings.TrimSuffix(name, filepath.Ext(name))
+		}
 	}
 	name = sanitizeServiceName(name)
 	return name, version, environment

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -141,15 +141,16 @@ your communications using HTTPS. Unless you do so, your API Key could be observe
 [options="header"]
 |============
 | Environment                | Default         | Example
-| `ELASTIC_APM_SERVICE_NAME` | unknown-go-service | `my-app`
+| `ELASTIC_APM_SERVICE_NAME` | Executable name | `my-app`
 |============
 
 The name of your service or application.  This is used to keep all the errors and
 transactions of your service together and is the primary filter in the Elastic APM
 user interface.
 
-If you do not specify `ELASTIC_APM_SERVICE_NAME`, the Go agent will use
-`unknown-go-service`.
+If you do not specify `ELASTIC_APM_SERVICE_NAME`, the Go agent will use the
+executable name. e.g. if your executable is called "my-app.exe", then your
+service will be identified as "my-app".
 
 NOTE: The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.
 In other words: your service name must only contain characters from the ASCII

--- a/env_test.go
+++ b/env_test.go
@@ -197,9 +197,9 @@ func TestTracerServiceNameEnvSanitizationSpecified(t *testing.T) {
 	assert.Equal(t, "foo_bar", service.Name)
 }
 
-func TestTracerServiceNameDefault(t *testing.T) {
+func TestTracerServiceNameEnvSanitizationExecutableName(t *testing.T) {
 	_, _, service, _ := getSubprocessMetadata(t)
-	assert.Equal(t, "unknown-go-service", service.Name)
+	assert.Equal(t, "apm_test", service.Name) // .test -> _test
 }
 
 func TestTracerGlobalLabelsUnspecified(t *testing.T) {

--- a/tracer.go
+++ b/tracer.go
@@ -90,7 +90,7 @@ type TracerOptions struct {
 	//
 	// If ServiceName is empty, the service name will be defined using the
 	// ELASTIC_APM_SERVICE_NAME environment variable, or if that is not set,
-	// unknown-go-service will be used.
+	// the executable name.
 	ServiceName string
 
 	// ServiceVersion holds the service version.


### PR DESCRIPTION
Reverts elastic/apm-agent-go#1231

From the spec:

> If possible, agents SHOULD detect sensible defaults for service.name and service.version. In any case agents MUST include service.name - if discovering it is not possible then the default value: unknown-${service.agent.name}-service MUST be used.

We were already doing the first bit ("detect sensible defaults") for service.name, so the fallback is not necessary. It's only necessary to use `unknown-${service.agent.name}-service` if a "sensible default" cannot be detected.