### PR TITLE
.github: run precheck & coverage with 'stable' go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version-file: go.mod
+          go-version: stable
           cache: true
           cache-dependency-path: '**/go.sum'
       - name: Precheck
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        go-version: [ "1.15", "1.16", "1.17", "oldstable", "stable" ]
+        go-version: [ "1.15", "1.16", "1.17", "1.18", "1.19", "oldstable", "stable" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version-file: go.mod
+          go-version: stable
           cache: true
           cache-dependency-path: '**/go.sum'
       - name: Integration tests


### PR DESCRIPTION
The integration/coverage tests don't necessarily run with all Go versions, nor do precheck Makefile targets. Use the "stable" Go version for these jobs to avoid failures like in https://github.com/elastic/apm-agent-go/actions/runs/4267287201/jobs/7428720621.