### PR TITLE
apm: fix race in DefaultTracer

### DIFF
--- a/tracer_test.go
+++ b/tracer_test.go
@@ -48,6 +48,24 @@ import (
 	"go.elastic.co/apm/v2/transport/transporttest"
 )
 
+func TestDefaultTracer(t *testing.T) {
+	defer apm.SetDefaultTracer(nil)
+
+	// Call DefaultTracer concurrently to ensure there are
+	// no races in creating the default tracer.
+	tracers := make(chan *apm.Tracer, 1000)
+	for i := 0; i < cap(tracers); i++ {
+		go func() {
+			tracers <- apm.DefaultTracer()
+		}()
+	}
+
+	tracer0 := <-tracers
+	for i := 1; i < cap(tracers); i++ {
+		assert.Same(t, tracer0, <-tracers)
+	}
+}
+
 func TestTracerStats(t *testing.T) {
 	tracer := apmtest.NewDiscardTracer()
 	defer tracer.Close()


### PR DESCRIPTION
Fix a race in DefaultTracer which could lead to two tracers being created, one of which would be closed.
We must hold the write lock while creating the default tracer, checking again that it was not set after releasing the read lock.

Fixes #1247 