### PR TITLE
fix(apmsql): mark connect span as exit span

### DIFF
--- a/module/apmsql/driver.go
+++ b/module/apmsql/driver.go
@@ -181,7 +181,9 @@ type driverConnector struct {
 }
 
 func (d *driverConnector) Connect(ctx context.Context) (driver.Conn, error) {
-	span, ctx := apm.StartSpan(ctx, "connect", d.driver.connectSpanType)
+	span, ctx := apm.StartSpanOptions(ctx, "connect", d.driver.connectSpanType, apm.SpanOptions{
+		ExitSpan: true,
+	})
 	defer span.End()
 	dsnInfo := d.driver.dsnParser(d.name)
 	if !span.Dropped() {


### PR DESCRIPTION
The first connect span from the driver connector was not being marked as an exit span.
Add span options and mark it as exit span like the other spans for external services