### PR TITLE
fix(apmredigo): mark calls with timeout as exit spans

### DIFF
--- a/module/apmredigo/conn.go
+++ b/module/apmredigo/conn.go
@@ -106,7 +106,9 @@ func DoWithTimeout(ctx context.Context, conn redis.Conn, timeout time.Duration, 
 	if spanName == "" {
 		spanName = "(flush pipeline)"
 	}
-	span, _ := apm.StartSpan(ctx, spanName, "db.redis")
+	span, _ := apm.StartSpanOptions(ctx, spanName, "db.redis", apm.SpanOptions{
+		ExitSpan: true,
+	})
 	defer span.End()
 	return redis.DoWithTimeout(conn, timeout, commandName, args...)
 }

--- a/module/apmredigo/conn_test.go
+++ b/module/apmredigo/conn_test.go
@@ -77,7 +77,7 @@ func TestConnWithTimeout(t *testing.T) {
 
 func TestWrapPipeline(t *testing.T) {
 	var conn mockConnWithTimeout
-	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+	_, spans, _ := apmtest.WithUncompressedTransaction(func(ctx context.Context) {
 		conn := apmredigo.Wrap(conn).WithContext(ctx)
 		conn.Do("")
 		redis.DoWithTimeout(conn, time.Second, "")


### PR DESCRIPTION
Specific calls (DoWithTimeout) were not being marked as exit spans, as opposed to normal calls.
Add span options and mark the span as exit span.