### PR TITLE
fix: expand k8s pod discovery regex

### DIFF
--- a/internal/apmhostutil/container_linux.go
+++ b/internal/apmhostutil/container_linux.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -45,8 +44,8 @@ var (
 
 	kubepodsRegexp = regexp.MustCompile(
 		"" +
-			`(?:^/kubepods[\S]*/pod([^/]+)/$)|` +
-			`(?:kubepods[^/]*-pod([^/]+)\.slice/)`,
+			`(?:^/kubepods[\S]*/pod([^/]+)$)|` +
+			`(?:kubepods[^/]*-pod([^/]+)\.slice)`,
 	)
 
 	containerIDRegexp = regexp.MustCompile(
@@ -99,32 +98,40 @@ func readCgroupContainerInfo(r io.Reader) (*model.Container, *model.Kubernetes, 
 	var kubernetes *model.Kubernetes
 	s := bufio.NewScanner(r)
 	for s.Scan() {
+		// split the line according to the format "hierarchy-ID:controller-list:cgroup-path"
 		fields := strings.SplitN(s.Text(), ":", 3)
 		if len(fields) != 3 {
 			continue
 		}
+
+		// extract cgroup-path
 		cgroupPath := fields[2]
 
-		// Depending on the filesystem driver used for cgroup
-		// management, the paths in /proc/pid/cgroup will have
-		// one of the following formats in a Docker container:
-		//
-		//   systemd: /system.slice/docker-<container-ID>.scope
-		//   cgroupfs: /docker/<container-ID>
-		//
-		// In a Kubernetes pod, the cgroup path will look like:
-		//
-		//   systemd: /kubepods.slice/kubepods-<QoS-class>.slice/kubepods-<QoS-class>-pod<pod-UID>.slice/<container-iD>.scope
-		//   cgroupfs: /kubepods/<QoS-class>/pod<pod-UID>/<container-iD>
-		//
-		dir, id := path.Split(cgroupPath)
-		if strings.HasSuffix(id, systemdScopeSuffix) {
-			id = id[:len(id)-len(systemdScopeSuffix)]
-			if dash := strings.IndexRune(id, '-'); dash != -1 {
-				id = id[dash+1:]
+		// split based on the last occurrence of the colon character, if such exists, in order
+		// to support paths of containers created by containerd-cri, where the path part takes
+		// the form: <dirname>:cri-containerd:<container-ID>
+		idx := strings.LastIndex(cgroupPath, ":")
+		if idx == -1 {
+			// if colon char is not found within the path, the split is done based on the
+			// last occurrence of the slash character
+			if idx = strings.LastIndex(cgroupPath, "/"); idx == -1 {
+				continue
 			}
 		}
-		if match := kubepodsRegexp.FindStringSubmatch(dir); match != nil {
+
+		dirname, basename := cgroupPath[:idx], cgroupPath[idx+1:]
+
+		// If the basename ends with ".scope", check for a hyphen and remove everything up to
+		// and including that. This allows us to match .../docker-<container-id>.scope as well
+		// as .../<container-id>.
+		if strings.HasSuffix(basename, ".scope") {
+			basename = strings.TrimSuffix(basename, ".scope")
+
+			if hyphen := strings.Index(basename, "-"); hyphen != -1 {
+				basename = basename[hyphen+1:]
+			}
+		}
+		if match := kubepodsRegexp.FindStringSubmatch(dirname); match != nil {
 			// By default, Kubernetes will set the hostname of
 			// the pod containers to the pod name. Users that
 			// override the name should use the Downard API to
@@ -145,9 +152,9 @@ func readCgroupContainerInfo(r io.Reader) (*model.Container, *model.Kubernetes, 
 			// We don't check the contents of the last path segment
 			// when we've matched "^/kubepods"; we assume that it is
 			// a valid container ID.
-			container = &model.Container{ID: id}
-		} else if containerIDRegexp.MatchString(id) {
-			container = &model.Container{ID: id}
+			container = &model.Container{ID: basename}
+		} else if containerIDRegexp.MatchString(basename) {
+			container = &model.Container{ID: basename}
 		}
 	}
 	if err := s.Err(); err != nil {

--- a/internal/apmhostutil/container_linux.go
+++ b/internal/apmhostutil/container_linux.go
@@ -46,12 +46,12 @@ var (
 	kubepodsRegexp = regexp.MustCompile(
 		"" +
 			`(?:^/kubepods[\S]*/pod([^/]+)/$)|` +
-			`(?:^/kubepods\.slice/kubepods-[^/]+\.slice/kubepods-[^/]+-pod([^/]+)\.slice/$)`,
+			`(?:kubepods[^/]*-pod([^/]+)\.slice/)`,
 	)
 
 	containerIDRegexp = regexp.MustCompile(
 		"^" +
-			"[[:xdigit:]]{64}|" +
+			"[[:xdigit:]]{64}$|" +
 			"[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4,}" +
 			"$",
 	)

--- a/internal/apmhostutil/container_linux.go
+++ b/internal/apmhostutil/container_linux.go
@@ -49,10 +49,9 @@ var (
 	)
 
 	containerIDRegexp = regexp.MustCompile(
-		"^" +
-			"[[:xdigit:]]{64}$|" +
-			"[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4,}" +
-			"$",
+		"" +
+			"^[[:xdigit:]]{64}$|" +
+			"^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4,}$",
 	)
 )
 

--- a/internal/apmhostutil/container_linux.go
+++ b/internal/apmhostutil/container_linux.go
@@ -32,10 +32,6 @@ import (
 	"go.elastic.co/apm/v2/model"
 )
 
-const (
-	systemdScopeSuffix = ".scope"
-)
-
 var (
 	cgroupContainerInfoOnce  sync.Once
 	cgroupContainerInfoError error

--- a/internal/apmhostutil/container_linux_test.go
+++ b/internal/apmhostutil/container_linux_test.go
@@ -129,11 +129,14 @@ func TestCgroupContainerInfoKubernetes(t *testing.T) {
 		containerID:      "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63",
 		kubernetesPodUID: "90d81341-92de-11e7-8cf2-507b9d4141fa",
 	}, {
+		input:            "1:name=systemd:/system.slice/containerd.service/kubepods-burstable-podff49d0be_16b7_4a49_bb9e_8ec1f1f4e27f.slice:cri-containerd:0f99ad5f45163ed14ab8eaf92ed34bb4a631d007f8755a7d79be614bcb0df0ef",
+		containerID:      "0f99ad5f45163ed14ab8eaf92ed34bb4a631d007f8755a7d79be614bcb0df0ef",
+		kubernetesPodUID: "ff49d0be-16b7-4a49-bb9e-8ec1f1f4e27f",
+	}, {
 		input:            "9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope",
 		containerID:      "b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f",
 		kubernetesPodUID: "22949dce-fd8b-11ea-8ede-98f2b32c645c",
 	}, {
-
 		input:            "12:pids:/kubepods/kubepods/besteffort/pod0e886e9a-3879-45f9-b44d-86ef9df03224/244a65edefdffe31685c42317c9054e71dc1193048cf9459e2a4dd35cbc1dba4",
 		containerID:      "244a65edefdffe31685c42317c9054e71dc1193048cf9459e2a4dd35cbc1dba4",
 		kubernetesPodUID: "0e886e9a-3879-45f9-b44d-86ef9df03224",

--- a/internal/apmhostutil/container_linux_test.go
+++ b/internal/apmhostutil/container_linux_test.go
@@ -129,6 +129,11 @@ func TestCgroupContainerInfoKubernetes(t *testing.T) {
 		containerID:      "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63",
 		kubernetesPodUID: "90d81341-92de-11e7-8cf2-507b9d4141fa",
 	}, {
+		input:            "9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope",
+		containerID:      "b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f",
+		kubernetesPodUID: "22949dce-fd8b-11ea-8ede-98f2b32c645c",
+	}, {
+
 		input:            "12:pids:/kubepods/kubepods/besteffort/pod0e886e9a-3879-45f9-b44d-86ef9df03224/244a65edefdffe31685c42317c9054e71dc1193048cf9459e2a4dd35cbc1dba4",
 		containerID:      "244a65edefdffe31685c42317c9054e71dc1193048cf9459e2a4dd35cbc1dba4",
 		kubernetesPodUID: "0e886e9a-3879-45f9-b44d-86ef9df03224",


### PR DESCRIPTION
update k8s pod ID discovery regex to the current status of the spec.

See https://github.com/elastic/apm/blob/main/specs/agents/metadata.md#containerkubernetes-metadata

Add a testcase to make sure the pod mentioned in the related issue is
discovered correctly.

Closes https://github.com/elastic/apm-agent-go/issues/822