### PR TITLE
Return usable/recording spans from the agent context

### DIFF
--- a/module/apmotel/wrapper.go
+++ b/module/apmotel/wrapper.go
@@ -43,18 +43,28 @@ func init() {
 
 func contextWithSpan(ctx context.Context, apmSpan *apm.Span) context.Context {
 	ctx = oldOverrideContextWithSpan(ctx, apmSpan)
-	return trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    trace.TraceID(apmSpan.TraceContext().Trace),
-		SpanID:     trace.SpanID(apmSpan.TraceContext().Span),
-		TraceFlags: trace.TraceFlags(0).WithSampled(!apmSpan.Dropped()),
-	}))
+
+	return trace.ContextWithSpan(ctx, &span{
+		spanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    trace.TraceID(apmSpan.TraceContext().Trace),
+			SpanID:     trace.SpanID(apmSpan.TraceContext().Span),
+			TraceFlags: trace.TraceFlags(0).WithSampled(!apmSpan.Dropped()),
+		}),
+
+		span: apmSpan,
+	})
 }
 
 func contextWithTransaction(ctx context.Context, apmTransaction *apm.Transaction) context.Context {
 	ctx = oldOverrideContextWithTransaction(ctx, apmTransaction)
-	return trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    trace.TraceID(apmTransaction.TraceContext().Trace),
-		SpanID:     trace.SpanID(apmTransaction.TraceContext().Span),
-		TraceFlags: trace.TraceFlags(0).WithSampled(apmTransaction.Sampled()),
-	}))
+
+	return trace.ContextWithSpan(ctx, &span{
+		spanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    trace.TraceID(apmTransaction.TraceContext().Trace),
+			SpanID:     trace.SpanID(apmTransaction.TraceContext().Span),
+			TraceFlags: trace.TraceFlags(0).WithSampled(apmTransaction.Sampled()),
+		}),
+
+		tx: apmTransaction,
+	})
 }

--- a/module/apmotel/wrapper_test.go
+++ b/module/apmotel/wrapper_test.go
@@ -42,6 +42,7 @@ func TestLinkAgentToOtel(t *testing.T) {
 
 	assert.Equal(t, [16]byte(apmTx.TraceContext().Trace), [16]byte(otelSpan.SpanContext().TraceID()))
 	assert.Equal(t, [8]byte(apmTx.TraceContext().Span), [8]byte(otelSpan.SpanContext().SpanID()))
+	assert.Equal(t, apmTx.Sampled(), otelSpan.IsRecording())
 }
 
 func TestLinkOtelToAgent(t *testing.T) {
@@ -57,4 +58,5 @@ func TestLinkOtelToAgent(t *testing.T) {
 
 	assert.Equal(t, [16]byte(apmTx.TraceContext().Trace), [16]byte(otelSpan.SpanContext().TraceID()))
 	assert.Equal(t, [8]byte(apmTx.TraceContext().Span), [8]byte(otelSpan.SpanContext().SpanID()))
+	assert.Equal(t, apmTx.Sampled(), otelSpan.IsRecording())
 }


### PR DESCRIPTION
This is a fix for #1476.