### PR TITLE
Expose method to get metadata collected by agent

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -862,6 +862,7 @@ func (t *Tracer) GetECSMetadata() map[string]interface{} {
 	if t.process != nil {
 		process := make(map[string]interface{})
 		process["title"] = t.process.Title
+		process["pid"] = t.process.Pid
 		process["parent"] = map[string]interface{}{
 			"pid": t.process.Ppid,
 		}


### PR DESCRIPTION
## Motivation

Agent collects rich metadata about service, process and system. The metadata can be used to enrich information collected by other libraries. One possible use case can be to enrich logs shipped by custom log appenders.