### PR TITLE
feat: rename span_frames_min_duration to span_stack_trace_min_duration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ endif::[]
 https://github.com/elastic/apm-agent-go/compare/v2.1.0...main[View commits]
 
 - Global labels are now parsed when the tracer is constructed, instead of parsing only once on package initialization {pull}1290[#(1290)]
+- Rename span_frames_min_duration to span_stack_trace_min_duration {pull}1285[#(1285)]
 
 [[release-notes-2.x]]
 === Go Agent version 2.x

--- a/config.go
+++ b/config.go
@@ -49,7 +49,7 @@ const (
 	envServiceName                 = "ELASTIC_APM_SERVICE_NAME"
 	envServiceVersion              = "ELASTIC_APM_SERVICE_VERSION"
 	envEnvironment                 = "ELASTIC_APM_ENVIRONMENT"
-	envSpanFramesMinDuration       = "ELASTIC_APM_SPAN_FRAMES_MIN_DURATION"
+	envSpanStackTraceMinDuration   = "ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION"
 	envActive                      = "ELASTIC_APM_ACTIVE"
 	envRecording                   = "ELASTIC_APM_RECORDING"
 	envAPIRequestSize              = "ELASTIC_APM_API_REQUEST_SIZE"
@@ -84,17 +84,17 @@ const (
 	envCPUProfileDuration  = "ELASTIC_APM_CPU_PROFILE_DURATION"
 	envHeapProfileInterval = "ELASTIC_APM_HEAP_PROFILE_INTERVAL"
 
-	defaultAPIRequestSize        = 750 * configutil.KByte
-	defaultAPIRequestTime        = 10 * time.Second
-	defaultAPIBufferSize         = 1 * configutil.MByte
-	defaultMetricsBufferSize     = 750 * configutil.KByte
-	defaultMetricsInterval       = 30 * time.Second
-	defaultMaxSpans              = 500
-	defaultCaptureHeaders        = true
-	defaultCaptureBody           = CaptureBodyOff
-	defaultSpanFramesMinDuration = 5 * time.Millisecond
-	defaultStackTraceLimit       = 50
-	defaultContinuationStrategy  = "continue"
+	defaultAPIRequestSize            = 750 * configutil.KByte
+	defaultAPIRequestTime            = 10 * time.Second
+	defaultAPIBufferSize             = 1 * configutil.MByte
+	defaultMetricsBufferSize         = 750 * configutil.KByte
+	defaultMetricsInterval           = 30 * time.Second
+	defaultMaxSpans                  = 500
+	defaultCaptureHeaders            = true
+	defaultCaptureBody               = CaptureBodyOff
+	defaultSpanStackTraceMinDuration = 5 * time.Millisecond
+	defaultStackTraceLimit           = 50
+	defaultContinuationStrategy      = "continue"
 
 	defaultExitSpanMinDuration = time.Millisecond
 
@@ -310,8 +310,8 @@ func initialService() (name, version, environment string) {
 	return name, version, environment
 }
 
-func initialSpanFramesMinDuration() (time.Duration, error) {
-	return configutil.ParseDurationEnv(envSpanFramesMinDuration, defaultSpanFramesMinDuration)
+func initialSpanStackTraceMinDuration() (time.Duration, error) {
+	return configutil.ParseDurationEnv(envSpanStackTraceMinDuration, defaultSpanStackTraceMinDuration)
 }
 
 func initialActive() (bool, error) {
@@ -488,7 +488,7 @@ func (t *Tracer) updateRemoteConfig(logger Logger, old, attrs map[string]string)
 			updates = append(updates, func(cfg *instrumentationConfig) {
 				cfg.continuationStrategy = v
 			})
-		case envSpanFramesMinDuration:
+		case envSpanStackTraceMinDuration:
 			duration, err := configutil.ParseDuration(v)
 			if err != nil {
 				errorf("central config failure: failed to parse %s: %s", k, err)
@@ -496,7 +496,7 @@ func (t *Tracer) updateRemoteConfig(logger Logger, old, attrs map[string]string)
 				continue
 			} else {
 				updates = append(updates, func(cfg *instrumentationConfig) {
-					cfg.spanFramesMinDuration = duration
+					cfg.spanStackTraceMinDuration = duration
 				})
 			}
 		case envStackTraceLimit:
@@ -658,17 +658,17 @@ type instrumentationConfig struct {
 // set the initial entry in instrumentationConfig.local, in order to properly reset
 // to the local value, even if the default is the zero value.
 type instrumentationConfigValues struct {
-	recording             bool
-	captureBody           CaptureBodyMode
-	captureHeaders        bool
-	maxSpans              int
-	sampler               Sampler
-	spanFramesMinDuration time.Duration
-	exitSpanMinDuration   time.Duration
-	continuationStrategy  string
-	stackTraceLimit       int
-	propagateLegacyHeader bool
-	sanitizedFieldNames   wildcard.Matchers
-	ignoreTransactionURLs wildcard.Matchers
-	compressionOptions    compressionOptions
+	recording                 bool
+	captureBody               CaptureBodyMode
+	captureHeaders            bool
+	maxSpans                  int
+	sampler                   Sampler
+	spanStackTraceMinDuration time.Duration
+	exitSpanMinDuration       time.Duration
+	continuationStrategy      string
+	stackTraceLimit           int
+	propagateLegacyHeader     bool
+	sanitizedFieldNames       wildcard.Matchers
+	ignoreTransactionURLs     wildcard.Matchers
+	compressionOptions        compressionOptions
 }

--- a/config_test.go
+++ b/config_test.go
@@ -81,7 +81,7 @@ func TestTracerCentralConfigUpdate(t *testing.T) {
 	run("recording", "false", func(tracer *apmtest.RecordingTracer) bool {
 		return !tracer.Recording()
 	})
-	run("span_frames_min_duration", "1ms", func(tracer *apmtest.RecordingTracer) bool {
+	run("span_stack_trace_min_duration", "1ms", func(tracer *apmtest.RecordingTracer) bool {
 		tracer.ResetPayloads()
 
 		tx := tracer.StartTransaction("name", "type")

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -426,14 +426,14 @@ The minimum duration allowed for this setting is 1 microsecond (`us`).
 
 [float]
 [[config-span-frames-min-duration-ms]]
-=== `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`
+=== `ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION`
 
 <<dynamic-configuration, image:./images/dynamic-config.svg[] >>
 
 [options="header"]
 |============
-| Environment                            | Default
-| `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION` | `5ms`
+| Environment                                 | Default
+| `ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION` | `5ms`
 |============
 
 The APM agent will collect a stack trace for every recorded span whose duration

--- a/env_test.go
+++ b/env_test.go
@@ -259,8 +259,7 @@ func testTracerCaptureBodyEnv(t *testing.T, envValue string, expectBody bool) {
 }
 
 func TestTracerSpanFramesMinDurationEnv(t *testing.T) {
-	os.Setenv("ELASTIC_APM_SPAN_FRAMES_MIN_DURATION", "10ms")
-	defer os.Unsetenv("ELASTIC_APM_SPAN_FRAMES_MIN_DURATION")
+	t.Setenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION", "10ms")
 
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
@@ -286,11 +285,10 @@ func TestTracerSpanFramesMinDurationEnv(t *testing.T) {
 }
 
 func TestTracerSpanFramesMinDurationEnvInvalid(t *testing.T) {
-	os.Setenv("ELASTIC_APM_SPAN_FRAMES_MIN_DURATION", "aeon")
-	defer os.Unsetenv("ELASTIC_APM_SPAN_FRAMES_MIN_DURATION")
+	t.Setenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION", "aeon")
 
 	_, err := apm.NewTracer("tracer_testing", "")
-	assert.EqualError(t, err, "failed to parse ELASTIC_APM_SPAN_FRAMES_MIN_DURATION: invalid duration aeon")
+	assert.EqualError(t, err, "failed to parse ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION: invalid duration aeon")
 }
 
 func TestTracerStackTraceLimitEnv(t *testing.T) {

--- a/env_test.go
+++ b/env_test.go
@@ -259,7 +259,8 @@ func testTracerCaptureBodyEnv(t *testing.T, envValue string, expectBody bool) {
 }
 
 func TestTracerSpanFramesMinDurationEnv(t *testing.T) {
-	t.Setenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION", "10ms")
+	os.Setenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION", "10ms")
+	defer os.Unsetenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION")
 
 	tracer, transport := transporttest.NewRecorderTracer()
 	defer tracer.Close()
@@ -285,7 +286,8 @@ func TestTracerSpanFramesMinDurationEnv(t *testing.T) {
 }
 
 func TestTracerSpanFramesMinDurationEnvInvalid(t *testing.T) {
-	t.Setenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION", "aeon")
+	os.Setenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION", "aeon")
+	defer os.Unsetenv("ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION")
 
 	_, err := apm.NewTracer("tracer_testing", "")
 	assert.EqualError(t, err, "failed to parse ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION: invalid duration aeon")

--- a/span.go
+++ b/span.go
@@ -123,7 +123,7 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 		} else {
 			binary.LittleEndian.PutUint64(span.traceContext.Span[:], tx.rand.Uint64())
 		}
-		span.stackFramesMinDuration = tx.spanFramesMinDuration
+		span.stackStackTraceMinDuration = tx.spanStackTraceMinDuration
 		span.stackTraceLimit = tx.stackTraceLimit
 		span.compressedSpan.options = tx.compressedSpan.options
 		span.exitSpanMinDuration = tx.exitSpanMinDuration
@@ -176,7 +176,7 @@ func (t *Tracer) StartSpan(name, spanType string, transactionID SpanID, opts Spa
 	span.traceContext.Span = spanID
 
 	instrumentationConfig := t.instrumentationConfig()
-	span.stackFramesMinDuration = instrumentationConfig.spanFramesMinDuration
+	span.stackStackTraceMinDuration = instrumentationConfig.spanStackTraceMinDuration
 	span.stackTraceLimit = instrumentationConfig.stackTraceLimit
 	span.compressedSpan.options = instrumentationConfig.compressionOptions
 	span.exitSpanMinDuration = instrumentationConfig.exitSpanMinDuration
@@ -363,15 +363,15 @@ func (s *Span) End() {
 			}
 		}
 	}
-	switch s.stackFramesMinDuration {
-	case -1:
+	switch {
+	case s.stackStackTraceMinDuration < 0:
+		// If s.stackFramesMinDuration < 0, we never set stacktrace.
+	case s.stackStackTraceMinDuration == 0:
 		// Always set stacktrace
 		s.setStacktrace(1)
-	case 0:
-		// If s.stackFramesMinDuration == 0, we never set stacktrace.
 	default:
 		if !s.dropped() && len(s.stacktrace) == 0 &&
-			s.Duration >= s.stackFramesMinDuration {
+			s.Duration >= s.stackStackTraceMinDuration {
 			s.setStacktrace(1)
 		}
 	}
@@ -544,13 +544,13 @@ func (s *Span) dropFastExitSpan() {
 // When a span is ended or discarded, its SpanData field will be set
 // to nil.
 type SpanData struct {
-	exitSpanMinDuration    time.Duration
-	stackFramesMinDuration time.Duration
-	stackTraceLimit        int
-	timestamp              time.Time
-	childrenTimer          childrenTimer
-	composite              compositeSpan
-	compressedSpan         compressedSpan
+	exitSpanMinDuration        time.Duration
+	stackStackTraceMinDuration time.Duration
+	stackTraceLimit            int
+	timestamp                  time.Time
+	childrenTimer              childrenTimer
+	composite                  compositeSpan
+	compressedSpan             compressedSpan
 
 	// Name holds the span name, initialized with the value passed to StartSpan.
 	Name string

--- a/span_test.go
+++ b/span_test.go
@@ -243,11 +243,11 @@ func TestStartExitSpan(t *testing.T) {
 	assert.True(t, span.IsExitSpan())
 }
 
-func TestFramesMinDurationSpecialCases(t *testing.T) {
+func TestSpanStackTraceMinDurationSpecialCases(t *testing.T) {
 	tracer := apmtest.NewRecordingTracer()
 
 	// verify that no stacktraces are recorded
-	tracer.SetSpanFramesMinDuration(0)
+	tracer.SetSpanStackTraceMinDuration(-1)
 	tx := tracer.StartTransaction("name", "type")
 	span := tx.StartSpan("span", "span", nil)
 	span.End()
@@ -263,7 +263,7 @@ func TestFramesMinDurationSpecialCases(t *testing.T) {
 	// verify that stacktraces are always recorded
 	tracer = apmtest.NewRecordingTracer()
 	defer tracer.Close()
-	tracer.SetSpanFramesMinDuration(-1)
+	tracer.SetSpanStackTraceMinDuration(0)
 	tx = tracer.StartTransaction("name", "type")
 	span = tx.StartSpan("span2", "span2", nil)
 	span.End()

--- a/tracer.go
+++ b/tracer.go
@@ -132,33 +132,33 @@ type TracerOptions struct {
 	//   MajorServerVersion(ctx context.Context, refreshStale bool) uint32
 	Transport transport.Transport
 
-	requestDuration       time.Duration
-	metricsInterval       time.Duration
-	maxSpans              int
-	requestSize           int
-	bufferSize            int
-	metricsBufferSize     int
-	sampler               Sampler
-	sanitizedFieldNames   wildcard.Matchers
-	disabledMetrics       wildcard.Matchers
-	ignoreTransactionURLs wildcard.Matchers
-	continuationStrategy  string
-	captureHeaders        bool
-	captureBody           CaptureBodyMode
-	spanFramesMinDuration time.Duration
-	stackTraceLimit       int
-	active                bool
-	recording             bool
-	configWatcher         apmconfig.Watcher
-	breakdownMetrics      bool
-	propagateLegacyHeader bool
-	profileSender         profileSender
-	versionGetter         majorVersionGetter
-	cpuProfileInterval    time.Duration
-	cpuProfileDuration    time.Duration
-	heapProfileInterval   time.Duration
-	exitSpanMinDuration   time.Duration
-	compressionOptions    compressionOptions
+	requestDuration           time.Duration
+	metricsInterval           time.Duration
+	maxSpans                  int
+	requestSize               int
+	bufferSize                int
+	metricsBufferSize         int
+	sampler                   Sampler
+	sanitizedFieldNames       wildcard.Matchers
+	disabledMetrics           wildcard.Matchers
+	ignoreTransactionURLs     wildcard.Matchers
+	continuationStrategy      string
+	captureHeaders            bool
+	captureBody               CaptureBodyMode
+	spanStackTraceMinDuration time.Duration
+	stackTraceLimit           int
+	active                    bool
+	recording                 bool
+	configWatcher             apmconfig.Watcher
+	breakdownMetrics          bool
+	propagateLegacyHeader     bool
+	profileSender             profileSender
+	versionGetter             majorVersionGetter
+	cpuProfileInterval        time.Duration
+	cpuProfileDuration        time.Duration
+	heapProfileInterval       time.Duration
+	exitSpanMinDuration       time.Duration
+	compressionOptions        compressionOptions
 }
 
 // initDefaults updates opts with default values.
@@ -236,9 +236,9 @@ func (opts *TracerOptions) initDefaults(continueOnError bool) error {
 		captureBody = CaptureBodyOff
 	}
 
-	spanFramesMinDuration, err := initialSpanFramesMinDuration()
+	spanStackTraceMinDuration, err := initialSpanStackTraceMinDuration()
 	if failed(err) {
-		spanFramesMinDuration = defaultSpanFramesMinDuration
+		spanStackTraceMinDuration = defaultSpanStackTraceMinDuration
 	}
 
 	stackTraceLimit, err := initialStackTraceLimit()
@@ -343,7 +343,7 @@ func (opts *TracerOptions) initDefaults(continueOnError bool) error {
 	opts.breakdownMetrics = breakdownMetricsEnabled
 	opts.captureHeaders = captureHeaders
 	opts.captureBody = captureBody
-	opts.spanFramesMinDuration = spanFramesMinDuration
+	opts.spanStackTraceMinDuration = spanStackTraceMinDuration
 	opts.stackTraceLimit = stackTraceLimit
 	opts.active = active
 	opts.recording = recording
@@ -496,8 +496,8 @@ func newTracer(opts TracerOptions) *Tracer {
 	t.setLocalInstrumentationConfig(envTransactionSampleRate, func(cfg *instrumentationConfigValues) {
 		cfg.sampler = opts.sampler
 	})
-	t.setLocalInstrumentationConfig(envSpanFramesMinDuration, func(cfg *instrumentationConfigValues) {
-		cfg.spanFramesMinDuration = opts.spanFramesMinDuration
+	t.setLocalInstrumentationConfig(envSpanStackTraceMinDuration, func(cfg *instrumentationConfigValues) {
+		cfg.spanStackTraceMinDuration = opts.spanStackTraceMinDuration
 	})
 	t.setLocalInstrumentationConfig(envStackTraceLimit, func(cfg *instrumentationConfigValues) {
 		cfg.stackTraceLimit = opts.stackTraceLimit
@@ -799,11 +799,11 @@ func (t *Tracer) SetSpanCompressionSameKindMaxDuration(v time.Duration) {
 	})
 }
 
-// SetSpanFramesMinDuration sets the minimum duration for a span after which
+// SetSpanStackTraceMinDuration sets the minimum duration for a span after which
 // we will capture its stack frames.
-func (t *Tracer) SetSpanFramesMinDuration(d time.Duration) {
+func (t *Tracer) SetSpanStackTraceMinDuration(d time.Duration) {
 	t.setLocalInstrumentationConfig(envMaxSpans, func(cfg *instrumentationConfigValues) {
-		cfg.spanFramesMinDuration = d
+		cfg.spanStackTraceMinDuration = d
 	})
 }
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -295,7 +295,7 @@ func TestTracerServiceNameValidation(t *testing.T) {
 func TestSpanStackTrace(t *testing.T) {
 	tracer, r := transporttest.NewRecorderTracer()
 	defer tracer.Close()
-	tracer.SetSpanFramesMinDuration(10 * time.Millisecond)
+	tracer.SetSpanStackTraceMinDuration(10 * time.Millisecond)
 
 	tx := tracer.StartTransaction("name", "type")
 	s := tx.StartSpan("name", "type", nil)

--- a/transaction.go
+++ b/transaction.go
@@ -71,7 +71,7 @@ func (t *Tracer) StartTransactionOptions(name, transactionType string, opts Tran
 	tx.maxSpans = instrumentationConfig.maxSpans
 	tx.compressedSpan.options = instrumentationConfig.compressionOptions
 	tx.exitSpanMinDuration = instrumentationConfig.exitSpanMinDuration
-	tx.spanFramesMinDuration = instrumentationConfig.spanFramesMinDuration
+	tx.spanStackTraceMinDuration = instrumentationConfig.spanStackTraceMinDuration
 	tx.stackTraceLimit = instrumentationConfig.stackTraceLimit
 	tx.Context.captureHeaders = instrumentationConfig.captureHeaders
 	tx.propagateLegacyHeader = instrumentationConfig.propagateLegacyHeader
@@ -393,14 +393,14 @@ type TransactionData struct {
 	// error rate calculations.
 	Outcome string
 
-	recording               bool
-	maxSpans                int
-	exitSpanMinDuration     time.Duration
-	spanFramesMinDuration   time.Duration
-	stackTraceLimit         int
-	breakdownMetricsEnabled bool
-	propagateLegacyHeader   bool
-	timestamp               time.Time
+	recording                 bool
+	maxSpans                  int
+	exitSpanMinDuration       time.Duration
+	spanStackTraceMinDuration time.Duration
+	stackTraceLimit           int
+	breakdownMetricsEnabled   bool
+	propagateLegacyHeader     bool
+	timestamp                 time.Time
 
 	links             []SpanLink
 	mu                sync.Mutex


### PR DESCRIPTION
rename the property and update the handling of special
values like 0 and negative values according to the spec.

Closes https://github.com/elastic/apm-agent-go/issues/1142