### PR TITLE
fix: make sure at least one of the service target fields is sent

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -445,10 +445,10 @@ type ServiceSpanContext struct {
 // fields that are deprecated.
 type ServiceTargetSpanContext struct {
 	// Type holds the destination service type.
-	Type string `json:"type,omitempty"`
+	Type string `json:"type"`
 
 	// Name holds the destination service name.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 // DestinationServiceSpanContext holds contextual information about a

--- a/spancontext.go
+++ b/spancontext.go
@@ -66,17 +66,17 @@ type DatabaseSpanContext struct {
 // for a span that relates to an operation involving an external service.
 type ServiceSpanContext struct {
 	// Target holds the destination service.
-	Target *ServiceTargetSpanContext `json:"target,omitempty"`
+	Target *ServiceTargetSpanContext
 }
 
 // ServiceTargetSpanContext fields replace the `span.destination.service.*`
 // fields that are deprecated.
 type ServiceTargetSpanContext struct {
 	// Type holds the destination service type.
-	Type string `json:"type,omitempty"`
+	Type string
 
 	// Name holds the destination service name.
-	Name string `json:"name"`
+	Name string
 }
 
 // DestinationServiceSpanContext holds destination service span span.


### PR DESCRIPTION
According to the spec:

'at least one of those two fields is required to be provided and not empty'

While both are optional, the only one with an explicit clause that
allows empty values is 'type'.
To better reflect that, 'type' is always included (even if empty) and
'name' is omitted if empty.

See https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans-service-target.md

Additionally, unused json tags are removed from internal fields.