### PR TITLE
Only upgrade go version in genmod, don't downgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,19 @@ jobs:
       - name: Unit tests
         run: make test
 
+  check-update-modules:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: stable
+          cache: true
+          cache-dependency-path: '**/go.sum'
+      - name: Check Update Modules Command
+        run: make update-modules
+
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/genmod/go.mod
+++ b/scripts/genmod/go.mod
@@ -3,6 +3,7 @@ module genmod
 require (
 	github.com/pkg/errors v0.9.1
 	go.elastic.co/apm/v2 v2.1.0
+	golang.org/x/mod v0.5.1
 )
 
 replace go.elastic.co/apm/v2 => ../..

--- a/scripts/genmod/go.sum
+++ b/scripts/genmod/go.sum
@@ -30,8 +30,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=
-github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=

--- a/scripts/genmod/main.go
+++ b/scripts/genmod/main.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
 
 	"go.elastic.co/apm/v2"
 )
@@ -138,7 +139,7 @@ func updateModule(dir string, gomod *GoMod, modules map[string]*GoMod) error {
 			"-require", require.Path + "@" + *versionFlag,
 			"-replace", require.Path + "=" + relDir,
 		}
-		if *goVersionFlag != "" {
+		if *goVersionFlag != "" && semver.Compare("v"+*goVersionFlag, "v"+gomod.Go) == 1 {
 			args = append(args, "-go", *goVersionFlag)
 		}
 		cmd := exec.Command("go", args...)


### PR DESCRIPTION
We have some modules (such as apmotel) that don't support all the versions we provide support for.
For example, OpenTelemetry follows the [go release policy](https://go.dev/doc/devel/release), so versions lower than 1.19 aren't supported, and generics are used.

This means we can't build that module on go 1.15, and can't run `make update-modules`.

With this change, we will try to upgrade the go version if it's lower than the one specified. However, if it's higher, we consider that to be on purpose, and don't change it.