### PR TITLE
tracer: Parse global labels per tracer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,8 @@ endif::[]
 
 https://github.com/elastic/apm-agent-go/compare/v2.1.0...main[View commits]
 
+- Global labels are now parsed when the tracer is constructed, instead of parsing only once on package initialization {pull}1290[#(1290)]
+
 [[release-notes-2.x]]
 === Go Agent version 2.x
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,6 @@ import (
 	"go.elastic.co/apm/v2/internal/apmlog"
 	"go.elastic.co/apm/v2/internal/configutil"
 	"go.elastic.co/apm/v2/internal/wildcard"
-	"go.elastic.co/apm/v2/model"
 	"go.elastic.co/apm/v2/transport"
 )
 
@@ -125,21 +124,6 @@ var (
 		"*auth*",
 		"set-cookie",
 	}, ","))
-
-	globalLabels = func() model.StringMap {
-		var labels model.StringMap
-		for _, kv := range configutil.ParseListEnv(envGlobalLabels, ",", nil) {
-			i := strings.IndexRune(kv, '=')
-			if i > 0 {
-				k, v := strings.TrimSpace(kv[:i]), strings.TrimSpace(kv[i+1:])
-				labels = append(labels, model.StringMapItem{
-					Key:   cleanLabelKey(k),
-					Value: truncateString(v),
-				})
-			}
-		}
-		return labels
-	}()
 )
 
 // Regular expression matching comment characters to escape in the User-Agent header value.


### PR DESCRIPTION
## Description
This patch removes the `globalLabel` variable and one-time parsing of
the global labels, in favor of parsing the global labels individually
on tracer construction. This has the advantage that tracers that are
created after start-up will parse environment variables at that time
and not only when the `apm` package is imported.

Encountered while writing a systemtest for elastic/apm-server#8139.
