### PR TITLE
Add Unwrap to return the wrapped driver.Conn

### DIFF
--- a/module/apmsql/conn.go
+++ b/module/apmsql/conn.go
@@ -206,6 +206,11 @@ func (c *conn) CheckNamedValue(nv *driver.NamedValue) error {
 	return checkNamedValue(nv, c.namedValueChecker)
 }
 
+// Unwrap returns the wrapped database/sql/driver.Conn.
+func (c *conn) Unwrap() driver.Conn {
+	return c.Conn
+}
+
 type connBeginTx struct {
 	*conn
 	connBeginTx driver.ConnBeginTx

--- a/module/apmsql/conn_test.go
+++ b/module/apmsql/conn_test.go
@@ -1,0 +1,31 @@
+package apmsql_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.elastic.co/apm/module/apmsql"
+	_ "go.elastic.co/apm/module/apmsql/sqlite3"
+)
+
+func TestConnUnwrap(t *testing.T) {
+	db, err := apmsql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	type Unwrapper interface {
+		Unwrap() driver.Conn
+	}
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	_ = conn.Raw(func(driverConn interface{}) error {
+		unwrappedConn := driverConn.(Unwrapper)
+		require.Equal(t, "*apmsql.connBeginTx", fmt.Sprintf("%T", unwrappedConn))
+		return nil
+	})
+}


### PR DESCRIPTION
Since go 1.13, [`Conn.Raw`](https://pkg.go.dev/database/sql#Conn.Raw) was added to allow extracting the underlying connection. It becomes handy if it's used with libraries like ([pgx](https://github.com/jackc/pgx/blob/master/stdlib/sql.go)) which will allow us to run pgx-specific functionalities.

However, the current `apmsql` library adds a wrapper on top of that connection and it's a private type so there is no way to extract the raw connection from `pgx`. This PR will add `Unwrap` function which will allow getting the underlying connection.