### PR TITLE
test: add testcase for sqs delete_batch operation

### DIFF
--- a/module/apmawssdkgo/sqs_test.go
+++ b/module/apmawssdkgo/sqs_test.go
@@ -124,6 +124,24 @@ func TestSQS(t *testing.T) {
 			},
 		},
 		{
+			name:      "SQS DELETE_BATCH from OtherQueue",
+			action:    "delete_batch",
+			resource:  "sqs/OtherQueue",
+			queueName: "OtherQueue",
+			queueURL:  "https://sqs.testing.invalid/123456789012/OtherQueue",
+			fn: func(ctx context.Context, svc *sqs.SQS, queueURL string) {
+				svc.DeleteMessageBatchWithContext(ctx, &sqs.DeleteMessageBatchInput{
+					QueueUrl: &queueURL,
+					Entries: []*sqs.DeleteMessageBatchRequestEntry{
+						{
+							Id:            aws.String("1"),
+							ReceiptHandle: aws.String("receiptHandle"),
+						},
+					},
+				})
+			},
+		},
+		{
 			ignored: true,
 			fn: func(ctx context.Context, svc *sqs.SQS, _ string) {
 				svc.CreateQueueWithContext(ctx, &sqs.CreateQueueInput{


### PR DESCRIPTION
Assert 'span.name' and 'span.action' are following the
spec for delete_batch operations.

The actions were not described in the original spec but
the output seems to be correct so we just add a test to
avoid regressions and verification.

Closes https://github.com/elastic/apm-agent-go/issues/1170