### PR TITLE
fix: use the correct destination resource and name for azure queue

### DIFF
--- a/module/apmazure/queue.go
+++ b/module/apmazure/queue.go
@@ -34,7 +34,7 @@ type queueRPC struct {
 }
 
 func (q *queueRPC) name() string {
-	return fmt.Sprintf("AzureQueue %s %s %s", q.operation(), q.dir(), q.accountName)
+	return fmt.Sprintf("AzureQueue %s %s %s", q.operation(), q.dir(), q.queueName)
 }
 
 func (q *queueRPC) _type() string {

--- a/module/apmazure/queue_test.go
+++ b/module/apmazure/queue_test.go
@@ -47,14 +47,14 @@ func TestQueueSend(t *testing.T) {
 	span := spans[0]
 
 	assert.Equal(t, "messaging", span.Type)
-	assert.Equal(t, "AzureQueue SEND to fakeaccnt", span.Name)
+	assert.Equal(t, "AzureQueue SEND to myqueue", span.Name)
 	assert.Equal(t, 403, span.Context.HTTP.StatusCode)
 	assert.Equal(t, "azurequeue", span.Subtype)
 	assert.Equal(t, "SEND", span.Action)
 	destination := span.Context.Destination
 	assert.Equal(t, "fakeaccnt.queue.core.windows.net", destination.Address)
 	assert.Equal(t, 443, destination.Port)
-	assert.Equal(t, "azurequeue/fakeaccnt", destination.Service.Resource)
+	assert.Equal(t, "azurequeue/myqueue", destination.Service.Resource)
 	assert.Equal(t, "azurequeue", span.Context.Service.Target.Type)
 	assert.Equal(t, "myqueue", span.Context.Service.Target.Name)
 }
@@ -75,19 +75,19 @@ func TestQueueReceive(t *testing.T) {
 	transaction := payloads.Transactions[0]
 	// ParentID is empty, a new transaction was created
 	assert.Equal(t, model.SpanID{}, transaction.ParentID)
-	assert.Equal(t, "AzureQueue PEEK from fakeaccnt", transaction.Name)
+	assert.Equal(t, "AzureQueue PEEK from myqueue", transaction.Name)
 	assert.Equal(t, "messaging", transaction.Type)
 
 	span := payloads.Spans[0]
 	assert.Equal(t, "messaging", span.Type)
-	assert.Equal(t, "AzureQueue PEEK from fakeaccnt", span.Name)
+	assert.Equal(t, "AzureQueue PEEK from myqueue", span.Name)
 	assert.Equal(t, 403, span.Context.HTTP.StatusCode)
 	assert.Equal(t, "azurequeue", span.Subtype)
 	assert.Equal(t, "PEEK", span.Action)
 	destination := span.Context.Destination
 	assert.Equal(t, "fakeaccnt.queue.core.windows.net", destination.Address)
 	assert.Equal(t, 443, destination.Port)
-	assert.Equal(t, "azurequeue/fakeaccnt", destination.Service.Resource)
+	assert.Equal(t, "azurequeue/myqueue", destination.Service.Resource)
 	assert.Equal(t, "azurequeue", span.Context.Service.Target.Type)
 	assert.Equal(t, "myqueue", span.Context.Service.Target.Name)
 }

--- a/module/apmazure/storage.go
+++ b/module/apmazure/storage.go
@@ -105,8 +105,13 @@ func (p *apmPipeline) Do(
 	}
 	span.Action = rpc.operation()
 	span.Subtype = rpc.subtype()
+
+	resource := rpc.subtype() + "/" + rpc.storageAccountName()
+	if rpc.subtype() == "azurequeue" {
+		resource = rpc.subtype() + "/" + rpc.targetName()
+	}
 	span.Context.SetDestinationService(apm.DestinationServiceSpanContext{
-		Resource: rpc.subtype() + "/" + rpc.storageAccountName(),
+		Resource: resource,
 	})
 	span.Context.SetServiceTarget(apm.ServiceTargetSpanContext{
 		Type: rpc.subtype(),


### PR DESCRIPTION
Destination resource was 'azurequeue/<AccountName>' but should be
'azurequeue/<QueueName>'.
Span name should be 'AzureQueue <OperationName> to <QueueName>'
but was using the 'AccountName' was being used.