### PR TITLE
Otel Module: handle resources

### DIFF
--- a/module/apmotel/span.go
+++ b/module/apmotel/span.go
@@ -90,6 +90,10 @@ func (s *span) End(options ...trace.SpanEndOption) {
 		outcome = "unknown"
 	}
 
+	for iter := s.provider.resource.Iter(); iter.Next(); {
+		s.attributes = append(s.attributes, iter.Attribute())
+	}
+
 	if s.span != nil {
 		s.setSpanAttributes()
 		s.span.Outcome = outcome

--- a/module/apmotel/tracer_provider.go
+++ b/module/apmotel/tracer_provider.go
@@ -23,6 +23,7 @@ package apmotel // import "go.elastic.co/apm/module/apmotel/v2"
 import (
 	"sync"
 
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.elastic.co/apm/v2"
@@ -33,7 +34,8 @@ type tracerProvider struct {
 
 	apmTracer *apm.Tracer
 
-	tracers map[string]*tracer
+	tracers  map[string]*tracer
+	resource *resource.Resource
 }
 
 // NewTracerProvider creates a new tracer provider which acts as a bridge with the Elastic Agent tracer.
@@ -42,6 +44,7 @@ func NewTracerProvider(opts ...TracerProviderOption) (trace.TracerProvider, erro
 	tp := &tracerProvider{
 		apmTracer: cfg.apmTracer,
 		tracers:   map[string]*tracer{},
+		resource:  cfg.resource,
 	}
 
 	return tp, nil

--- a/module/apmotel/tracer_provider_config.go
+++ b/module/apmotel/tracer_provider_config.go
@@ -21,11 +21,16 @@
 package apmotel // import "go.elastic.co/apm/module/apmotel/v2"
 
 import (
+	"go.opentelemetry.io/otel/sdk/resource"
+
 	"go.elastic.co/apm/v2"
 )
 
 type tracerProviderConfig struct {
 	apmTracer *apm.Tracer
+
+	// resource contains attributes representing an entity that produces telemetry.
+	resource *resource.Resource
 }
 
 type TracerProviderOption func(tracerProviderConfig) tracerProviderConfig
@@ -40,6 +45,10 @@ func newTracerProviderConfig(opts ...TracerProviderOption) tracerProviderConfig 
 		cfg.apmTracer = apm.DefaultTracer()
 	}
 
+	if cfg.resource == nil {
+		cfg.resource = resource.Default()
+	}
+
 	return cfg
 }
 
@@ -47,6 +56,18 @@ func newTracerProviderConfig(opts ...TracerProviderOption) tracerProviderConfig 
 func WithAPMTracer(t *apm.Tracer) TracerProviderOption {
 	return func(cfg tracerProviderConfig) tracerProviderConfig {
 		cfg.apmTracer = t
+		return cfg
+	}
+}
+
+// WithResource configures the provided resource, which will be referenced by
+// all tracers this provider creates.
+//
+// If this option is not used, the TracerProvider will use the
+// resource.Default() Resource by default.
+func WithResource(r *resource.Resource) TracerProviderOption {
+	return func(cfg tracerProviderConfig) tracerProviderConfig {
+		cfg.resource, _ = resource.Merge(resource.Environment(), r)
 		return cfg
 	}
 }

--- a/module/apmotel/tracer_provider_config.go
+++ b/module/apmotel/tracer_provider_config.go
@@ -21,10 +21,33 @@
 package apmotel // import "go.elastic.co/apm/module/apmotel/v2"
 
 import (
+	"os"
+	"path/filepath"
+
 	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 
 	"go.elastic.co/apm/v2"
 )
+
+// defaultResource is the resource that will be used by default if none were provided in the config
+func defaultResource() *resource.Resource {
+	return resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceNameKey.String(getServiceName()),
+		semconv.TelemetrySDKName("apmotel"),
+		semconv.TelemetrySDKLanguageGo,
+		semconv.TelemetrySDKVersion(apm.AgentVersion),
+	)
+}
+
+func getServiceName() string {
+	executable, err := os.Executable()
+	if err != nil {
+		return "unknown_service:go"
+	}
+	return "unknown_service:" + filepath.Base(executable)
+}
 
 type tracerProviderConfig struct {
 	apmTracer *apm.Tracer
@@ -64,7 +87,7 @@ func WithAPMTracer(t *apm.Tracer) TracerProviderOption {
 // all tracers this provider creates.
 //
 // If this option is not used, the TracerProvider will use the
-// resource.Default() Resource by default.
+// defaultResource() Resource by default.
 func WithResource(r *resource.Resource) TracerProviderOption {
 	return func(cfg tracerProviderConfig) tracerProviderConfig {
 		cfg.resource, _ = resource.Merge(resource.Environment(), r)

--- a/module/apmotel/tracer_provider_config_test.go
+++ b/module/apmotel/tracer_provider_config_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 
 	"go.elastic.co/apm/v2"
 	"go.elastic.co/apm/v2/transport/transporttest"
@@ -42,6 +44,7 @@ func TestNewTracerProviderConfig(t *testing.T) {
 			options: nil,
 			wantConfig: tracerProviderConfig{
 				apmTracer: apm.DefaultTracer(),
+				resource:  resource.Default(),
 			},
 		},
 		{
@@ -51,6 +54,17 @@ func TestNewTracerProviderConfig(t *testing.T) {
 			},
 			wantConfig: tracerProviderConfig{
 				apmTracer: apmTracer,
+				resource:  resource.Default(),
+			},
+		},
+		{
+			name: "WithResource",
+			options: []TracerProviderOption{
+				WithResource(resource.NewWithAttributes(semconv.SchemaURL)),
+			},
+			wantConfig: tracerProviderConfig{
+				apmTracer: apm.DefaultTracer(),
+				resource:  resource.NewWithAttributes(semconv.SchemaURL),
 			},
 		},
 	}


### PR DESCRIPTION
As I was digging through traces generated by this module, I would have wanted to see attributes set by it to identify where the traces were coming from. But I only was able to know the agent was sending them.

So this adds support for resources, as supported in the official OpenTelemetry SDK, which allows setting custom attributes on all spans.
By default, the following attributes are set:

* `service.name`: `unknown_service:<executable name>`
* `telemetry.sdk.language`: `go`
* `telemetry.sdk.name`: `apmotel`
* `telemetry.sdk.version`: `apm.AgentVersion`

This closely matches the default resource from the official SDK: https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/resource/resource.go#L203