### PR TITLE
Fix data race accessing Request.URL

### DIFF
--- a/spancontext.go
+++ b/spancontext.go
@@ -196,7 +196,15 @@ func (c *SpanContext) SetHTTPRequest(req *http.Request) {
 	if req.URL == nil {
 		return
 	}
-	c.http.URL = req.URL
+
+	// Clone the URL, since callers of http.RoundTrip may mutate the
+	// Request after the response body is closed.
+	clonedURL := *req.URL
+	if req.URL.User != nil {
+		clonedURLUser := *req.URL.User
+		clonedURL.User = &clonedURLUser
+	}
+	c.http.URL = &clonedURL
 	c.model.HTTP = &c.http
 
 	addr, port := apmhttputil.DestinationAddr(req)


### PR DESCRIPTION
If an HTTP client is instrumented with apmhttp, then the http.Request.URL is recorded for including in span context. The caller of the HTTP client request may mutate the URL after the response is ready, so we must clone the URL while recording it to prevent data races.