### PR TITLE
fix: default to custom for empty transaction and span types

### DIFF
--- a/span.go
+++ b/span.go
@@ -225,6 +225,9 @@ type SpanOptions struct {
 }
 
 func (t *Tracer) startSpan(name, spanType string, transactionID SpanID, opts SpanOptions) *Span {
+	if spanType == "" {
+		spanType = "custom"
+	}
 	sd, _ := t.spanDataPool.Get().(*SpanData)
 	if sd == nil {
 		sd = &SpanData{Duration: -1}

--- a/span.go
+++ b/span.go
@@ -225,9 +225,6 @@ type SpanOptions struct {
 }
 
 func (t *Tracer) startSpan(name, spanType string, transactionID SpanID, opts SpanOptions) *Span {
-	if spanType == "" {
-		spanType = "custom"
-	}
 	sd, _ := t.spanDataPool.Get().(*SpanData)
 	if sd == nil {
 		sd = &SpanData{Duration: -1}
@@ -344,6 +341,9 @@ func (s *Span) End() {
 	defer s.mu.Unlock()
 	if s.ended() {
 		return
+	}
+	if s.Type == "" {
+		s.Type = "custom"
 	}
 	if s.exit && !s.Context.setDestinationServiceCalled {
 		// The span was created as an exit span, but the user did not

--- a/span_test.go
+++ b/span_test.go
@@ -118,6 +118,22 @@ func TestSpanParentID(t *testing.T) {
 	assert.Equal(t, model.SpanID(parentID), payloads.Spans[0].ParentID)
 }
 
+func TestSpanEnsureType(t *testing.T) {
+	tracer := apmtest.NewRecordingTracer()
+	defer tracer.Close()
+
+	tx := tracer.StartTransaction("name", "type")
+	span := tx.StartSpan("name", "", nil)
+	span.End()
+	tx.End()
+	tracer.Flush(nil)
+
+	payloads := tracer.Payloads()
+	require.Len(t, payloads.Spans, 1)
+
+	assert.NotEmpty(t, payloads.Spans[0].Type)
+}
+
 func TestSpanLink(t *testing.T) {
 	tracer := apmtest.NewRecordingTracer()
 	defer tracer.Close()

--- a/span_test.go
+++ b/span_test.go
@@ -131,7 +131,7 @@ func TestSpanEnsureType(t *testing.T) {
 	payloads := tracer.Payloads()
 	require.Len(t, payloads.Spans, 1)
 
-	assert.NotEmpty(t, payloads.Spans[0].Type)
+	assert.Equal(t, "custom", payloads.Spans[0].Type)
 }
 
 func TestSpanLink(t *testing.T) {

--- a/transaction.go
+++ b/transaction.go
@@ -42,6 +42,10 @@ func (t *Tracer) StartTransaction(name, transactionType string) *Transaction {
 // StartTransactionOptions returns a new Transaction with the
 // specified name, type, and options.
 func (t *Tracer) StartTransactionOptions(name, transactionType string, opts TransactionOptions) *Transaction {
+	if transactionType == "" {
+		transactionType = "custom"
+	}
+
 	td, _ := t.transactionDataPool.Get().(*TransactionData)
 	if td == nil {
 		td = &TransactionData{

--- a/transaction.go
+++ b/transaction.go
@@ -42,10 +42,6 @@ func (t *Tracer) StartTransaction(name, transactionType string) *Transaction {
 // StartTransactionOptions returns a new Transaction with the
 // specified name, type, and options.
 func (t *Tracer) StartTransactionOptions(name, transactionType string, opts TransactionOptions) *Transaction {
-	if transactionType == "" {
-		transactionType = "custom"
-	}
-
 	td, _ := t.transactionDataPool.Get().(*TransactionData)
 	if td == nil {
 		td = &TransactionData{
@@ -286,6 +282,9 @@ func (tx *Transaction) End() {
 	defer tx.mu.Unlock()
 	if tx.ended() {
 		return
+	}
+	if tx.Type == "" {
+		tx.Type = "custom"
 	}
 	if tx.recording {
 		if tx.Duration < 0 {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -153,7 +153,7 @@ func TestTransactionEnsureType(t *testing.T) {
 
 	payloads := transport.Payloads()
 	require.Len(t, payloads.Transactions, 1)
-	assert.NotEmpty(t, payloads.Transactions[0].Type)
+	assert.Equal(t, "custom", payloads.Transactions[0].Type)
 }
 
 func TestTransactionParentID(t *testing.T) {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -143,6 +143,19 @@ func TestTransactionEnsureParent(t *testing.T) {
 	assert.Equal(t, model.SpanID(parentSpan), payloads.Transactions[0].ParentID)
 }
 
+func TestTransactionEnsureType(t *testing.T) {
+	tracer, transport := transporttest.NewRecorderTracer()
+	defer tracer.Close()
+
+	tx := tracer.StartTransaction("name", "")
+	tx.End()
+	tracer.Flush(nil)
+
+	payloads := transport.Payloads()
+	require.Len(t, payloads.Transactions, 1)
+	assert.NotEmpty(t, payloads.Transactions[0].Type)
+}
+
 func TestTransactionParentID(t *testing.T) {
 	tracer := apmtest.NewRecordingTracer()
 	defer tracer.Close()


### PR DESCRIPTION
According to the spec:

If no transaction.type or span.type is provided or the value
is an empty string, the agent needs to set a default value
custom.

Add test to assert the behaviour is compliant to the spec.

Closes https://github.com/elastic/apm-agent-go/issues/1211