### PR TITLE
Remove survey link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ The Go agent enables you to trace the execution of operations in your applicatio
 sending performance metrics and errors to the Elastic APM server. You can find a
 list of the supported frameworks and other technologies in the [documentation](https://www.elastic.co/guide/en/apm/agent/go/current/supported-tech.html).
 
-We'd love to hear your feedback, please take a minute to fill out our [survey](https://docs.google.com/forms/d/e/1FAIpQLScbW7D8m-otPO7cxqeg7XstWR8vMnxG6brnXLs_TFVSTHuHvg/viewform?usp=sf_link).
-
 ## Installation
 
 ```bash

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -3,10 +3,8 @@
 
 This page describes the technologies supported by the Elastic APM Go agent.
 
-If your favorite technology is not supported yet, you can vote for it by
-participating in our https://docs.google.com/forms/d/e/1FAIpQLScbW7D8m-otPO7cxqeg7XstWR8vMnxG6brnXLs_TFVSTHuHvg/viewform?usp=sf_link[survey], or joining the conversation in the https://discuss.elastic.co/c/apm[Discuss forum].
-We will use the results of the survey and Discuss topics to add support
-for the most requested technologies.
+If your favorite technology is not supported yet, you start a conversation
+in the https://discuss.elastic.co/c/apm[Discuss forum].
 
 If you would like to get more involved, take a look at the <<contributing, contributing guide>>.
 


### PR DESCRIPTION
The survey itself is rather outdated, and has served its purpose. Send users to the Discuss forum instead.