### PR TITLE
docs: update correct env flag for loglevel

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -26,7 +26,7 @@ you can set `ELASTIC_APM_LOG_FILE=stderr`.
 NOTE: The agent does not rotate log files. Log rotation must be handled externally.
 
 With logging enabled, use <<config-log-level,`ELASTIC_APM_LOG_LEVEL`>> to increase the granularity of the agent's logging.
-For example: `ELASTIC_APM_LOG_FILE=debug`.
+For example: `ELASTIC_APM_LOG_LEVEL=debug`.
 
 Be sure to execute a few requests to your application before posting your log files.
 Each request should add lines similar to these in the logs:


### PR DESCRIPTION
+ fixes the env flag for log level in docs. 