### PR TITLE
ci: use Orka workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,7 +187,7 @@ pipeline {
           }
         }
         stage('OSX') {
-          agent { label 'macosx && x86_64' }
+          agent { label 'macos12 && x86_64' }
           options { skipDefaultCheckout() }
           environment {
             GO_VERSION = "${params.GO_VERSION}"


### PR DESCRIPTION
No more static workers but Orka workers therefore the labels have changed