### PR TITLE
Fix update-modules not updating non public modules

### DIFF
--- a/internal/apmgodog/go.mod
+++ b/internal/apmgodog/go.mod
@@ -1,4 +1,4 @@
-module apmgodog
+module apmgodog/v2
 
 go 1.13
 

--- a/internal/apmgodog/go.mod
+++ b/internal/apmgodog/go.mod
@@ -1,6 +1,6 @@
 module apmgodog/v2
 
-go 1.13
+go 1.15
 
 require (
 	github.com/cucumber/godog v0.12.2

--- a/internal/tracecontexttest/go.mod
+++ b/internal/tracecontexttest/go.mod
@@ -1,9 +1,9 @@
 module tracecontexttest/v2
 
-require go.elastic.co/apm/module/apmhttp/v2 v2.0.0
+require go.elastic.co/apm/module/apmhttp/v2 v2.4.1
 
 replace go.elastic.co/apm/v2 => ../..
 
 replace go.elastic.co/apm/module/apmhttp/v2 => ../../module/apmhttp
 
-go 1.13
+go 1.15

--- a/internal/tracecontexttest/go.mod
+++ b/internal/tracecontexttest/go.mod
@@ -1,4 +1,4 @@
-module tracecontexttest
+module tracecontexttest/v2
 
 require go.elastic.co/apm/module/apmhttp/v2 v2.0.0
 

--- a/module/apmelasticsearch/internal/integration/go.mod
+++ b/module/apmelasticsearch/internal/integration/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 // indirect
 	github.com/olivere/elastic v6.2.16+incompatible
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm/module/apmelasticsearch/v2 v2.1.0
+	go.elastic.co/apm/module/apmelasticsearch/v2 v2.4.1
 	go.elastic.co/apm/v2 v2.4.1
 )
 
@@ -16,4 +16,4 @@ replace go.elastic.co/apm/module/apmelasticsearch/v2 => ../..
 
 replace go.elastic.co/apm/module/apmhttp/v2 => ../../../apmhttp
 
-go 1.13
+go 1.15

--- a/module/apmelasticsearch/internal/integration/go.mod
+++ b/module/apmelasticsearch/internal/integration/go.mod
@@ -1,4 +1,4 @@
-module apmelasticsearch_integration
+module apmelasticsearch_integration/v2
 
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.5.0

--- a/scripts/genmod/go.mod
+++ b/scripts/genmod/go.mod
@@ -2,7 +2,7 @@ module genmod/v2
 
 require (
 	github.com/pkg/errors v0.9.1
-	go.elastic.co/apm/v2 v2.1.0
+	go.elastic.co/apm/v2 v2.4.1
 	golang.org/x/mod v0.5.1
 )
 

--- a/scripts/genmod/go.mod
+++ b/scripts/genmod/go.mod
@@ -1,4 +1,4 @@
-module genmod
+module genmod/v2
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/scripts/genmod/go.mod
+++ b/scripts/genmod/go.mod
@@ -1,7 +1,6 @@
 module genmod/v2
 
 require (
-	github.com/pkg/errors v0.9.1
 	go.elastic.co/apm/v2 v2.4.1
 	golang.org/x/mod v0.5.1
 )

--- a/scripts/genmod/main.go
+++ b/scripts/genmod/main.go
@@ -32,7 +32,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 
 	"go.elastic.co/apm/v2"
@@ -153,7 +152,7 @@ func updateModule(dir string, gomod *GoMod, modules map[string]*GoMod) error {
 		cmd.Stderr = os.Stderr
 		cmd.Dir = dir
 		if err := cmd.Run(); err != nil {
-			return errors.Wrap(err, "'go mod edit' failed")
+			return fmt.Errorf("'go mod edit' failed: %w", err)
 		}
 	}
 	return nil
@@ -220,7 +219,7 @@ func checkModule(dir string, gomod *GoMod, modules map[string]*GoMod) error {
 		}
 	}
 	if gomodBad {
-		return errors.Errorf("%s/go.mod invalid", gomod.dir)
+		return fmt.Errorf("%s/go.mod invalid", gomod.dir)
 	}
 	return nil
 }
@@ -234,7 +233,7 @@ func checkModuleComplete(dir string, gomod *GoMod, modules map[string]*GoMod) er
 	cmd.Stderr = os.Stderr
 	cmd.Dir = gomod.dir
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "'go mod download' failed")
+		return fmt.Errorf("'go mod download' failed: %w", err)
 	}
 
 	// Check we can build the module's tests and its transitive dependencies
@@ -243,7 +242,7 @@ func checkModuleComplete(dir string, gomod *GoMod, modules map[string]*GoMod) er
 	cmd.Stderr = os.Stderr
 	cmd.Dir = gomod.dir
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "'go test' failed")
+		return fmt.Errorf("'go test' failed: %w", err)
 	}
 
 	// We create a temporary program which imports the module, and then
@@ -305,7 +304,7 @@ func main() {}
 	cmd.Stderr = os.Stderr
 	cmd.Dir = tmpdir
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "'go mod tidy' failed")
+		return fmt.Errorf("'go mod tidy' failed: %w", err)
 	}
 
 	cmd = exec.Command("diff", "-c", "-", "--label=old", tmpGomodPath, "--label=new")

--- a/scripts/genmod/main.go
+++ b/scripts/genmod/main.go
@@ -88,10 +88,7 @@ func main() {
 				if err != nil {
 					return err
 				}
-				// Skip non-public modules.
-				if strings.HasPrefix(gomod.Module.Path, "go.elastic.co/apm") {
-					modules[gomod.Module.Path] = gomod
-				}
+				modules[gomod.Module.Path] = gomod
 			}
 			return nil
 		}
@@ -156,7 +153,7 @@ func updateModule(dir string, gomod *GoMod, modules map[string]*GoMod) error {
 		cmd.Stderr = os.Stderr
 		cmd.Dir = dir
 		if err := cmd.Run(); err != nil {
-			return err
+			return errors.Wrap(err, "'go mod edit' failed")
 		}
 	}
 	return nil
@@ -308,7 +305,7 @@ func main() {}
 	cmd.Stderr = os.Stderr
 	cmd.Dir = tmpdir
 	if err := cmd.Run(); err != nil {
-		return err
+		return errors.Wrap(err, "'go mod tidy' failed")
 	}
 
 	cmd = exec.Command("diff", "-c", "-", "--label=old", tmpGomodPath, "--label=new")

--- a/scripts/genmod/main.go
+++ b/scripts/genmod/main.go
@@ -158,7 +158,7 @@ func updateModule(dir string, gomod *GoMod, modules map[string]*GoMod) error {
 	return nil
 }
 
-// checkModule checks that the require stanzas in $dir/go.mod have the
+// checkModule checks that the required stanzas in $dir/go.mod have the
 // correct versions, appropriate matching "replace" stanzas, and the
 // correct required Go version (if -go is specified).
 func checkModule(dir string, gomod *GoMod, modules map[string]*GoMod) error {
@@ -326,7 +326,7 @@ func required(path string, modules map[string]*GoMod) []string {
 }
 
 // toposort topologically sorts the required modules, starting
-// with the moduled specified by path.
+// with the module specified by path.
 func toposort(path string, modules map[string]*GoMod, seen map[string]bool, paths *[]string) {
 	if seen[path] {
 		return


### PR DESCRIPTION
Existing `make update-modules` is not updating non public modules. Fix that by removing the non public module filter in genmod. After the fix, all non public modules go.mod should also reference the latest go agent version.