### PR TITLE
fix: allow exit spans to have child spans with the same type and subtype

### DIFF
--- a/span.go
+++ b/span.go
@@ -70,8 +70,14 @@ func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions)
 	}
 
 	if opts.parent.IsExitSpan() {
-		spanType, after, _ := strings.Cut(spanType, ".")
-		subType, _, _ := strings.Cut(after, ".")
+		arr := strings.SplitN(spanType, ".", 3)
+
+		spanType := arr[0]
+		subType := ""
+
+		if len(arr) > 1 {
+			subType = arr[1]
+		}
 
 		if spanType != opts.parent.Type || subType != opts.parent.Subtype {
 			return newDroppedSpan()

--- a/span.go
+++ b/span.go
@@ -352,7 +352,8 @@ func (s *Span) End() {
 			return
 		}
 
-		s.Context.destination = model.DestinationSpanContext{}
+		s.Context.model.Destination = nil
+		s.Context.model.Service = nil
 	}
 	if s.exit && !s.Context.setDestinationServiceCalled {
 		// The span was created as an exit span, but the user did not

--- a/span.go
+++ b/span.go
@@ -65,8 +65,17 @@ func (tx *Transaction) StartSpan(name, spanType string, parent *Span) *Span {
 // span type, subtype, and action; a single dot separates span type and
 // subtype, and the action will not be set.
 func (tx *Transaction) StartSpanOptions(name, spanType string, opts SpanOptions) *Span {
-	if tx == nil || opts.parent.IsExitSpan() {
+	if tx == nil {
 		return newDroppedSpan()
+	}
+
+	if opts.parent.IsExitSpan() {
+		spanType, after, _ := strings.Cut(spanType, ".")
+		subType, _, _ := strings.Cut(after, ".")
+
+		if spanType != opts.parent.Type || subType != opts.parent.Subtype {
+			return newDroppedSpan()
+		}
 	}
 
 	if opts.Parent == (TraceContext{}) {

--- a/span.go
+++ b/span.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.elastic.co/apm/v2/model"
 	"go.elastic.co/apm/v2/stacktrace"
 )
 
@@ -350,6 +351,8 @@ func (s *Span) End() {
 			s.tracer = nil
 			return
 		}
+
+		s.Context.destination = model.DestinationSpanContext{}
 	}
 	if s.exit && !s.Context.setDestinationServiceCalled {
 		// The span was created as an exit span, but the user did not

--- a/span_test.go
+++ b/span_test.go
@@ -241,13 +241,13 @@ func TestStartExitSpan(t *testing.T) {
 
 	// when the parent span is an exit span, any children should be noops.
 	span2 := tx.StartSpan("name", "differenttype", span)
-	assert.True(t, span2.Dropped())
 	span2.End()
+	assert.True(t, span2.Dropped())
 
 	// Exit spans MAY have child spans that have the same `type` and `subtype`.
 	span3 := tx.StartSpan("name", "type", span)
-	assert.False(t, span3.Dropped())
 	span3.End()
+	assert.False(t, span3.Dropped())
 
 	span.End()
 


### PR DESCRIPTION
Do not silently drop child spans of exit spans. The spec allows for exit spans to have child spans if they have the same type and subtype. One example of this is http trace requests being child spans of an exit span.

Update exit span test to make sure the feature is working as intended.

Closes https://github.com/elastic/apm-agent-go/issues/1319