### PR TITLE
Mark some more spans as exit spans

### DIFF
--- a/module/apmgocql/apmgocql_test.go
+++ b/module/apmgocql/apmgocql_test.go
@@ -74,6 +74,18 @@ func TestQueryObserver(t *testing.T) {
 			Instance:  "quay ",
 			Statement: "SELECT * FROM foo.bar",
 		},
+		Destination: &model.DestinationSpanContext{
+			Service: &model.DestinationServiceSpanContext{
+				Type:     "db",
+				Resource: "cassandra",
+			},
+		},
+		Service: &model.ServiceSpanContext{
+			Target: &model.ServiceTargetSpanContext{
+				Type: "cassandra",
+				Name: "quay ",
+			},
+		},
 	}, spans[0].Context)
 
 	require.Len(t, errors, 1)

--- a/module/apmgocql/apmgocql_test.go
+++ b/module/apmgocql/apmgocql_test.go
@@ -183,6 +183,17 @@ func TestQueryObserverIntegration(t *testing.T) {
 			Type:      "cassandra",
 			Statement: createKeyspaceStatement,
 		},
+		Destination: &model.DestinationSpanContext{
+			Service: &model.DestinationServiceSpanContext{
+				Type:     "db",
+				Resource: "cassandra",
+			},
+		},
+		Service: &model.ServiceSpanContext{
+			Target: &model.ServiceTargetSpanContext{
+				Type: "cassandra",
+			},
+		},
 	}, spans[0].Context)
 	assert.Equal(t, "CREATE", spans[1].Name)
 	assert.Equal(t, "INSERT INTO foo.bar", spans[2].Name)

--- a/module/apmgocql/observer.go
+++ b/module/apmgocql/observer.go
@@ -87,7 +87,8 @@ func (o *Observer) ObserveBatch(ctx context.Context, batch gocql.ObservedBatch) 
 // ObserveQuery observes query results, and creates spans for them.
 func (o *Observer) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
 	span, _ := apm.StartSpanOptions(ctx, querySignature(query.Statement), "db.cassandra.query", apm.SpanOptions{
-		Start: query.Start,
+		Start:    query.Start,
+		ExitSpan: true,
 	})
 	span.Duration = query.End.Sub(query.Start)
 	span.Context.SetDatabase(apm.DatabaseSpanContext{

--- a/module/apmgoredis/client_test.go
+++ b/module/apmgoredis/client_test.go
@@ -87,7 +87,7 @@ func TestWrap(t *testing.T) {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
 			client := testCase.client
 
-			_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+			_, spans, _ := apmtest.WithUncompressedTransaction(func(ctx context.Context) {
 				client := apmgoredis.Wrap(client).WithContext(ctx)
 				client.Ping()
 			})
@@ -113,7 +113,7 @@ func TestWithContext(t *testing.T) {
 				client.Ping()
 			}
 
-			_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+			_, spans, _ := apmtest.WithUncompressedTransaction(func(ctx context.Context) {
 				client := apmgoredis.Wrap(client)
 				ping(ctx, client)
 			})
@@ -131,7 +131,7 @@ func TestWrapPipeline(t *testing.T) {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
 			client := testCase.client
 
-			_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+			_, spans, _ := apmtest.WithUncompressedTransaction(func(ctx context.Context) {
 				client := apmgoredis.Wrap(client).WithContext(ctx)
 				pipe := client.Pipeline()
 				pipe.Do("")
@@ -140,9 +140,9 @@ func TestWrapPipeline(t *testing.T) {
 			})
 
 			require.Len(t, spans, 3)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
+			assert.Equal(t, "(empty command)", spans[0].Name)
 			assert.Equal(t, "(empty command)", spans[1].Name)
-			assert.Equal(t, "(empty command)", spans[2].Name)
+			assert.Equal(t, "(pipeline)", spans[2].Name)
 		})
 	}
 }
@@ -156,7 +156,7 @@ func TestWrapPipelineTransaction(t *testing.T) {
 
 			client := testCase.client
 
-			_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+			_, spans, _ := apmtest.WithUncompressedTransaction(func(ctx context.Context) {
 				client := apmgoredis.Wrap(client).WithContext(ctx)
 				pipe := client.TxPipeline()
 				pipe.Do("")
@@ -165,9 +165,9 @@ func TestWrapPipelineTransaction(t *testing.T) {
 			})
 
 			require.Len(t, spans, 3)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
+			assert.Equal(t, "(empty command)", spans[0].Name)
 			assert.Equal(t, "(empty command)", spans[1].Name)
-			assert.Equal(t, "(empty command)", spans[2].Name)
+			assert.Equal(t, "(pipeline)", spans[2].Name)
 		})
 	}
 }
