### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -21,10 +21,16 @@ endif::[]
 [[unreleased]]
 === Unreleased
 
-https://github.com/elastic/apm-agent-go/compare/v2.3.0...main[View commits]
+https://github.com/elastic/apm-agent-go/compare/v2.4.0...main[View commits]
 
 [[release-notes-2.x]]
 === Go Agent version 2.x
+
+[[release-notes-2.4.0]]
+==== 2.4.0 - 2023/04/26
+
+- Add bridge to support OpenTelemetry metrics {pull}1407[#1407]
+- Add custom SDK support OpenTelemetry traces {pull}1410[#1410]
 
 [[release-notes-2.3.0]]
 ==== 2.3.0 - 2023/03/30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,6 @@ For example, APM Server version `7.15.0` corresponds with the Go APM Agent versi
 
 1. Update `version.go` and `internal/apmversion/version.go`, and then run `make update-modules`
 2. Update [`CHANGELOG.asciidoc`](changelog.asciidoc), by adding a new version heading (`==== 1.x.x - yyyy/MM/dd`) and changing the base tag of the Unreleased comparison URL
-3. For major and minor releases, update the EOL table in [`upgrading.asciidoc`](docs/upgrading.asciidoc).
 4. Merge changes into github.com/elastic/apm-agent-go@main
 5. Create tags: vN.N.N, and module/$MODULE/vN.N.N for each instrumentation module with the script `scripts/tagversion.sh`. Execute the output manually in your terminal. Note: The output assumes `upstream` is the name of the upstream remote.
 6. Create release on GitHub: `gh release create vN.N.N`

--- a/internal/apmgodog/go.mod
+++ b/internal/apmgodog/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/cucumber/godog v0.12.2
-	go.elastic.co/apm/module/apmgrpc/v2 v2.3.0
+	go.elastic.co/apm/module/apmgrpc/v2 v2.4.0
 	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
 	go.elastic.co/apm/v2 v2.4.0
 	go.elastic.co/fastjson v1.1.0

--- a/internal/apmgodog/go.mod
+++ b/internal/apmgodog/go.mod
@@ -5,8 +5,8 @@ go 1.13
 require (
 	github.com/cucumber/godog v0.12.2
 	go.elastic.co/apm/module/apmgrpc/v2 v2.3.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	go.elastic.co/fastjson v1.1.0
 	google.golang.org/grpc v1.21.1
 )

--- a/internal/apmschema/go.mod
+++ b/internal/apmschema/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/santhosh-tekuri/jsonschema v1.2.4
 	github.com/stretchr/testify v1.8.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/internal/apmversion/version.go
+++ b/internal/apmversion/version.go
@@ -19,5 +19,5 @@ package apmversion
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "2.3.0"
+	AgentVersion = "2.4.0"
 )

--- a/module/apmawssdkgo/go.mod
+++ b/module/apmawssdkgo/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/aws/aws-sdk-go v1.38.14
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmazure/go.mod
+++ b/module/apmazure/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/Azure/azure-storage-file-go v0.8.0
 	github.com/Azure/azure-storage-queue-go v0.0.0-20191125232315-636801874cdd
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
 )
 

