### PR TITLE
[2.x]  docs: update doc with go support policy (Backport #1488)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,9 @@ https://github.com/elastic/apm-agent-go/compare/v2.4.3...main[View commits]
 ==== 2.4.3 - 2023/06/22
 
 - Fixed a data race in HTTP client instrumentation {pull}1472[#1472]
+- Bumped minimum Go version to 1.19 {pull}1453[#1453]
+- Fixed mixing of OTel and Elastic APM instrumentation {pull}1450[#1450]
+- Updated to stable OTel metrics API {pull}1448[#1448]
 
 [[release-notes-2.4.2]]
 ==== 2.4.2 - 2023/05/22

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 This is the official Go package for [Elastic APM](https://www.elastic.co/solutions/apm).
 
 The Go agent enables you to trace the execution of operations in your application,
-sending performance metrics and errors to the Elastic APM server. You can find a
-list of the supported frameworks and other technologies in the [documentation](https://www.elastic.co/guide/en/apm/agent/go/current/supported-tech.html).
+sending performance metrics and errors to the Elastic APM server.
 
 We'd love to hear your feedback, please take a minute to fill out our [survey](https://docs.google.com/forms/d/e/1FAIpQLScbW7D8m-otPO7cxqeg7XstWR8vMnxG6brnXLs_TFVSTHuHvg/viewform?usp=sf_link).
 
@@ -21,10 +20,10 @@ go get go.elastic.co/apm/v2
 
 ## Requirements
 
-We support and test against the two latest major releases of Go,
-as described by the [Go release policy](https://go.dev/doc/devel/release#policy), on Linux, Windows and MacOS.
-
 Requires [APM Server](https://github.com/elastic/apm-server) v6.5 or newer.
+
+You can find a list of the supported frameworks and other technologies in the
+[documentation](https://www.elastic.co/guide/en/apm/agent/go/current/supported-tech.html).
 
 ## License
 

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -21,7 +21,8 @@ go get -u go.elastic.co/apm/v2
 [float]
 === Requirements
 
-The Go agent is tested with Go 1.8+ on Linux, Windows, and MacOS.
+You can find a list of the supported frameworks and other technologies in the
+<<supported-tech>> section.
 
 [float]
 [[instrumenting-source]]


### PR DESCRIPTION
* docs: update doc with go support policy

* docs: remove go.mod comment

the doc doesn't actually mention specific versions