### PR TITLE
feat: add service target fields support to sql module

### DIFF
--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -76,6 +76,10 @@ func (c *conn) startSpan(ctx context.Context, name, spanType, stmt string) (*apm
 				Name:     c.driver.driverName,
 				Resource: c.driver.driverName,
 			})
+			span.Context.SetServiceTarget(apm.ServiceTargetSpanContext{
+				Type: c.driver.driverName,
+				Name: c.dsnInfo.Database,
+			})
 		}
 		span.Context.SetDatabase(apm.DatabaseSpanContext{
 			Instance:  c.dsnInfo.Database,

--- a/module/apmsql/mysql/mysql_test.go
+++ b/module/apmsql/mysql/mysql_test.go
@@ -65,6 +65,12 @@ func TestQueryContext(t *testing.T) {
 				Resource: "mysql",
 			},
 		},
+		Service: &model.ServiceSpanContext{
+			Target: &model.ServiceTargetSpanContext{
+				Type: "mysql",
+				Name: "test_db",
+			},
+		},
 		Database: &model.DatabaseSpanContext{
 			Instance:  "test_db",
 			Statement: "SELECT * FROM foo",

--- a/module/apmsql/pgxv4/pq_test.go
+++ b/module/apmsql/pgxv4/pq_test.go
@@ -63,6 +63,12 @@ func TestQueryContext(t *testing.T) {
 				Resource: "postgresql",
 			},
 		},
+		Service: &model.ServiceSpanContext{
+			Target: &model.ServiceTargetSpanContext{
+				Type: "postgresql",
+				Name: "test_db",
+			},
+		},
 		Database: &model.DatabaseSpanContext{
 			Instance:  "test_db",
 			Statement: "SELECT * FROM foo",

--- a/module/apmsql/pq/pq_test.go
+++ b/module/apmsql/pq/pq_test.go
@@ -63,6 +63,12 @@ func TestQueryContext(t *testing.T) {
 				Resource: "postgresql",
 			},
 		},
+		Service: &model.ServiceSpanContext{
+			Target: &model.ServiceTargetSpanContext{
+				Type: "postgresql",
+				Name: "test_db",
+			},
+		},
 		Database: &model.DatabaseSpanContext{
 			Instance:  "test_db",
 			Statement: "SELECT * FROM foo",


### PR DESCRIPTION
Sets service target fields for services using the
sql module.

See https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-db.md#sql-databases