### PR TITLE
[2.x] indent new apmpgx docs (#1371)

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -972,7 +972,7 @@ func main() {
 ----
 
 [[builtin-modules-apmpgx]]
-== module/apmpgx
+==== module/apmpgx
 Package apmpgx provides a means of instrumenting the
 https://github.com/jackc/pgx[Pgx] for v4.17+,
 so that SQL queries are reported as spans within the current transaction.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.x`:
 - [indent new apmpgx docs (#1371)](https://github.com/elastic/apm-agent-go/pull/1371)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)