@@ -177,7 +177,7 @@ func TestWrapPipelined(t *testing.T) {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
 			client := testCase.client
 
-			_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+			_, spans, _ := apmtest.WithUncompressedTransaction(func(ctx context.Context) {
 				client := apmgoredis.Wrap(client).WithContext(ctx)
 
 				client.Pipelined(func(pipe redis.Pipeliner) error {
@@ -190,10 +190,10 @@ func TestWrapPipelined(t *testing.T) {
 			})
 
 			require.Len(t, spans, 4)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
-			assert.Equal(t, "SET", spans[1].Name)
-			assert.Equal(t, "GET", spans[2].Name)
-			assert.Equal(t, "FLUSHDB", spans[3].Name)
+			assert.Equal(t, "SET", spans[0].Name)
+			assert.Equal(t, "GET", spans[1].Name)
+			assert.Equal(t, "FLUSHDB", spans[2].Name)
+			assert.Equal(t, "(pipeline)", spans[3].Name)
 		})
 	}
 }
@@ -207,7 +207,7 @@ func TestWrapPipelinedTransaction(t *testing.T) {
 
 			client := testCase.client
 
-			_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+			_, spans, _ := apmtest.WithUncompressedTransaction(func(ctx context.Context) {
 				client := apmgoredis.Wrap(client).WithContext(ctx)
 
 				client.TxPipelined(func(pipe redis.Pipeliner) error {
@@ -220,10 +220,10 @@ func TestWrapPipelinedTransaction(t *testing.T) {
 			})
 
 			require.Len(t, spans, 4)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
-			assert.Equal(t, "SET", spans[1].Name)
-			assert.Equal(t, "GET", spans[2].Name)
-			assert.Equal(t, "FLUSHDB", spans[3].Name)
+			assert.Equal(t, "SET", spans[0].Name)
+			assert.Equal(t, "GET", spans[1].Name)
+			assert.Equal(t, "FLUSHDB", spans[2].Name)
+			assert.Equal(t, "(pipeline)", spans[3].Name)
 		})
 	}
 }

--- a/module/apmgoredis/integration_test.go
+++ b/module/apmgoredis/integration_test.go
@@ -111,10 +111,10 @@ func TestPipelined(t *testing.T) {
 			})
 
 			require.Len(t, spans, 4)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
-			assert.Equal(t, "SET", spans[1].Name)
-			assert.Equal(t, "GET", spans[2].Name)
-			assert.Equal(t, "FLUSHDB", spans[3].Name)
+			assert.Equal(t, "SET", spans[0].Name)
+			assert.Equal(t, "GET", spans[1].Name)
+			assert.Equal(t, "FLUSHDB", spans[2].Name)
+			assert.Equal(t, "(pipeline)", spans[3].Name)
 		})
 	}
 }
@@ -151,10 +151,10 @@ func TestPipeline(t *testing.T) {
 			})
 
 			require.Len(t, spans, 4)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
-			assert.Equal(t, "SET", spans[1].Name)
-			assert.Equal(t, "GET", spans[2].Name)
-			assert.Equal(t, "FLUSHDB", spans[3].Name)
+			assert.Equal(t, "SET", spans[0].Name)
+			assert.Equal(t, "GET", spans[1].Name)
+			assert.Equal(t, "FLUSHDB", spans[2].Name)
+			assert.Equal(t, "(pipeline)", spans[3].Name)
 		})
 	}
 }
@@ -203,10 +203,10 @@ func TestPipelinedTransaction(t *testing.T) {
 			})
 
 			require.Len(t, spans, 4)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
+			assert.Equal(t, "INCR", spans[0].Name)
 			assert.Equal(t, "INCR", spans[1].Name)
 			assert.Equal(t, "INCR", spans[2].Name)
-			assert.Equal(t, "INCR", spans[3].Name)
+			assert.Equal(t, "(pipeline)", spans[3].Name)
 		})
 	}
 }
@@ -251,10 +251,10 @@ func TestPipelineTransaction(t *testing.T) {
 			})
 
 			require.Len(t, spans, 4)
-			assert.Equal(t, "(pipeline)", spans[0].Name)
+			assert.Equal(t, "INCR", spans[0].Name)
 			assert.Equal(t, "INCR", spans[1].Name)
 			assert.Equal(t, "INCR", spans[2].Name)
-			assert.Equal(t, "INCR", spans[3].Name)
+			assert.Equal(t, "(pipeline)", spans[3].Name)
 		})
 	}
 }

