### PR TITLE
apmelasticsearch: don't use Host for cluster name

### DIFF
--- a/module/apmelasticsearch/client.go
+++ b/module/apmelasticsearch/client.go
@@ -93,10 +93,9 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		Resource: "elasticsearch",
 	})
 
+	// TODO implement the rest of the spec for determining the cluster name:
+	// https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-db.md#cluster-name
 	clusterName := req.Header.Get("x-found-handling-cluster")
-	if clusterName == "" {
-		clusterName = req.URL.Host
-	}
 
 	span.Context.SetServiceTarget(apm.ServiceTargetSpanContext{
 		Type: "elasticsearch",

--- a/module/apmelasticsearch/internal/integration/elastic_integration_test.go
+++ b/module/apmelasticsearch/internal/integration/elastic_integration_test.go
@@ -71,14 +71,12 @@ func TestElastic(t *testing.T) {
 	assert.Equal(t, "", spans[0].Action)
 	assert.Equal(t, &model.SpanContext{
 		Database: &model.DatabaseSpanContext{
-			Instance:  esurl.Host,
 			Type:      "elasticsearch",
 			Statement: `{"query":{"match_all":{}}}`,
 		},
 		Service: &model.ServiceSpanContext{
 			Target: &model.ServiceTargetSpanContext{
 				Type: "elasticsearch",
-				Name: esurl.Host,
 			},
 		},
 		HTTP: &model.HTTPSpanContext{

--- a/module/apmelasticsearch/internal/integration/olivere_integration_test.go
+++ b/module/apmelasticsearch/internal/integration/olivere_integration_test.go
@@ -77,7 +77,6 @@ func TestOlivereElastic(t *testing.T) {
 	assert.Equal(t, "", spans[0].Action)
 	assert.Equal(t, &model.SpanContext{
 		Database: &model.DatabaseSpanContext{
-			Instance:  esurl.Host,
 			Type:      "elasticsearch",
 			Statement: `{"query":{"match_all":{}}}`,
 		},
@@ -93,7 +92,6 @@ func TestOlivereElastic(t *testing.T) {
 		Service: &model.ServiceSpanContext{
 			Target: &model.ServiceTargetSpanContext{
 				Type: "elasticsearch",
-				Name: esurl.Host,
 			},
 		},
 		HTTP: &model.HTTPSpanContext{


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-go/issues/1306