### PR TITLE
update default value of ELASTIC_APM_CLOUD_PROVIDER in doc

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -655,7 +655,7 @@ for backwards compatibility with older versions of Elastic APM agents.
 [options="header"]
 |============
 | Environment                  | Default  | Example
-| `ELASTIC_APM_CLOUD_PROVIDER` | `"none"` | `"aws"`
+| `ELASTIC_APM_CLOUD_PROVIDER` | `"auto"` | `"aws"`
 |============
 
 This config value allows you to specify which cloud provider should be assumed


### PR DESCRIPTION
if i understand correctly the default value is "auto"
https://github.com/elastic/apm-agent-go/blob/main/utils.go#L179