--- a/module/apmbeego/go.mod
+++ b/module/apmbeego/go.mod
@@ -3,9 +3,9 @@ module go.elastic.co/apm/module/apmbeego/v2
 require (
 	github.com/astaxie/beego v1.12.3
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/module/apmsql/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/module/apmsql/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmchi/go.mod
+++ b/module/apmchi/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmchi/v2
 require (
 	github.com/go-chi/chi v1.5.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmchiv5/go.mod
+++ b/module/apmchiv5/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmchiv5/v2
 require (
 	github.com/go-chi/chi/v5 v5.0.2
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmecho/go.mod
+++ b/module/apmecho/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 )
 

--- a/module/apmechov4/go.mod
+++ b/module/apmechov4/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmelasticsearch/go.mod
+++ b/module/apmelasticsearch/go.mod
@@ -2,8 +2,8 @@ module go.elastic.co/apm/module/apmelasticsearch/v2
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 )
 

--- a/module/apmelasticsearch/internal/integration/go.mod
+++ b/module/apmelasticsearch/internal/integration/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/olivere/elastic v6.2.16+incompatible
 	github.com/stretchr/testify v1.6.1
 	go.elastic.co/apm/module/apmelasticsearch/v2 v2.1.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../../../..

--- a/module/apmfasthttp/go.mod
+++ b/module/apmfasthttp/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.34.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace (

--- a/module/apmfiber/go.mod
+++ b/module/apmfiber/go.mod
@@ -5,9 +5,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	github.com/valyala/fasthttp v1.34.0
-	go.elastic.co/apm/module/apmfasthttp/v2 v2.3.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmfasthttp/v2 v2.4.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgin/go.mod
+++ b/module/apmgin/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgocql/go.mod
+++ b/module/apmgocql/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/gocql/gocql v0.0.0-20181124151448-70385f88b28b
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgokit/go.mod
+++ b/module/apmgokit/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmgrpc/v2 v2.3.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmgrpc/v2 v2.4.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 	google.golang.org/grpc v1.17.0
 )

--- a/module/apmgometrics/go.mod
+++ b/module/apmgometrics/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmgometrics/v2
 require (
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgopg/go.mod
+++ b/module/apmgopg/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.18.1 // indirect
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/module/apmsql/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmsql/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	mellium.im/sasl v0.2.1 // indirect
 )
 

--- a/module/apmgopgv10/go.mod
+++ b/module/apmgopgv10/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/go-pg/pg/v10 v10.7.3
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/module/apmsql/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmsql/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgoredis/go.mod
+++ b/module/apmgoredis/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 

--- a/module/apmgoredisv8/go.mod
+++ b/module/apmgoredisv8/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgorilla/go.mod
+++ b/module/apmgorilla/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgorm/go.mod
+++ b/module/apmgorm/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/jinzhu/gorm v1.9.10
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/module/apmsql/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmsql/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmgormv2/go.mod
+++ b/module/apmgormv2/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect
 	github.com/stretchr/testify v1.8.0
-	go.elastic.co/apm/module/apmsql/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmsql/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/tools v0.1.11 // indirect
 	gorm.io/driver/mysql v1.0.2
 	gorm.io/driver/postgres v1.3.4

--- a/module/apmgrpc/go.mod
+++ b/module/apmgrpc/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 	google.golang.org/grpc v1.17.0
 )

--- a/module/apmhttp/go.mod
+++ b/module/apmhttp/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmhttp/v2
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 )
 

--- a/module/apmhttprouter/go.mod
+++ b/module/apmhttprouter/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmhttprouter/v2
 require (
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmlambda/go.mod
+++ b/module/apmlambda/go.mod
@@ -2,7 +2,7 @@ module go.elastic.co/apm/module/apmlambda/v2
 
 require (
 	github.com/aws/aws-lambda-go v1.8.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmlogrus/go.mod
+++ b/module/apmlogrus/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.2.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 )
 

--- a/module/apmmongo/go.mod
+++ b/module/apmmongo/go.mod
@@ -2,7 +2,7 @@ module go.elastic.co/apm/module/apmmongo/v2
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 	go.mongodb.org/mongo-driver v1.5.1
 )
 

--- a/module/apmnegroni/go.mod
+++ b/module/apmnegroni/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/stretchr/testify v1.6.1
 	github.com/urfave/negroni v1.0.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmot/go.mod
+++ b/module/apmot/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmot/v2
 require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmotel/go.mod
+++ b/module/apmotel/go.mod
@@ -2,8 +2,8 @@ module go.elastic.co/apm/module/apmotel/v2
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2

--- a/module/apmpgx/go.mod
+++ b/module/apmpgx/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/jackc/pgx/v4 v4.17.0
 	github.com/stretchr/testify v1.8.0
-	go.elastic.co/apm/module/apmsql/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmsql/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmpgxv5/go.mod
+++ b/module/apmpgxv5/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/jackc/pgx/v5 v5.0.4
 	github.com/stretchr/testify v1.8.0
-	go.elastic.co/apm/module/apmsql/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmsql/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmprometheus/go.mod
+++ b/module/apmprometheus/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmredigo/go.mod
+++ b/module/apmredigo/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmredigo/v2
 require (
 	github.com/gomodule/redigo v1.8.2
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmrestful/go.mod
+++ b/module/apmrestful/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmrestfulv3/go.mod
+++ b/module/apmrestfulv3/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/emicklei/go-restful/v3 v3.8.0
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.3.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/module/apmhttp/v2 v2.4.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/module/apmsql/go.mod
+++ b/module/apmsql/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 	golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7 // indirect
 )
 

--- a/module/apmzap/go.mod
+++ b/module/apmzap/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmzap/v2
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1

--- a/module/apmzerolog/go.mod
+++ b/module/apmzerolog/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.14.3
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/v2 v2.3.0
+	go.elastic.co/apm/v2 v2.4.0
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/version.go
+++ b/version.go
@@ -19,5 +19,5 @@ package apm // import "go.elastic.co/apm/v2"
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "2.3.0"
+	AgentVersion = "2.4.0"
 )


### PR DESCRIPTION
This cuts the release for 2.4.0, which adds support for OpenTelemetry.
See the diff: https://github.com/elastic/apm-agent-go/compare/v2.3.0...main

