### PR TITLE
Set the proper trace ID and span ID in trace context

### DIFF
--- a/module/apmotel/tracer.go
+++ b/module/apmotel/tracer.go
@@ -87,6 +87,10 @@ func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanS
 				Start:  startTime,
 			})
 			s.tx = parent.tx
+			s.spanContext = trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID: trace.TraceID(s.span.TraceContext().Trace),
+				SpanID:  trace.SpanID(s.span.TraceContext().Span),
+			})
 			return trace.ContextWithSpan(ctx, s), s
 		}
 	}
@@ -99,6 +103,10 @@ func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanS
 		}
 	}
 	s.tx = t.provider.apmTracer.StartTransactionOptions(spanName, "", tranOpts)
+	s.spanContext = trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID(s.tx.TraceContext().Trace),
+		SpanID:  trace.SpanID(s.tx.TraceContext().Span),
+	})
 
 	return trace.ContextWithSpan(ctx, s), s
 }

--- a/module/apmotel/tracer_test.go
+++ b/module/apmotel/tracer_test.go
@@ -53,6 +53,8 @@ func TestTracerStartTransaction(t *testing.T) {
 
 	assert.NotNil(t, s.(*span).tx)
 	assert.Nil(t, s.(*span).span)
+
+	assert.True(t, trace.SpanContextFromContext(ctx).IsValid())
 }
 
 func TestTracerStartTransactionWithParentContext(t *testing.T) {
@@ -71,6 +73,8 @@ func TestTracerStartTransactionWithParentContext(t *testing.T) {
 
 	assert.NotNil(t, s.(*span).tx)
 	assert.Nil(t, s.(*span).span)
+
+	assert.True(t, trace.SpanContextFromContext(ctx).IsValid())
 }
 
 func TestTracerStartChildSpan(t *testing.T) {


### PR DESCRIPTION
Right now, we always send an empty TraceContext in spans, making it invalid (it needs a Trace ID and Span ID to be valid), and breaking propagation.
See https://github.com/open-telemetry/opentelemetry-go/blob/main/propagation/trace_context.go#LL48C8-L48C41

With this change, the Trace Context now properly includes both data, and is valid, which would allow distributed tracing properly.