### PR TITLE
docs: update doc with go support policy

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,9 @@ https://github.com/elastic/apm-agent-go/compare/v2.4.3...main[View commits]
 ==== 2.4.3 - 2023/06/22
 
 - Fixed a data race in HTTP client instrumentation {pull}1472[#1472]
+- Bumped minimum Go version to 1.19 {pull}1453[#1453]
+- Fixed mixing of OTel and Elastic APM instrumentation {pull}1450[#1450]
+- Updated to stable OTel metrics API {pull}1448[#1448]
 
 [[release-notes-2.4.2]]
 ==== 2.4.2 - 2023/05/22

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 This is the official Go package for [Elastic APM](https://www.elastic.co/solutions/apm).
 
 The Go agent enables you to trace the execution of operations in your application,
-sending performance metrics and errors to the Elastic APM server. You can find a
-list of the supported frameworks and other technologies in the [documentation](https://www.elastic.co/guide/en/apm/agent/go/current/supported-tech.html).
+sending performance metrics and errors to the Elastic APM server.
 
 ## Installation
 
@@ -19,10 +18,10 @@ go get go.elastic.co/apm/v2
 
 ## Requirements
 
-We support and test against the two latest major releases of Go,
-as described by the [Go release policy](https://go.dev/doc/devel/release#policy), on Linux, Windows and MacOS.
-
 Requires [APM Server](https://github.com/elastic/apm-server) v6.5 or newer.
+
+You can find a list of the supported frameworks and other technologies in the
+[documentation](https://www.elastic.co/guide/en/apm/agent/go/current/supported-tech.html).
 
 ## License
 

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -21,7 +21,8 @@ go get -u go.elastic.co/apm/v2
 [float]
 === Requirements
 
-The Go agent is tested with Go 1.8+ on Linux, Windows, and MacOS.
+You can find a list of the supported frameworks and other technologies in the
+<<supported-tech>> section.
 
 [float]
 [[instrumenting-source]]

--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,5 @@ require (
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 )
 
+// keep this in sync with the documentation
 go 1.19

--- a/go.mod
+++ b/go.mod
@@ -21,5 +21,4 @@ require (
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 )
 
-// keep this in sync with the documentation
 go 1.19


### PR DESCRIPTION
Solidify support go policy in one place.

Update release notes to include the go version bump.


Closes https://github.com/elastic/apm-agent-go/issues/1485