### PR TITLE
feat: add service target fields

### DIFF
--- a/model/marshal_fastjson.go
+++ b/model/marshal_fastjson.go
@@ -800,6 +800,18 @@ func (v *SpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 			firstErr = err
 		}
 	}
+	if v.Service != nil {
+		const prefix = ",\"service\":"
+		if first {
+			first = false
+			w.RawString(prefix[1:])
+		} else {
+			w.RawString(prefix)
+		}
+		if err := v.Service.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if !v.Tags.isZero() {
 		const prefix = ",\"tags\":"
 		if first {
@@ -881,6 +893,31 @@ func (v *DestinationSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
 	}
 	w.RawByte('}')
 	return firstErr
+}
+
+func (v *ServiceSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
+	var firstErr error
+	w.RawByte('{')
+	if v.Target != nil {
+		w.RawString("\"target\":")
+		if err := v.Target.MarshalFastJSON(w); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	w.RawByte('}')
+	return firstErr
+}
+
+func (v *ServiceTargetSpanContext) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	w.RawString("\"name\":")
+	w.String(v.Name)
+	if v.Type != "" {
+		w.RawString(",\"type\":")
+		w.String(v.Type)
+	}
+	w.RawByte('}')
+	return nil
 }
 
 func (v *DestinationServiceSpanContext) MarshalFastJSON(w *fastjson.Writer) error {

--- a/model/model.go
+++ b/model/model.go
@@ -434,13 +434,15 @@ type DestinationSpanContext struct {
 	Cloud *DestinationCloudSpanContext `json:"cloud,omitempty"`
 }
 
-// The span service target fields replace the `span.destination.service.*`
-// fields that are deprecated.
+// ServiceSpanContext holds contextual information about the service
+// for a span that relates to an operation involving an external service.
 type ServiceSpanContext struct {
 	// Target holds the destination service.
 	Target *ServiceTargetSpanContext `json:"target,omitempty"`
 }
 
+// ServiceTargetSpanContext fields replace the `span.destination.service.*`
+// fields that are deprecated.
 type ServiceTargetSpanContext struct {
 	// Type holds the destination service type.
 	Type string `json:"type,omitempty"`

--- a/model/model.go
+++ b/model/model.go
@@ -394,6 +394,9 @@ type SpanContext struct {
 	// Destination holds information about a destination service.
 	Destination *DestinationSpanContext `json:"destination,omitempty"`
 
+	// Service holds information about the service.
+	Service *ServiceSpanContext `json:"service,omitempty"`
+
 	// Database holds contextual information for database
 	// operation spans.
 	Database *DatabaseSpanContext `json:"db,omitempty"`
@@ -431,17 +434,40 @@ type DestinationSpanContext struct {
 	Cloud *DestinationCloudSpanContext `json:"cloud,omitempty"`
 }
 
+// The span service target fields replace the `span.destination.service.*`
+// fields that are deprecated.
+type ServiceSpanContext struct {
+	// Target holds the destination service.
+	Target *ServiceTargetSpanContext `json:"target,omitempty"`
+}
+
+type ServiceTargetSpanContext struct {
+	// Type holds the destination service type.
+	Type string `json:"type,omitempty"`
+
+	// Name holds the destination service name.
+	Name string `json:"name"`
+}
+
 // DestinationServiceSpanContext holds contextual information about a
 // destination service.
+//
+// Deprecated: replaced by `service.target.{type,name}`.
 type DestinationServiceSpanContext struct {
 	// Type holds the destination service type. Deprecated.
+	//
+	// Deprecated: replaced by `service.target.{type,name}`.
 	Type string `json:"type,omitempty"`
 
 	// Name holds the destination service name. Deprecated.
+	//
+	// Deprecated: replaced by `service.target.{type,name}`.
 	Name string `json:"name"`
 
 	// Resource identifies the destination service
 	// resource, e.g. a URI or message queue name.
+	//
+	// Deprecated: replaced by `service.target.{type,name}`.
 	Resource string `json:"resource,omitempty"`
 }
 

--- a/spancontext.go
+++ b/spancontext.go
@@ -32,6 +32,8 @@ type SpanContext struct {
 	model                model.SpanContext
 	destination          model.DestinationSpanContext
 	destinationService   model.DestinationServiceSpanContext
+	service              model.ServiceSpanContext
+	serviceTarget        model.ServiceTargetSpanContext
 	destinationCloud     model.DestinationCloudSpanContext
 	message              model.MessageSpanContext
 	databaseRowsAffected int64
@@ -60,14 +62,33 @@ type DatabaseSpanContext struct {
 	User string
 }
 
+// The span service target fields replace the `span.destination.service.*`
+// fields that are deprecated.
+type ServiceSpanContext struct {
+	// Target holds the destination service.
+	Target *ServiceTargetSpanContext `json:"target,omitempty"`
+}
+
+type ServiceTargetSpanContext struct {
+	// Type holds the destination service type.
+	Type string `json:"type,omitempty"`
+
+	// Name holds the destination service name.
+	Name string `json:"name"`
+}
+
 // DestinationServiceSpanContext holds destination service span span.
 type DestinationServiceSpanContext struct {
 	// Name holds a name for the destination service, which may be used
 	// for grouping and labeling in service maps. Deprecated.
+	//
+	// Deprecated: replaced by `service.target.{type,name}`.
 	Name string
 
 	// Resource holds an identifier for a destination service resource,
 	// such as a message queue.
+	//
+	// Deprecated: replaced by `service.target.{type,name}`.
 	Resource string
 }
 
@@ -244,6 +265,13 @@ func (c *SpanContext) SetDestinationService(service DestinationServiceSpanContex
 	c.destinationService.Resource = truncateString(service.Resource)
 	c.destination.Service = &c.destinationService
 	c.model.Destination = &c.destination
+}
+
+func (c *SpanContext) SetServiceTarget(service ServiceTargetSpanContext) {
+	c.serviceTarget.Type = truncateString(service.Type)
+	c.serviceTarget.Name = truncateString(service.Name)
+	c.service.Target = &c.serviceTarget
+	c.model.Service = &c.service
 }
 
 // SetDestinationCloud sets the destination cloud info in the context.

--- a/spancontext.go
+++ b/spancontext.go
@@ -62,13 +62,15 @@ type DatabaseSpanContext struct {
 	User string
 }
 
-// The span service target fields replace the `span.destination.service.*`
-// fields that are deprecated.
+// ServiceSpanContext holds contextual information about the service
+// for a span that relates to an operation involving an external service.
 type ServiceSpanContext struct {
 	// Target holds the destination service.
 	Target *ServiceTargetSpanContext `json:"target,omitempty"`
 }
 
+// ServiceTargetSpanContext fields replace the `span.destination.service.*`
+// fields that are deprecated.
 type ServiceTargetSpanContext struct {
 	// Type holds the destination service type.
 	Type string `json:"type,omitempty"`
@@ -256,6 +258,8 @@ func (c *SpanContext) SetMessage(message MessageSpanContext) {
 //
 // Both service.Name and service.Resource are required. If either is empty,
 // then SetDestinationService is a no-op.
+//
+// Deprecated: use SetServiceTarget
 func (c *SpanContext) SetDestinationService(service DestinationServiceSpanContext) {
 	c.setDestinationServiceCalled = true
 	if service.Resource == "" {
@@ -267,6 +271,7 @@ func (c *SpanContext) SetDestinationService(service DestinationServiceSpanContex
 	c.model.Destination = &c.destination
 }
 
+// SetServiceTarget sets the service target info in the context.
 func (c *SpanContext) SetServiceTarget(service ServiceTargetSpanContext) {
 	c.serviceTarget.Type = truncateString(service.Type)
 	c.serviceTarget.Name = truncateString(service.Name)


### PR DESCRIPTION
This should lay the groundwork for backend dependencies granularity.

Different backends have different specs/guidelines and the goal is to replace `SetDestinationService` with `SetServiceTarget` and use the new fields. 

Related to https://github.com/elastic/apm-agent-go/issues/1233  
Related to https://github.com/elastic/apm-agent-go/issues/1267  