### PR TITLE
Add update-specs updatecli workflow

### DIFF
--- a/.ci/update-specs.yml
+++ b/.ci/update-specs.yml
@@ -1,0 +1,101 @@
+name: update-specs
+
+title: synchronize schema specs
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: apm-agent-go
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+
+sources:
+  sha:
+    kind: file
+    spec:
+      file: 'https://github.com/elastic/apm-data/commit/main.patch'
+      matchpattern: "^From\\s([0-9a-f]{40})\\s"
+  error.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/error.json
+  metadata.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/metadata.json
+  metricset.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/metricset.json
+  span.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/span.json
+  transaction.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/transaction.json
+
+actions:
+  pr:
+    kind: "github/pullrequest"
+    scmid: default
+    sourceid: sha
+    spec:
+      automerge: false
+      draft: false
+      labels:
+        - "automation"
+      description: |-
+        ### What
+        APM agent json schema automatic sync
+        ### Why
+        *Changeset*
+        * https://github.com/elastic/apm-data/commit/{{ source "sha" }}
+
+targets:
+  error.json:
+    name: error.json
+    scmid: default
+    sourceid: error.json
+    kind: file
+    spec:
+      file: internal/apmschema/jsonschema/error.json
+      forcecreate: true
+  metadata.json:
+    name: metadata.json
+    scmid: default
+    sourceid: metadata.json
+    kind: file
+    spec:
+      file: internal/apmschema/jsonschema/metadata.json
+      forcecreate: true
+  metricset.json:
+    name: metricset.json
+    scmid: default
+    sourceid: metricset.json
+    kind: file
+    spec:
+      file: internal/apmschema/jsonschema/metricset.json
+      forcecreate: true
+  span.json:
+    name: span.json
+    scmid: default
+    sourceid: span.json
+    kind: file
+    spec:
+      file: internal/apmschema/jsonschema/span.json
+      forcecreate: true
+  transaction.json:
+    name: transaction.json
+    scmid: default
+    sourceid: transaction.json
+    kind: file
+    spec:
+      file: internal/apmschema/jsonschema/transaction.json
+      forcecreate: true

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -5,6 +5,7 @@ on:
   workflow_run:
     workflows:
       - ci
+      - update-specs
     types: [completed]
 
 jobs:

--- a/.github/workflows/update-specs.yml
+++ b/.github/workflows/update-specs.yml
@@ -1,0 +1,32 @@
+name: update-specs
+
+on:
+  workflow_dispatch: ~
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Git
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
+      - name: Run Updatecli
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: updatecli apply --config ./.ci/update-specs.yml
+      - if: failure()
+        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#apm-agent-go"


### PR DESCRIPTION
## What does this pull request do?

Moves the update specs workflow from apm-server to the consumer using updatecli to have a "dependabot"-like experience.

## How to test

```
GITHUB_TOKEN=<token>\
GIT_USER=<username> \
GIT_EMAIL=j<email> \
updatecli diff -c .ci/update-specs.yml
```

## Related issues

- https://github.com/elastic/observability-robots/issues/1516