--- a/module/apmgorm/apmgorm_test.go
+++ b/module/apmgorm/apmgorm_test.go
@@ -121,7 +121,7 @@ func testWithContext(t *testing.T, dsnInfo apmsql.DSNInfo, dialect string, args 
 			Port:    dsnInfo.Port,    // might be ""
 			Service: &model.DestinationServiceSpanContext{
 				Type:     "db",
-				Resource: "sqlite3",
+				Resource: span.Subtype,
 			},
 		}, span.Context.Destination)
 	}

--- a/module/apmgorm/context.go
+++ b/module/apmgorm/context.go
@@ -110,7 +110,9 @@ func newBeforeCallback(spanType string) func(*gorm.Scope) {
 		if !ok {
 			return
 		}
-		span, ctx := apm.StartSpan(ctx, "", spanType)
+		span, ctx := apm.StartSpanOptions(ctx, "", spanType, apm.SpanOptions{
+			ExitSpan: true,
+		})
 		if span.Dropped() {
 			span.End()
 			ctx = nil

--- a/span.go
+++ b/span.go
@@ -370,6 +370,9 @@ func (s *Span) End() {
 		s.Context.model.Destination = nil
 		s.Context.model.Service = nil
 
+		// BUG(axw) s.parent.SpanData must be accessed with s.parent.mu held.
+		// Even then, s.parent.SpanData will be nil if ended, so we need to
+		// find an alternative approach.
 		if s.Type != s.parent.Type || s.Subtype != s.parent.Subtype {
 			s.dropWhen(true)
 			s.end()

--- a/span.go
+++ b/span.go
@@ -295,6 +295,12 @@ type Span struct {
 	// SpanData holds the span data. This field is set to nil when
 	// the span's End method is called.
 	*SpanData
+
+	// finalType and finalSubtype are set to SpanData.Type and SpanData.Subtype
+	// respectively when the span is ended. This is necessary for filtering out
+	// child spans of exit spans that have non-matching type/subtype.
+	finalType    string
+	finalSubtype string
 }
 
 // TraceContext returns the span's TraceContext.
@@ -366,14 +372,30 @@ func (s *Span) End() {
 	if s.Type == "" {
 		s.Type = "custom"
 	}
+	// Store the span type and subtype on the Span struct so we can filter
+	// out child spans of exit spans with non-matching type/subtype below.
+	s.finalType = s.Type
+	s.finalSubtype = s.Subtype
+
 	if s.parent.IsExitSpan() {
+		// Children of exit spans must not have service destination/target
+		// context, as otherwise service destination metrics will be double
+		// counted.
 		s.Context.model.Destination = nil
 		s.Context.model.Service = nil
 
-		// BUG(axw) s.parent.SpanData must be accessed with s.parent.mu held.
-		// Even then, s.parent.SpanData will be nil if ended, so we need to
-		// find an alternative approach.
-		if s.Type != s.parent.Type || s.Subtype != s.parent.Subtype {
+		var parentType, parentSubtype string
+		s.parent.mu.RLock()
+		if s.parent.ended() {
+			parentType = s.parent.finalType
+			parentSubtype = s.parent.finalSubtype
+		} else {
+			parentType = s.parent.Type
+			parentSubtype = s.parent.Subtype
+		}
+		s.parent.mu.RUnlock()
+
+		if s.Type != parentType || s.Subtype != parentSubtype {
 			s.dropWhen(true)
 			s.end()
 			return

--- a/span_test.go
+++ b/span_test.go
@@ -239,7 +239,8 @@ func TestStartExitSpan(t *testing.T) {
 	span := tx.StartSpanOptions("name", "type", apm.SpanOptions{ExitSpan: true})
 	assert.True(t, span.IsExitSpan())
 
-	// when the parent span is an exit span, any children should be noops.
+	// when the parent span is an exit span, children with a different type or
+	// subtype should be noops.
 	span2 := tx.StartSpan("name", "differenttype", span)
 	span2.End()
 	assert.True(t, span2.Dropped())
@@ -254,6 +255,12 @@ func TestStartExitSpan(t *testing.T) {
 	// Spans should still be marked as an exit span after they've been
 	// ended.
 	assert.True(t, span.IsExitSpan())
+
+	// Even ended exit spans MAY have child spans that have the same
+	// `type` and `subtype`.
+	span4 := tx.StartSpan("name", "type", span)
+	span4.End()
+	assert.False(t, span4.Dropped())
 }
 
 func TestSpanStackTraceMinDurationSpecialCases(t *testing.T) {


### PR DESCRIPTION
Also, note a bug in Span.End() when ending a child of an exit span.

Relates to https://github.com/elastic/apm-agent-go/issues/1315