### PR TITLE
feat: implement trace_continuation_strategy

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -143,6 +143,24 @@ func TestTracerCentralConfigUpdate(t *testing.T) {
 		require.NoError(t, err)
 		return tracer.IgnoredTransactionURL(u)
 	})
+	run("trace_continuation_strategy", "restart", func(tracer *apmtest.RecordingTracer) bool {
+		tracer.ResetPayloads()
+
+		traceID := apm.TraceID{1}
+
+		tx := tracer.StartTransactionOptions("name", "type", apm.TransactionOptions{TraceContext: apm.TraceContext{
+			Trace: traceID,
+			Span:  apm.SpanID{2},
+		}})
+		tx.End()
+
+		tracer.Flush(nil)
+		payloads := tracer.Payloads()
+		txs := payloads.Transactions
+		require.Len(t, txs, 1)
+
+		return apm.TraceID(txs[0].TraceID) != traceID && len(txs[0].Links) == 1 && apm.TraceID(txs[0].Links[0].TraceID) == traceID
+	})
 	run("span_compression_enabled", "false", func(tracer *apmtest.RecordingTracer) bool {
 		tracer.ResetPayloads()
 		tx := tracer.StartTransaction("name", "type")

--- a/module/apmhttp/handler_test.go
+++ b/module/apmhttp/handler_test.go
@@ -502,50 +502,6 @@ func TestHandlerTraceparentHeader(t *testing.T) {
 	}
 }
 
-func TestHandleContinuationStrategy(t *testing.T) {
-	tracer, transport := transporttest.NewRecorderTracer()
-	defer tracer.Close()
-
-	mux := http.NewServeMux()
-	mux.Handle("/foo", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(http.StatusTeapot)
-	}))
-
-	const traceparentValue = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-	makeReq := func(headers ...string) *http.Request {
-		req, _ := http.NewRequest("GET", "http://server.testing/foo", nil)
-		for i := 0; i < len(headers); i += 2 {
-			req.Header.Set(headers[i], headers[i+1])
-		}
-		return req
-	}
-
-	h := apmhttp.Wrap(mux, apmhttp.WithTracer(tracer))
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, makeReq("Elastic-Apm-Traceparent", traceparentValue))
-
-	tracer.SetContinuationStrategy("restart")
-
-	h.ServeHTTP(w, makeReq("traceparent", traceparentValue))
-	tracer.Flush(nil)
-
-	payloads := transport.Payloads()
-	require.Len(t, payloads.Transactions, 2)
-
-	first := payloads.Transactions[0]
-	assert.Equal(t, "0af7651916cd43dd8448eb211c80319c", apm.TraceID(first.TraceID).String())
-	assert.Equal(t, "b7ad6b7169203331", apm.SpanID(first.ParentID).String())
-	assert.NotZero(t, first.ID)
-
-	second := payloads.Transactions[1]
-	assert.NotEqual(t, first.TraceID, second.TraceID)
-	assert.NotEqual(t, first.ParentID, second.ParentID)
-	assert.Len(t, second.Links, 1)
-	link := second.Links[0]
-	assert.Equal(t, first.TraceID, link.TraceID)
-	assert.Equal(t, first.ParentID, link.SpanID)
-}
-
 func TestHandlerTracestateHeader(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle("/foo", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/tracecontext.go
+++ b/tracecontext.go
@@ -170,6 +170,7 @@ type TraceState struct {
 	// These must not be modified after NewTraceState returns.
 	parseElasticTracestateError error
 	haveSampleRate              bool
+	haveElastic                 bool
 	sampleRate                  float64
 }
 
@@ -206,6 +207,7 @@ func NewTraceState(entries ...TraceStateEntry) TraceState {
 	}
 	if haveElastic {
 		out.parseElasticTracestateError = out.parseElasticTracestate(*out.head)
+		out.haveElastic = true
 	}
 	return out
 }

--- a/transaction.go
+++ b/transaction.go
@@ -78,8 +78,29 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	tx.Context.sanitizedFieldNames = instrumentationConfig.sanitizedFieldNames
 	tx.breakdownMetricsEnabled = t.breakdownMetrics.enabled
 
+	continuationStrategy := instrumentationConfig.continuationStrategy
+	shouldRestartTrace := false
+	if continuationStrategy == "restart_external" {
+		if opts.TraceContext.State.haveElastic {
+			continuationStrategy = "continue"
+		} else {
+			continuationStrategy = "restart"
+		}
+	}
+
+	if continuationStrategy == "restart" {
+		if !opts.TraceContext.Trace.isZero() && !opts.TraceContext.Span.isZero() {
+			link := SpanLink{
+				Trace: opts.TraceContext.Trace,
+				Span:  opts.TraceContext.Span,
+			}
+			tx.links = append(tx.links, link)
+			shouldRestartTrace = true
+		}
+	}
+
 	var root bool
-	if opts.TraceContext.Trace.Validate() == nil {
+	if opts.TraceContext.Trace.Validate() == nil && !shouldRestartTrace {
 		tx.traceContext.Trace = opts.TraceContext.Trace
 		tx.traceContext.Options = opts.TraceContext.Options
 		if opts.TraceContext.Span.Validate() == nil {
@@ -147,7 +168,7 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	if tx.timestamp.IsZero() {
 		tx.timestamp = time.Now()
 	}
-	tx.links = opts.Links
+	tx.links = append(tx.links, opts.Links...)
 	return tx
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -101,6 +101,16 @@ func TestContinuationStrategy(t *testing.T) {
 			expectNewTraceID: true,
 			expectSpanLink:   true,
 		},
+		"restart with es": {
+			traceContext: apm.TraceContext{
+				Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+				Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+				State: apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "s:0.5"}),
+			},
+			strategy:         "restart",
+			expectNewTraceID: true,
+			expectSpanLink:   true,
+		},
 		"continue": {
 			traceContext: apm.TraceContext{
 				Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -85,6 +85,98 @@ func startTransactionInvalidTraceContext(t *testing.T, traceContext apm.TraceCon
 	tx.Discard()
 }
 
+func TestContinuationStrategy(t *testing.T) {
+	testCases := map[string]struct {
+		traceContext     apm.TraceContext
+		strategy         string
+		expectNewTraceID bool
+		expectSpanLink   bool
+	}{
+		"restart": {
+			traceContext: apm.TraceContext{
+				Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+				Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+			},
+			strategy:         "restart",
+			expectNewTraceID: true,
+			expectSpanLink:   true,
+		},
+		"continue": {
+			traceContext: apm.TraceContext{
+				Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+				Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+			},
+			strategy:         "continue",
+			expectNewTraceID: false,
+			expectSpanLink:   false,
+		},
+		"restart_external": {
+			traceContext: apm.TraceContext{
+				Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+				Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+			},
+			strategy:         "restart_external",
+			expectNewTraceID: true,
+			expectSpanLink:   true,
+		},
+		"restart_external with missing header": {
+			traceContext:     apm.TraceContext{},
+			strategy:         "restart_external",
+			expectNewTraceID: true,
+			expectSpanLink:   false,
+		},
+		"restart_external with es": {
+			traceContext: apm.TraceContext{
+				Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+				Span:  apm.SpanID{0, 1, 2, 3, 4, 5, 6, 7},
+				State: apm.NewTraceState(apm.TraceStateEntry{Key: "es", Value: "s:0.5"}),
+			},
+			strategy:         "restart_external",
+			expectNewTraceID: false,
+			expectSpanLink:   false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tracer, transport := transporttest.NewRecorderTracer()
+			defer tracer.Close()
+
+			tracer.SetContinuationStrategy(tc.strategy)
+
+			providedSpanID := model.SpanID(tc.traceContext.Span)
+			providedTraceID := model.TraceID(tc.traceContext.Trace)
+
+			tx := tracer.StartTransactionOptions("name", "type", apm.TransactionOptions{
+				TraceContext: tc.traceContext,
+			})
+			tx.End()
+
+			tracer.Flush(nil)
+			payloads := transport.Payloads()
+
+			require.Len(t, payloads.Transactions, 1)
+
+			tr := payloads.Transactions[0]
+			assert.NotZero(t, tr.ID)
+
+			if tc.expectNewTraceID {
+				assert.NotEqual(t, providedTraceID, tr.TraceID)
+			} else {
+				assert.Equal(t, providedTraceID, tr.TraceID)
+			}
+
+			if tc.expectSpanLink {
+				assert.Len(t, tr.Links, 1)
+				link := tr.Links[0]
+				assert.Equal(t, providedTraceID, link.TraceID)
+				assert.Equal(t, providedSpanID, link.SpanID)
+			} else {
+				assert.Empty(t, tr.Links)
+			}
+		})
+	}
+}
+
 func TestStartTransactionTraceParentSpanIDSpecified(t *testing.T) {
 	startTransactionIDSpecified(t, apm.TraceContext{
 		Trace: apm.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},


### PR DESCRIPTION
Add ELASTIC_APM_TRACE_CONTINUATION_STRATEGY variable to change the
continuation strategy. (Default to 'continue')

Add test to verify trace ids are different and span links are
populated properly.

Closes https://github.com/elastic/apm-agent-go/issues/1221