### PR TITLE
fix: reformat code with go 1.19 to fix ci failure 

### DIFF
--- a/breakdown_test.go
+++ b/breakdown_test.go
@@ -162,10 +162,11 @@ func TestBreakdownMetrics_Disabled(t *testing.T) {
 	assertBreakdownMetrics(t, []model.Metrics{}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████████████████████████    30   30 transaction
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest1(t *testing.T) {
+	//                                 total self type
+	//  ██████████████████████████████    30   30 transaction
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -181,11 +182,12 @@ func TestBreakdownMetrics_AcceptanceTest1(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░░░░░░██████████    30   20 transaction
-//  └─────────██████████              10   10 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest2(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░░░░░░██████████    30   20 transaction
+	//  └─────────██████████              10   10 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -206,11 +208,12 @@ func TestBreakdownMetrics_AcceptanceTest2(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░░░░░░██████████    30   20 transaction
-//  └─────────██████████              10   10 app
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest3(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░░░░░░██████████    30   20 transaction
+	//  └─────────██████████              10   10 app
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -232,12 +235,13 @@ func TestBreakdownMetrics_AcceptanceTest3(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░░░░░░██████████    30   20 transaction
-//  └─────────██████████              10   10 db.mysql
-//  └─────────██████████              10   10 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest4(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░░░░░░██████████    30   20 transaction
+	//  └─────────██████████              10   10 db.mysql
+	//  └─────────██████████              10   10 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -261,12 +265,13 @@ func TestBreakdownMetrics_AcceptanceTest4(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░░░░░░░░░░░█████    30   15 transaction
-//  └─────────██████████              10   10 db.mysql
-//  └──────────────██████████         10   10 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest5(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░░░░░░░░░░░█████    30   15 transaction
+	//  └─────────██████████              10   10 db.mysql
+	//  └──────────────██████████         10   10 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -290,12 +295,13 @@ func TestBreakdownMetrics_AcceptanceTest5(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  █████░░░░░░░░░░░░░░░░░░░░█████    30   15 transaction
-//  └────██████████                   10   10 db.mysql
-//  └──────────────██████████         10   10 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest6(t *testing.T) {
+	//                                 total self type
+	//  █████░░░░░░░░░░░░░░░░░░░░█████    30   15 transaction
+	//  └────██████████                   10   10 db.mysql
+	//  └──────────────██████████         10   10 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -319,12 +325,13 @@ func TestBreakdownMetrics_AcceptanceTest6(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░█████░░░░░█████    30   15 transaction
-//  └─────────█████                    5    5 db.mysql
-//  └───────────────────█████          5    5 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest7(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░█████░░░░░█████    30   15 transaction
+	//  └─────────█████                    5    5 db.mysql
+	//  └───────────────────█████          5    5 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -348,12 +355,13 @@ func TestBreakdownMetrics_AcceptanceTest7(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░░░░░░██████████    30   20 transaction
-//  └─────────█████░░░░░              10    5 app
-//            └────██████████         10   10 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest8(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░░░░░░██████████    30   20 transaction
+	//  └─────────█████░░░░░              10    5 app
+	//            └────██████████         10   10 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -379,12 +387,13 @@ func TestBreakdownMetrics_AcceptanceTest8(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░░░░░░              20   20 transaction
-//  └─────────██████████░░░░░░░░░░    20   10 app
-//            └─────────██████████    10   10 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest9(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░░░░░░              20   20 transaction
+	//  └─────────██████████░░░░░░░░░░    20   10 app
+	//            └─────────██████████    10   10 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -414,11 +423,12 @@ func TestBreakdownMetrics_AcceptanceTest9(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████░░░░░░░░░░              20   10 transaction
-//  └─────────████████████████████    20   20 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest10(t *testing.T) {
+	//                                 total self type
+	//  ██████████░░░░░░░░░░              20   10 transaction
+	//  └─────────████████████████████    20   20 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 
@@ -440,11 +450,12 @@ func TestBreakdownMetrics_AcceptanceTest10(t *testing.T) {
 	}, payloadsBreakdownMetrics(transport))
 }
 
-//                                 total self type
-//  ██████████                        10   10 transaction
-//  └───────────────────██████████    10   10 db.mysql
-//           10        20        30
 func TestBreakdownMetrics_AcceptanceTest11(t *testing.T) {
+	//                                 total self type
+	//  ██████████                        10   10 transaction
+	//  └───────────────────██████████    10   10 db.mysql
+	//           10        20        30
+
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
 

--- a/error.go
+++ b/error.go
@@ -63,24 +63,34 @@ func (t *Tracer) Recovered(v interface{}) *Error {
 // github.com/pkg/errors.
 //
 // If err implements
-//   type interface {
-//       StackTrace() github.com/pkg/errors.StackTrace
-//   }
+//
+//	type interface {
+//	    StackTrace() github.com/pkg/errors.StackTrace
+//	}
+//
 // or
-//   type interface {
-//       StackTrace() []stacktrace.Frame
-//   }
+//
+//	type interface {
+//	    StackTrace() []stacktrace.Frame
+//	}
+//
 // then one of those will be used to set the error
 // stacktrace. Otherwise, NewError will take a stacktrace.
 //
 // If err implements
-//   type interface {Type() string}
+//
+//	type interface {Type() string}
+//
 // then that will be used to set the error type.
 //
 // If err implements
-//   type interface {Code() string}
+//
+//	type interface {Code() string}
+//
 // or
-//   type interface {Code() float64}
+//
+//	type interface {Code() float64}
+//
 // then one of those will be used to set the error code.
 func (t *Tracer) NewError(err error) *Error {
 	if err == nil {

--- a/fmt.go
+++ b/fmt.go
@@ -28,14 +28,14 @@ import (
 //
 // The returned Formatter understands the following verbs:
 //
-//   %v: trace ID, transaction ID, and span ID (if existing), space-separated
-//       the plus flag (%+v) adds field names, e.g. "trace.id=... transaction.id=..."
-//   %t: trace ID (hex-encoded, or empty string if non-existent)
-//       the plus flag (%+T) adds the field name, e.g. "trace.id=..."
-//   %x: transaction ID (hex-encoded, or empty string if non-existent)
-//       the plus flag (%+t) adds the field name, e.g. "transaction.id=..."
-//   %s: span ID (hex-encoded, or empty string if non-existent)
-//       the plus flag (%+s) adds the field name, e.g. "span.id=..."
+//	%v: trace ID, transaction ID, and span ID (if existing), space-separated
+//	    the plus flag (%+v) adds field names, e.g. "trace.id=... transaction.id=..."
+//	%t: trace ID (hex-encoded, or empty string if non-existent)
+//	    the plus flag (%+T) adds the field name, e.g. "trace.id=..."
+//	%x: transaction ID (hex-encoded, or empty string if non-existent)
+//	    the plus flag (%+t) adds the field name, e.g. "transaction.id=..."
+//	%s: span ID (hex-encoded, or empty string if non-existent)
+//	    the plus flag (%+s) adds the field name, e.g. "span.id=..."
 func TraceFormatter(ctx context.Context) fmt.Formatter {
 	f := traceFormatter{tx: TransactionFromContext(ctx)}
 	if f.tx != nil {

--- a/module/apmgorm/open.go
+++ b/module/apmgorm/open.go
@@ -30,9 +30,9 @@ import (
 // as spans.
 //
 // Open accepts the following signatures:
-//  - a datasource name (i.e. the second argument to sql.Open)
-//  - a driver name and a datasource name
-//  - a *sql.DB, or some other type with the same interface
+//   - a datasource name (i.e. the second argument to sql.Open)
+//   - a driver name and a datasource name
+//   - a *sql.DB, or some other type with the same interface
 //
 // If a driver and datasource name are supplied, and the appropriate
 // apmgorm/dialects package has been imported (or the driver has

--- a/module/apmhttp/traceheaders.go
+++ b/module/apmhttp/traceheaders.go
@@ -58,7 +58,8 @@ func FormatTraceparentHeader(c apm.TraceContext) string {
 
 // ParseTraceparentHeader parses the given header, which is expected to be in
 // the W3C Trace-Context traceparent format according to W3C Editor's Draft 23 May 2018:
-//     https://w3c.github.io/trace-context/#traceparent-field
+//
+//	https://w3c.github.io/trace-context/#traceparent-field
 //
 // Note that the returned TraceContext's Trace and Span fields are not necessarily
 // valid. The caller must decide whether or not it wishes to disregard invalid
@@ -134,7 +135,8 @@ func ParseTraceparentHeader(h string) (apm.TraceContext, error) {
 
 // ParseTracestateHeader parses the given header, which is expected to be in the
 // W3C Trace-Context tracestate format according to W3C Editor's Draft 18 Nov 2019:
-//    https://w3c.github.io/trace-context/#tracestate-header
+//
+//	https://w3c.github.io/trace-context/#tracestate-header
 //
 // Note that the returned TraceState is not necessarily valid. The caller must
 // decide whether or not it wishes to disregard invalid tracestate entries, and

--- a/module/apmot/doc.go
+++ b/module/apmot/doc.go
@@ -18,7 +18,7 @@
 // Package apmot provides an Elastic APM implementation of the OpenTracing API.
 //
 // Things not implemented by this tracer:
-//  - binary propagation format
-//  - baggage
-//  - logging (generally; errors are reported)
+//   - binary propagation format
+//   - baggage
+//   - logging (generally; errors are reported)
 package apmot // import "go.elastic.co/apm/module/apmot/v2"

--- a/module/apmzerolog/stack.go
+++ b/module/apmzerolog/stack.go
@@ -30,8 +30,8 @@ import (
 //
 // This is similar to github.com/rs/zerolog/pkgerrors.MarshalStack,
 // with the following differences:
-//  - the "source" field value may be an absolute path
-//  - the "func" field value will be fully qualified
+//   - the "source" field value may be an absolute path
+//   - the "func" field value will be fully qualified
 func MarshalErrorStack(err error) interface{} {
 	frames := stacktrace.AppendErrorStacktrace(nil, err, -1)
 	if len(frames) == 0 {

--- a/span_compressed.go
+++ b/span_compressed.go
@@ -62,11 +62,12 @@ func (cs compositeSpan) empty() bool {
 }
 
 // A span is eligible for compression if all the following conditions are met
-// 1. It's an exit span
-// 2. The trace context has not been propagated to a downstream service
-// 3. If the span has outcome (i.e., outcome is present and it's not null) then
-//    it should be success. It means spans with outcome indicating an issue of
-//    potential interest should not be compressed.
+//  1. It's an exit span
+//  2. The trace context has not been propagated to a downstream service
+//  3. If the span has outcome (i.e., outcome is present and it's not null) then
+//     it should be success. It means spans with outcome indicating an issue of
+//     potential interest should not be compressed.
+//
 // The second condition is important so that we don't remove (compress) a span
 // that may be the parent of a downstream service. This would orphan the sub-
 // graph started by the downstream service and cause it to not appear in the
@@ -109,19 +110,21 @@ func (s *Span) compress(sibling *Span) bool {
 //
 
 // attemptCompress tries to compress a span into a "composite span" when:
-// * Compression is enabled on agent.
-// * The cached span and the incoming span:
-//   * Share the same parent (are siblings).
-//   * Are consecutive spans.
-//   * Are both exit spans, outcome == success and are short enough (See
+//  1. Compression is enabled on agent.
+//  2. The cached span and the incoming span share the same parent (are siblings).
+//  3. The cached span and the incoming span are consecutive spans.
+//  4. The cached span and the incoming span are both exit spans,
+//     outcome == success and are short enough (See
 //     `ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION` and
 //     `ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION` for more info).
-//   * Represent the same exact operation or the same kind of operation:
-//     * Are an exact match (same name, kind and destination service).
-//       OR
-//     * Are the same kind match (same kind and destination service).
-//     When a span has already been compressed using a particular strategy, it
-//     CANNOT continue to compress spans using a different strategy.
+//  5. The cached span and the incoming span represent the same exact operation
+//     or the same kind of operation:
+//     - Are an exact match (same name, kind and destination service).
+//     - Are the same kind match (same kind and destination service).
+//
+// When a span has already been compressed using a particular strategy, it
+// CANNOT continue to compress spans using a different strategy.
+//
 // The compression algorithm is fairly simple and only compresses spans into a
 // composite span when the conditions listed above are met for all consecutive
 // spans, at any point any span that doesn't meet the conditions, will cause

--- a/tracecontext.go
+++ b/tracecontext.go
@@ -41,9 +41,9 @@ var (
 // tracestateKeyRegexp holds a regular expression used for validating
 // tracestate keys according to the standard rules:
 //
-//   key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
-//   key = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
-//   lcalpha = %x61-7A ; a-z
+//	key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+//	key = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+//	lcalpha = %x61-7A ; a-z
 //
 // nblkchr is used for defining valid runes for tracestate values.
 var (


### PR DESCRIPTION
Go 1.19 adds some changes to doc comments:

https://go.dev/doc/go1.19#go-doc

This breaks the Go 1.x ci job.

Reformat code accordingly