### PR TITLE
fix: readd deprecated span_frames_min_duration option as fallback for older configuration

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -426,6 +426,25 @@ The minimum duration allowed for this setting is 1 microsecond (`us`).
 
 [float]
 [[config-span-frames-min-duration-ms]]
+=== `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`
+
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+
+[options="header"]
+|============
+| Environment                                 | Default
+| `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`      | `5ms`
+|============
+
+The APM agent will collect a stack trace for every recorded span whose duration
+exceeds this configured value. While this is very helpful to find the exact
+place in your code that causes the span, collecting this stack trace does have
+some processing and storage overhead.
+
+NOTE: This configuration has been deprecated and will be removed in a future major version of the agent.
+
+[float]
+[[config-span-stack-trace-min-duration]]
 === `ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION`
 
 <<dynamic-configuration, image:./images/dynamic-config.svg[] >>

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -441,6 +441,9 @@ exceeds this configured value. While this is very helpful to find the exact
 place in your code that causes the span, collecting this stack trace does have
 some processing and storage overhead.
 
+NOTE: This configuration was previously known as `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`, which has been deprecated and will be removed in a future major
+version of the agent.
+
 [float]
 [[config-stack-trace-limit]]
 === `ELASTIC_APM_STACK_TRACE_LIMIT`


### PR DESCRIPTION
We cannot remove a config option right away as that's a breaking change
and it would create issue for older agents updating.
Add a deprecation notice to the config doc and add the old option as fallback.