### PR TITLE
Disable same kind, enable exact match compression by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,12 +66,11 @@ const (
 	envUseElasticTraceparentHeader = "ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER"
 	envCloudProvider               = "ELASTIC_APM_CLOUD_PROVIDER"
 
-	// NOTE(marclop) Experimental settings
-	// span_compression (default `false`)
+	// span_compression (default `true`)
 	envSpanCompressionEnabled = "ELASTIC_APM_SPAN_COMPRESSION_ENABLED"
 	// span_compression_exact_match_max_duration (default `50ms`)
 	envSpanCompressionExactMatchMaxDuration = "ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION"
-	// span_compression_same_kind_max_duration (default `5ms`)
+	// span_compression_same_kind_max_duration (default `0ms`)
 	envSpanCompressionSameKindMaxDuration = "ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION"
 
 	// exit_span_min_duration (default `1ms`)
@@ -104,10 +103,10 @@ const (
 	minMetricsBufferSize = 10 * configutil.KByte
 	maxMetricsBufferSize = 100 * configutil.MByte
 
-	// Experimental Span Compressions default setting values
-	defaultSpanCompressionEnabled               = false
+	// Span Compressions default setting values
+	defaultSpanCompressionEnabled               = true
 	defaultSpanCompressionExactMatchMaxDuration = 50 * time.Millisecond
-	defaultSpanCompressionSameKindMaxDuration   = 5 * time.Millisecond
+	defaultSpanCompressionSameKindMaxDuration   = 0
 )
 
 var (

--- a/config_test.go
+++ b/config_test.go
@@ -143,7 +143,7 @@ func TestTracerCentralConfigUpdate(t *testing.T) {
 		require.NoError(t, err)
 		return tracer.IgnoredTransactionURL(u)
 	})
-	run("span_compression_enabled", "true", func(tracer *apmtest.RecordingTracer) bool {
+	run("span_compression_enabled", "false", func(tracer *apmtest.RecordingTracer) bool {
 		tracer.ResetPayloads()
 		tx := tracer.StartTransaction("name", "type")
 		exitSpanOpts := apm.SpanOptions{ExitSpan: true}
@@ -154,12 +154,10 @@ func TestTracerCentralConfigUpdate(t *testing.T) {
 		}
 		tx.End()
 		tracer.Flush(nil)
-		return len(tracer.Payloads().Spans) == 1
+		return len(tracer.Payloads().Spans) == 2
 	})
 	run("span_compression_exact_match_max_duration", "100ms", func(tracer *apmtest.RecordingTracer) bool {
 		tracer.ResetPayloads()
-		tracer.SetSpanCompressionEnabled(true)
-		defer tracer.SetSpanCompressionEnabled(false)
 		tx := tracer.StartTransaction("name", "type")
 		exitSpanOpts := apm.SpanOptions{ExitSpan: true}
 		for i := 0; i < 2; i++ {
@@ -177,8 +175,6 @@ func TestTracerCentralConfigUpdate(t *testing.T) {
 	})
 	run("span_compression_same_kind_max_duration", "10ms", func(tracer *apmtest.RecordingTracer) bool {
 		tracer.ResetPayloads()
-		tracer.SetSpanCompressionEnabled(true)
-		defer tracer.SetSpanCompressionEnabled(false)
 		tx := tracer.StartTransaction("name", "type")
 		exitSpanOpts := apm.SpanOptions{ExitSpan: true}
 		for i := 0; i < 2; i++ {

--- a/span_test.go
+++ b/span_test.go
@@ -489,7 +489,7 @@ func TestCompressSpanSameKind(t *testing.T) {
 		// These should be compressed into 1 since they meet the compression
 		// criteria.
 		path := []string{"/a", "/b", "/c", "/d", "/e"}
-		for i := 0; i < 5; i++ {
+		for i := 0; i < len(path); i++ {
 			span := tx.StartSpanOptions(fmt.Sprint("GET ", path[i]), "request", apm.SpanOptions{
 				ExitSpan: true, Start: currentTime,
 			})
@@ -522,7 +522,7 @@ func TestCompressSpanSameKind(t *testing.T) {
 	}
 
 	t.Run("DefaultThreshold", func(t *testing.T) {
-		// With the default threshold the composite count will be 5.
+		// By default same kind compression is disabled thus count will be 7.
 		tracer := apmtest.NewRecordingTracer()
 		defer tracer.Close()
 		tracer.SetSpanCompressionEnabled(true)
@@ -532,21 +532,16 @@ func TestCompressSpanSameKind(t *testing.T) {
 		_, spans, debugFunc := testCase(tracer)
 		defer debugFunc()
 
-		require.Equal(t, 3, len(spans))
+		require.Equal(t, 7, len(spans))
 		mysqlSpan := spans[0]
 		assert.Equal(t, "mysql", mysqlSpan.Context.Destination.Service.Resource)
 		assert.Nil(t, mysqlSpan.Composite)
 
 		requestSpan := spans[1]
 		assert.Equal(t, "request", requestSpan.Context.Destination.Service.Resource)
-		require.NotNil(t, requestSpan.Composite)
-		assert.Equal(t, 5, requestSpan.Composite.Count)
-		assert.Equal(t, "same_kind", requestSpan.Composite.CompressionStrategy)
-		assert.Equal(t, "Calls to request", requestSpan.Name)
-		// Check that the sum and span duration is at least the duration of the time set.
-		assert.Equal(t, 0.0005, requestSpan.Composite.Sum, requestSpan.Composite.Sum)
-		assert.Equal(t, 0.0005, requestSpan.Duration, requestSpan.Duration)
+		require.Nil(t, requestSpan.Composite)
 	})
+
 	t.Run("10msThreshold", func(t *testing.T) {
 		// With this threshold the composite count will be 6.
 		os.Setenv("ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION", "10ms")
@@ -599,6 +594,7 @@ func TestCompressSpanSameKindParentSpan(t *testing.T) {
 	tracer := apmtest.NewRecordingTracer()
 	tracer.SetSpanCompressionEnabled(true)
 	tracer.SetExitSpanMinDuration(0)
+	tracer.SetSpanCompressionSameKindMaxDuration(5 * time.Millisecond)
 
 	// This test case covers spans that have other spans as parents.
 	// |_______________transaction (6b1e4866252dea6f) - 1.45ms________________|
@@ -708,6 +704,7 @@ func TestCompressSpanSameKindParentSpanContext(t *testing.T) {
 	tracer := apmtest.NewRecordingTracer()
 	tracer.SetSpanCompressionEnabled(true)
 	tracer.SetExitSpanMinDuration(0)
+	tracer.SetSpanCompressionSameKindMaxDuration(5 * time.Millisecond)
 
 	txStart := time.Now()
 	tx := tracer.StartTransactionOptions("name", "type",
@@ -951,6 +948,7 @@ func TestCompressSpanPrematureEnd(t *testing.T) {
 			defer tracer.Close()
 			tracer.SetSpanCompressionEnabled(true)
 			tracer.SetExitSpanMinDuration(test.exitSpanMinDuration)
+			tracer.SetSpanCompressionSameKindMaxDuration(5 * time.Millisecond)
 
 			txStart := time.Now()
 			tx := tracer.StartTransaction("name", "type")
@@ -1001,6 +999,7 @@ func TestCompressSpanPrematureEnd(t *testing.T) {
 		defer tracer.Close()
 		tracer.SetSpanCompressionEnabled(true)
 		tracer.SetExitSpanMinDuration(time.Nanosecond)
+		tracer.SetSpanCompressionSameKindMaxDuration(5 * time.Millisecond)
 
 		tx := tracer.StartTransaction("name", "type")
 		ctx := apm.ContextWithTransaction(context.Background(), tx)
@@ -1036,6 +1035,7 @@ func TestCompressSpanPrematureEnd(t *testing.T) {
 		defer tracer.Close()
 		tracer.SetSpanCompressionEnabled(true)
 		tracer.SetExitSpanMinDuration(time.Nanosecond)
+		tracer.SetSpanCompressionSameKindMaxDuration(5 * time.Millisecond)
 
 		tx := tracer.StartTransaction("name", "type")
 		parent := tx.StartSpan("parent", "internal", nil)

--- a/span_test.go
+++ b/span_test.go
@@ -521,7 +521,7 @@ func TestCompressSpanSameKind(t *testing.T) {
 		return transaction, spans, debugFunc
 	}
 
-	t.Run("DefaultThreshold", func(t *testing.T) {
+	t.Run("DefaultDisabled", func(t *testing.T) {
 		// By default same kind compression is disabled thus count will be 7.
 		tracer := apmtest.NewRecordingTracer()
 		defer tracer.Close()

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -419,6 +419,7 @@ func TestTransactionDroppedSpansStats(t *testing.T) {
 	t.Run("DefaultLimit", func(t *testing.T) {
 		tracer := apmtest.NewRecordingTracer()
 		defer tracer.Close()
+		tracer.SetSpanCompressionEnabled(false)
 
 		tx, _, _ := tracer.WithTransaction(func(ctx context.Context) {
 			generateSpans(ctx, 1000)
@@ -446,6 +447,7 @@ func TestTransactionDroppedSpansStats(t *testing.T) {
 		defer tracer.Close()
 		// Set the exit span minimum duration. This test asserts that spans
 		// with a duration over the span minimum duration are not dropped.
+		tracer.SetSpanCompressionEnabled(false)
 		tracer.SetExitSpanMinDuration(time.Microsecond)
 
 		// Each of the generated spans duration is 10 microseconds.
@@ -460,6 +462,7 @@ func TestTransactionDroppedSpansStats(t *testing.T) {
 		tracer := apmtest.NewRecordingTracer()
 		defer tracer.Close()
 		// Assert that any spans over 100 are dropped and stats are aggregated.
+		tracer.SetSpanCompressionEnabled(false)
 		tracer.SetMaxSpans(100)
 
 		tx, spans, _ := tracer.WithTransaction(func(ctx context.Context) {


### PR DESCRIPTION
As per the updated span compression specs:

1. Disables same kind compression by default
2. Enable exact match compression by default

Closes #1229 