### PR TITLE
module/apmbench: fix microbenchmarks

### DIFF
--- a/module/apmhttp/client_bench_test.go
+++ b/module/apmhttp/client_bench_test.go
@@ -51,7 +51,7 @@ func benchmarkClient(b *testing.B, wrap func(*http.Client) *http.Client) {
 			defer tracer.Close()
 			tx := tracer.StartTransaction("name", "type")
 			ctx := apm.ContextWithTransaction(context.Background(), tx)
-			client := wrap(nil)
+			client := wrap(http.DefaultClient)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+path, nil)


### PR DESCRIPTION
Fixes this panic:

```
BenchmarkClient/baseline//hello/world
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8cdcb4]

goroutine 55 [running]:
net/http.(*Client).deadline(0x0, 0x10e78c0, 0xb6e87d, 0x0)
	/var/lib/buildkite-agent/.gimme/versions/go1.15.10.linux.amd64/src/net/http/client.go:189
+0x34
net/http.(*Client).do(0x0, 0xc00032c100, 0x0, 0x0, 0x0)
	/var/lib/buildkite-agent/.gimme/versions/go1.15.10.linux.amd64/src/net/http/client.go:604
+0xbd
net/http.(*Client).Do(...)
	/var/lib/buildkite-agent/.gimme/versions/go1.15.10.linux.amd64/src/net/http/client.go:586
go.elastic.co/apm/module/apmhttp/v2_test.benchmarkClient.func1(0xc00013efc0)
	/var/lib/buildkite-agent/.buildkite-agent/builds/worker-1799330-build-hel1-dc1-hetzner-elasticnet-co/elastic/apm-agent-microbenchmark/.apm-agent-go/module/apmhttp/client_bench_test.go:59
+0x365
testing.(*B).runN(0xc00013efc0, 0x1)
	/var/lib/buildkite-agent/.gimme/versions/go1.15.10.linux.amd64/src/testing/benchmark.go:191
+0x1c6
testing.(*B).run1.func1(0xc00013efc0)
	/var/lib/buildkite-agent/.gimme/versions/go1.15.10.linux.amd64/src/testing/benchmark.go:231
+0x76
created by testing.(*B).run1
	/var/lib/buildkite-agent/.gimme/versions/go1.15.10.linux.amd64/src/testing/benchmark.go:224
+0x94
exit status 2
FAIL	go.elastic.co/apm/module/apmhttp/v2	0.023s
```

See https://buildkite.com/elastic/apm-agent-microbenchmark/builds/47