### PR TITLE
feat: ignore *principal* headers by default

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ https://github.com/elastic/apm-agent-go/compare/v2.1.0...main[View commits]
 
 - Global labels are now parsed when the tracer is constructed, instead of parsing only once on package initialization {pull}1290[#(1290)]
 - Rename span_frames_min_duration to span_stack_trace_min_duration {pull}1285[#(1285)]
+- Ignore *principal* headers by default {pull}1332[#(1332)]
 
 [[release-notes-2.x]]
 === Go Agent version 2.x

--- a/config.go
+++ b/config.go
@@ -124,6 +124,7 @@ var (
 		"*card*",
 		"*auth*",
 		"set-cookie",
+		"*principal*",
 	}, ","))
 )
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -279,7 +279,7 @@ version of the agent.
 [options="header"]
 |============
 | Environment                        | Default                                                                                                | Example
-| `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, *auth*, set-cookie` | `sekrits`
+| `ELASTIC_APM_SANITIZE_FIELD_NAMES` | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, *auth*, set-cookie, *principal*` | `sekrits`
 |============
 
 A list of patterns to match the names of HTTP headers, cookies, and POST form fields to redact.

--- a/internal/wildcard/matcher_test.go
+++ b/internal/wildcard/matcher_test.go
@@ -160,6 +160,7 @@ var benchmarkPatterns = []string{
 	"*session*",
 	"*credit*",
 	"*card*",
+	"*principal*",
 }
 
 func BenchmarkWildcardMatcher(b *testing.B) {


### PR DESCRIPTION
Update sanitization rule to ignore *principal* headers by default. Update documentation with the new default values.

Mostly related to Azure SSO and potential exposure of PII.

Closes https://github.com/elastic/apm-agent-go/issues/1316

Spec: https://github.com/elastic/apm/pull/680