### PR TITLE
scripts: add workflow to add to APM github project

### DIFF
--- a/.github/workflows/addToAPMProject.yml
+++ b/.github/workflows/addToAPMProject.yml
@@ -1,0 +1,46 @@
+name: Add to APM Project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    name: Assign issues to APM Project for the Server Team
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:ID!,$contentid:ID!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAGc3Zs0VSg"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+      - uses: octokit/graphql-action@v2.x
+        id: label_team
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation label_team($projectid:ID!,$itemid:ID!,$fieldid:ID!,$value:String!) {
+              updateProjectNextItemField(input: { projectId:$projectid itemId:$itemid fieldId:$fieldid value:$value }) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          itemid: ${{ fromJSON(steps.add_to_project.outputs.data).addProjectNextItem.projectNextItem.id }}
+          fieldid: "MDE2OlByb2plY3ROZXh0RmllbGQ0NDE0Ng=="
+          value: "6c538d8a"
+        env:
+          PROJECT_ID: "PN_kwDOAGc3Zs0VSg"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}


### PR DESCRIPTION
Add all newly created issues to the APM project board, labeled with team `server` to ensure we keep track of issues in our planned work. 

The script is copied from the [APM Server workflow](https://github.com/elastic/apm-server/blob/main/.github/workflows/add-to-apm-project.yml).