### PR TITLE
Allow retrieving span created in agent from otel, and store agent span in context when creating it with otel

### DIFF
--- a/module/apmotel/tracer.go
+++ b/module/apmotel/tracer.go
@@ -86,6 +86,7 @@ func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanS
 				Parent: tc,
 				Start:  startTime,
 			})
+			ctx = apm.ContextWithSpan(ctx, s.span)
 			s.tx = parent.tx
 			s.spanContext = trace.NewSpanContext(trace.SpanContextConfig{
 				TraceID:    trace.TraceID(s.span.TraceContext().Trace),
@@ -105,6 +106,7 @@ func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanS
 		}
 	}
 	s.tx = t.provider.apmTracer.StartTransactionOptions(spanName, "", tranOpts)
+	ctx = apm.ContextWithTransaction(ctx, s.tx)
 	s.spanContext = trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    trace.TraceID(s.tx.TraceContext().Trace),
 		SpanID:     trace.SpanID(s.tx.TraceContext().Span),

--- a/module/apmotel/tracer_test.go
+++ b/module/apmotel/tracer_test.go
@@ -168,7 +168,6 @@ func TestTracerStartChildSpanFromTransactionInContext(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-
 			apmTracer, _ := transporttest.NewRecorderTracer()
 			tp, err := NewTracerProvider(WithAPMTracer(apmTracer))
 			assert.NoError(t, err)

--- a/module/apmotel/tracer_test.go
+++ b/module/apmotel/tracer_test.go
@@ -56,6 +56,9 @@ func TestTracerStartTransaction(t *testing.T) {
 
 	assert.True(t, trace.SpanContextFromContext(ctx).IsValid())
 	assert.True(t, trace.SpanContextFromContext(ctx).IsSampled())
+
+	assert.True(t, apm.TransactionFromContext(ctx).Sampled())
+	assert.Nil(t, apm.SpanFromContext(ctx))
 }
 
 func TestTracerStartTransactionWithParentContext(t *testing.T) {
@@ -124,6 +127,9 @@ func TestTracerStartChildSpan(t *testing.T) {
 	assert.NotNil(t, cs.(*span).span)
 
 	assert.True(t, trace.SpanContextFromContext(ctx).IsValid())
+
+	assert.True(t, apm.TransactionFromContext(ctx).Sampled())
+	assert.False(t, apm.SpanFromContext(ctx).Dropped())
 }
 
 func TestTracerStartChildSpanFromTransactionInContext(t *testing.T) {

--- a/module/apmotel/wrapper.go
+++ b/module/apmotel/wrapper.go
@@ -23,8 +23,9 @@ package apmotel // import "go.elastic.co/apm/module/apmotel/v2"
 import (
 	"context"
 
-	"go.elastic.co/apm/v2"
 	"go.opentelemetry.io/otel/trace"
+
+	"go.elastic.co/apm/v2"
 )
 
 var (

--- a/module/apmotel/wrapper.go
+++ b/module/apmotel/wrapper.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package apmotel // import "go.elastic.co/apm/module/apmotel/v2"
+
+import (
+	"context"
+
+	"go.elastic.co/apm/v2"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var (
+	oldOverrideContextWithSpan        func(context.Context, *apm.Span) context.Context
+	oldOverrideContextWithTransaction func(context.Context, *apm.Transaction) context.Context
+)
+
+func init() {
+	// We override the apm context functions so that transactions
+	// and spans started with the native API are wrapped and made
+	// available as OpenTelemetry spans.
+
+	oldOverrideContextWithSpan = apm.OverrideContextWithSpan
+	oldOverrideContextWithTransaction = apm.OverrideContextWithTransaction
+	apm.OverrideContextWithSpan = contextWithSpan
+	apm.OverrideContextWithTransaction = contextWithTransaction
+}
+
+func contextWithSpan(ctx context.Context, apmSpan *apm.Span) context.Context {
+	ctx = oldOverrideContextWithSpan(ctx, apmSpan)
+	return trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID(apmSpan.TraceContext().Trace),
+		SpanID:     trace.SpanID(apmSpan.TraceContext().Span),
+		TraceFlags: trace.TraceFlags(0).WithSampled(!apmSpan.Dropped()),
+	}))
+}
+
+func contextWithTransaction(ctx context.Context, apmTransaction *apm.Transaction) context.Context {
+	ctx = oldOverrideContextWithTransaction(ctx, apmTransaction)
+	return trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID(apmTransaction.TraceContext().Trace),
+		SpanID:     trace.SpanID(apmTransaction.TraceContext().Span),
+		TraceFlags: trace.TraceFlags(0).WithSampled(apmTransaction.Sampled()),
+	}))
+}

--- a/module/apmotel/wrapper_test.go
+++ b/module/apmotel/wrapper_test.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package apmotel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.elastic.co/apm/v2"
+	"go.elastic.co/apm/v2/transport/transporttest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestLinkAgentToOtel(t *testing.T) {
+	apmTracer, _ := transporttest.NewRecorderTracer()
+	_, err := NewTracerProvider(WithAPMTracer(apmTracer))
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	tx := apmTracer.StartTransaction("test1", "test")
+	ctx = apm.ContextWithTransaction(ctx, tx)
+
+	apmTx := apm.TransactionFromContext(ctx)
+	otelSpan := trace.SpanFromContext(ctx)
+
+	assert.Equal(t, [16]byte(apmTx.TraceContext().Trace), [16]byte(otelSpan.SpanContext().TraceID()))
+	assert.Equal(t, [8]byte(apmTx.TraceContext().Span), [8]byte(otelSpan.SpanContext().SpanID()))
+}
+
+func TestLinkOtelToAgent(t *testing.T) {
+	apmTracer, _ := transporttest.NewRecorderTracer()
+	tp, err := NewTracerProvider(WithAPMTracer(apmTracer))
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	ctx, _ = tp.Tracer("").Start(ctx, "test")
+
+	apmTx := apm.TransactionFromContext(ctx)
+	otelSpan := trace.SpanFromContext(ctx)
+
+	assert.Equal(t, [16]byte(apmTx.TraceContext().Trace), [16]byte(otelSpan.SpanContext().TraceID()))
+	assert.Equal(t, [8]byte(apmTx.TraceContext().Span), [8]byte(otelSpan.SpanContext().SpanID()))
+}

--- a/module/apmotel/wrapper_test.go
+++ b/module/apmotel/wrapper_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace"
+
 	"go.elastic.co/apm/v2"
 	"go.elastic.co/apm/v2/transport/transporttest"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func TestLinkAgentToOtel(t *testing.T) {


### PR DESCRIPTION
Closes #1449 

We didn't store the agent span/transaction into the context, as that doesn't happen automatically and requires a manual operation when using the agent directly.
When using otel, which does add it to every context, it makes more sense not to have to require folks to do that themselves though.

This also sets up a context wrapper in the agent, so spans created from the agent are stored in the context to be read by otel.