### PR TITLE
Fix sha source in updatecli update-specs.yml

### DIFF
--- a/.ci/update-specs.yml
+++ b/.ci/update-specs.yml
@@ -20,6 +20,9 @@ sources:
     spec:
       file: 'https://github.com/elastic/apm-data/commit/main.patch'
       matchpattern: "^From\\s([0-9a-f]{40})\\s"
+    transformers:
+      - findsubmatch:
+          pattern: "[0-9a-f]{40}"
   error.json:
     kind: file
     spec:


### PR DESCRIPTION
Fix the PR description created by updatecli in for the update-specs workflow.

```diff
+* https://github.com/elastic/apm-data/commit/From f5680fd2c5aa3b592b1259f6713eb4af8468aa98
-* https://github.com/elastic/apm-data/commit/f5680fd2c5aa3b592b1259f6713eb4af8468aa98
```

![image](https://user-images.githubusercontent.com/16325797/218674386-826d47be-1fe0-4909-9cb9-ecb6955476ed.png)

## Related issues
Relates https://github.com/elastic/observability-robots/issues/1582