### PR TITLE
synchronize schema spec

### DIFF
--- a/internal/apmschema/jsonschema/error.json
+++ b/internal/apmschema/jsonschema/error.json
@@ -622,30 +622,29 @@
                     "string"
                   ]
                 }
-              }
-            },
-            "target": {
-              "description": "Target holds information about the outgoing service in case of an outgoing event",
-              "type": [
-                "null",
-                "object"
-              ],
-              "properties": {
-                "name": {
-                  "description": "Immutable name of the target service for the event",
-                  "type": [
-                    "null",
-                    "string"
+              },
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
                   ]
                 },
-                "type": {
-                  "description": "Immutable type of the target service for the event",
-                  "type": [
-                    "null",
-                    "string"
+                {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
                   ]
                 }
-              }
+              ]
             },
             "version": {
               "description": "Version of the monitored service.",

--- a/internal/apmschema/jsonschema/span.json
+++ b/internal/apmschema/jsonschema/span.json
@@ -147,7 +147,7 @@
                   "maxLength": 1024
                 },
                 "resource": {
-                  "description": "Resource identifies the destination service resource being operated on e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name'",
+                  "description": "Resource identifies the destination service resource being operated on e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name' DEPRECATED: this field will be removed in a future release",
                   "type": "string",
                   "maxLength": 1024
                 },
@@ -537,30 +537,29 @@
                     "string"
                   ]
                 }
-              }
-            },
-            "target": {
-              "description": "Target holds information about the outgoing service in case of an outgoing event",
-              "type": [
-                "null",
-                "object"
-              ],
-              "properties": {
-                "name": {
-                  "description": "Immutable name of the target service for the event",
-                  "type": [
-                    "null",
-                    "string"
+              },
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
                   ]
                 },
-                "type": {
-                  "description": "Immutable type of the target service for the event",
-                  "type": [
-                    "null",
-                    "string"
+                {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
                   ]
                 }
-              }
+              ]
             },
             "version": {
               "description": "Version of the monitored service.",

--- a/internal/apmschema/jsonschema/transaction.json
+++ b/internal/apmschema/jsonschema/transaction.json
@@ -621,30 +621,29 @@
                     "string"
                   ]
                 }
-              }
-            },
-            "target": {
-              "description": "Target holds information about the outgoing service in case of an outgoing event",
-              "type": [
-                "null",
-                "object"
-              ],
-              "properties": {
-                "name": {
-                  "description": "Immutable name of the target service for the event",
-                  "type": [
-                    "null",
-                    "string"
+              },
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
                   ]
                 },
-                "type": {
-                  "description": "Immutable type of the target service for the event",
-                  "type": [
-                    "null",
-                    "string"
+                {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
                   ]
                 }
-              }
+              ]
             },
             "version": {
               "description": "Version of the monitored service.",
@@ -779,6 +778,22 @@
               "unknown",
               null
             ]
+          },
+          "service_target_name": {
+            "description": "ServiceTargetName identifies the instance name of the target service being operated on",
+            "type": [
+              "null",
+              "string"
+            ],
+            "maxLength": 512
+          },
+          "service_target_type": {
+            "description": "ServiceTargetType identifies the type of the target service being operated on e.g. 'oracle', 'rabbitmq'",
+            "type": [
+              "null",
+              "string"
+            ],
+            "maxLength": 512
           }
         }
       },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/72d58a75c Allow indexing of empty service.type (https://github.com/elastic/apm-server/pull/8155)