### PR TITLE
ci: use the microbenchmarks-pool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
           }
         }
         stage('Benchmark') {
-          agent { label 'linux && immutable' }
+          agent { label 'microbenchmarks-pool' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true


### PR DESCRIPTION
### What

From now on we will use the same CI workers for the benchmarking
