### PR TITLE
restore instrumentation nav

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -972,7 +972,7 @@ func main() {
 ----
 
 [[builtin-modules-apmpgx]]
-== module/apmpgx
+==== module/apmpgx
 Package apmpgx provides a means of instrumenting the
 https://github.com/jackc/pgx[Pgx] for v4.17+,
 so that SQL queries are reported as spans within the current transaction.


### PR DESCRIPTION
https://www.elastic.co/guide/en/apm/agent/go/current/index.html currently renders as:

<img width="665" alt="image" src="https://user-images.githubusercontent.com/83483/213286806-71d7959f-5480-40a1-8223-1e6a62e6f9c8.png">

with `module/apmpgx` at the top level in the navigation.  This should restore the instrumentation navigation expected in the docs