### PR TITLE
perf: skip tracestate regex validation for es vendor key

### DIFF
--- a/tracecontext.go
+++ b/tracecontext.go
@@ -316,7 +316,7 @@ func (e *TraceStateEntry) writeBuf(buf *bytes.Buffer) {
 //
 // This will return non-nil if either the key or value is invalid.
 func (e *TraceStateEntry) Validate() error {
-	if !tracestateKeyRegexp.MatchString(e.Key) {
+	if e.Key != elasticTracestateVendorKey && !tracestateKeyRegexp.MatchString(e.Key) {
 		return fmt.Errorf("invalid key %q", e.Key)
 	}
 	if err := e.validateValue(); err != nil {


### PR DESCRIPTION
When creating a TraceState the entries are parsed and if
we meet an 'es' vendor key we parse the elastic tracestate.
If that happens we can skip the regex key validation to gain
a small performance improvement since the 'es' key is hardcoded
and safe to use.

Benchstat diff:

```
name            old time/op    new time/op    delta
Transaction-16     457ns ± 6%     395ns ± 1%  -13.49%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
Transaction-16      194B ± 1%      192B ± 0%   -1.13%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
Transaction-16      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
```

To reproduce: `go test -run=NONE -benchmem -bench=BenchmarkTransaction -count=10 .`