### PR TITLE
Add Faas fields to metricset model

### DIFF
--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1612,6 +1612,16 @@ func (v *Faas) MarshalFastJSON(w *fastjson.Writer) error {
 	var firstErr error
 	w.RawByte('{')
 	first := true
+	if v.Coldstart != false {
+		const prefix = ",\"coldstart\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.Bool(v.Coldstart)
+	}
 	if v.Execution != "" {
 		const prefix = ",\"execution\":"
 		if first {

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1611,67 +1611,28 @@ func (v *MetricsSpan) MarshalFastJSON(w *fastjson.Writer) error {
 func (v *Faas) MarshalFastJSON(w *fastjson.Writer) error {
 	var firstErr error
 	w.RawByte('{')
-	first := true
-	if v.Coldstart != false {
-		const prefix = ",\"coldstart\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
-		w.Bool(v.Coldstart)
-	}
+	w.RawString("\"coldstart\":")
+	w.Bool(v.Coldstart)
 	if v.Execution != "" {
-		const prefix = ",\"execution\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
+		w.RawString(",\"execution\":")
 		w.String(v.Execution)
 	}
 	if v.ID != "" {
-		const prefix = ",\"id\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
+		w.RawString(",\"id\":")
 		w.String(v.ID)
 	}
 	if v.Name != "" {
-		const prefix = ",\"name\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
+		w.RawString(",\"name\":")
 		w.String(v.Name)
 	}
 	if v.Trigger != nil {
-		const prefix = ",\"trigger\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
+		w.RawString(",\"trigger\":")
 		if err := v.Trigger.MarshalFastJSON(w); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	if v.Version != "" {
-		const prefix = ",\"version\":"
-		if first {
-			first = false
-			w.RawString(prefix[1:])
-		} else {
-			w.RawString(prefix)
-		}
+		w.RawString(",\"version\":")
 		w.String(v.Version)
 	}
 	w.RawByte('}')

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -1608,7 +1608,7 @@ func (v *MetricsSpan) MarshalFastJSON(w *fastjson.Writer) error {
 	return nil
 }
 
-func (v *Faas) MarshalFastJSON(w *fastjson.Writer) error {
+func (v *FAAS) MarshalFastJSON(w *fastjson.Writer) error {
 	var firstErr error
 	w.RawByte('{')
 	w.RawString("\"coldstart\":")
@@ -1639,7 +1639,7 @@ func (v *Faas) MarshalFastJSON(w *fastjson.Writer) error {
 	return firstErr
 }
 
-func (v *FaasTrigger) MarshalFastJSON(w *fastjson.Writer) error {
+func (v *FAASTrigger) MarshalFastJSON(w *fastjson.Writer) error {
 	w.RawByte('{')
 	first := true
 	if v.RequestID != "" {

--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -525,6 +525,12 @@ func (v *Transaction) MarshalFastJSON(w *fastjson.Writer) error {
 		}
 		w.RawByte(']')
 	}
+	if v.FAAS != nil {
+		w.RawString(",\"faas\":")
+		if err := v.FAAS.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if v.OTel != nil {
 		w.RawString(",\"otel\":")
 		if err := v.OTel.MarshalFastJSON(w); err != nil && firstErr == nil {
@@ -1520,6 +1526,12 @@ func (v *Metrics) MarshalFastJSON(w *fastjson.Writer) error {
 	if err := v.Timestamp.MarshalFastJSON(w); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	if v.FAAS != nil {
+		w.RawString(",\"faas\":")
+		if err := v.FAAS.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if !v.Span.isZero() {
 		w.RawString(",\"span\":")
 		if err := v.Span.MarshalFastJSON(w); err != nil && firstErr == nil {
@@ -1581,6 +1593,93 @@ func (v *MetricsSpan) MarshalFastJSON(w *fastjson.Writer) error {
 			w.RawString(prefix)
 		}
 		w.String(v.Subtype)
+	}
+	if v.Type != "" {
+		const prefix = ",\"type\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Type)
+	}
+	w.RawByte('}')
+	return nil
+}
+
+func (v *Faas) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
+	w.RawByte('{')
+	first := true
+	if v.Execution != "" {
+		const prefix = ",\"execution\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Execution)
+	}
+	if v.ID != "" {
+		const prefix = ",\"id\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.ID)
+	}
+	if v.Name != "" {
+		const prefix = ",\"name\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Name)
+	}
+	if v.Trigger != nil {
+		const prefix = ",\"trigger\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.Trigger.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if v.Version != "" {
+		const prefix = ",\"version\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.Version)
+	}
+	w.RawByte('}')
+	return firstErr
+}
+
+func (v *FaasTrigger) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	first := true
+	if v.RequestID != "" {
+		const prefix = ",\"request_id\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		w.String(v.RequestID)
 	}
 	if v.Type != "" {
 		const prefix = ",\"type\":"

--- a/model/model.go
+++ b/model/model.go
@@ -278,6 +278,8 @@ type Transaction struct {
 
 	// OTel holds information bridged from OpenTelemetry.
 	OTel *OTel `json:"otel,omitempty"`
+
+	FAAS *Faas `json:"faas,omitempty"`
 }
 
 // OTel holds bridged OpenTelemetry information.
@@ -811,6 +813,8 @@ type Metrics struct {
 	// with the common schema, anyway.
 	Labels StringMap `json:"tags,omitempty"`
 
+	FAAS *Faas `json:"faas,omitempty"`
+
 	// Samples holds a map of metric samples, keyed by metric name.
 	Samples map[string]Metric `json:"samples"`
 }
@@ -836,4 +840,24 @@ type Metric struct {
 	Values []float64 `json:"values,omitempty"`
 	// Count holds the metric observation count for the bucket.
 	Counts []uint64 `json:"counts,omitempty"`
+}
+
+type Faas struct {
+	// A unique identifier of the invoked serverless function.
+	ID string `json:"id,omitempty"`
+	// The request id of the function invocation.
+	Execution string `json:"execution,omitempty"`
+	// Trigger attributes.
+	Trigger *FaasTrigger `json:"trigger,omitempty"`
+	// The lambda function name.
+	Name string `json:"name,omitempty"`
+	// The lambda function version.
+	Version string `json:"version,omitempty"`
+}
+
+type FaasTrigger struct {
+	// The trigger type.
+	Type string `json:"type,omitempty"`
+	// The id of the origin trigger request.
+	RequestID string `json:"request_id,omitempty"`
 }

--- a/model/model.go
+++ b/model/model.go
@@ -279,7 +279,8 @@ type Transaction struct {
 	// OTel holds information bridged from OpenTelemetry.
 	OTel *OTel `json:"otel,omitempty"`
 
-	FAAS *Faas `json:"faas,omitempty"`
+	// FAAS holds Function-as-a-Service properties for the transaction.
+	FAAS *FAAS `json:"faas,omitempty"`
 }
 
 // OTel holds bridged OpenTelemetry information.
@@ -813,7 +814,8 @@ type Metrics struct {
 	// with the common schema, anyway.
 	Labels StringMap `json:"tags,omitempty"`
 
-	FAAS *Faas `json:"faas,omitempty"`
+	// FAAS holds Function-as-a-Service related properties for the metrics.
+	FAAS *FAAS `json:"faas,omitempty"`
 
 	// Samples holds a map of metric samples, keyed by metric name.
 	Samples map[string]Metric `json:"samples"`
@@ -836,30 +838,32 @@ type Metric struct {
 	Type string `json:"type,omitempty"`
 	// Value holds the metric value.
 	Value float64 `json:"value"`
-	// Buckets holds the metric bucket values.
+	// Values holds the metric bucket values.
 	Values []float64 `json:"values,omitempty"`
-	// Count holds the metric observation count for the bucket.
+	// Counts holds the metric observation count for the bucket.
 	Counts []uint64 `json:"counts,omitempty"`
 }
 
-type Faas struct {
-	// A unique identifier of the invoked serverless function.
+// FAAS holds Function-as-a-Service properties.
+type FAAS struct {
+	// ID holds a unique identifier of the invoked serverless function.
 	ID string `json:"id,omitempty"`
-	// The request id of the function invocation.
+	// Execution holds the request ID of the function invocation.
 	Execution string `json:"execution,omitempty"`
-	// Trigger attributes.
-	Trigger *FaasTrigger `json:"trigger,omitempty"`
-	// The lambda function name.
+	// Trigger holds information related to the trigger of the function invocation.
+	Trigger *FAASTrigger `json:"trigger,omitempty"`
+	// Name holds the lambda function name.
 	Name string `json:"name,omitempty"`
-	// The lambda function version.
+	// Version holds the lambda function version.
 	Version string `json:"version,omitempty"`
-	// Indicates if the lambda function triggered a Cold Start
+	// Coldstart indicates if the lambda function triggered a Cold Start
 	Coldstart bool `json:"coldstart"`
 }
 
-type FaasTrigger struct {
-	// The trigger type.
+// FAASTrigger holds information related to the trigger of a Function-as-a-Service invocation.
+type FAASTrigger struct {
+	// Type holds the trigger type.
 	Type string `json:"type,omitempty"`
-	// The id of the origin trigger request.
+	// RequestID holds the ID of the origin trigger request.
 	RequestID string `json:"request_id,omitempty"`
 }

--- a/model/model.go
+++ b/model/model.go
@@ -854,7 +854,7 @@ type Faas struct {
 	// The lambda function version.
 	Version string `json:"version,omitempty"`
 	// Indicates if the lambda function triggered a Cold Start
-	Coldstart bool `json:"coldstart,omitempty"`
+	Coldstart bool `json:"coldstart"`
 }
 
 type FaasTrigger struct {

--- a/model/model.go
+++ b/model/model.go
@@ -854,7 +854,7 @@ type Faas struct {
 	// The lambda function version.
 	Version string `json:"version,omitempty"`
 	// Indicates if the lambda function triggered a Cold Start
-	Coldstart *bool `json:"coldstart,omitempty"`
+	Coldstart bool `json:"coldstart,omitempty"`
 }
 
 type FaasTrigger struct {

--- a/model/model.go
+++ b/model/model.go
@@ -853,6 +853,8 @@ type Faas struct {
 	Name string `json:"name,omitempty"`
 	// The lambda function version.
 	Version string `json:"version,omitempty"`
+	// Indicates if the lambda function triggered a Cold Start
+	Coldstart *bool `json:"coldstart,omitempty"`
 }
 
 type FaasTrigger struct {


### PR DESCRIPTION
### Motivation / Summary
Allows the APM Lambda extension to generate and populate the `faas.*` fields for each of the metricsets by modifying the APM model.

This PR is directly related to https://github.com/elastic/apm-aws-lambda/pull/220 (details and test plan are included)