### PR TITLE
Remove container_metadata_discovery from tests

### DIFF
--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -24,10 +24,6 @@ sources:
       - findsubmatch:
           pattern: "[0-9a-f]{40}"
 
-  container_metadata_discovery.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/container_metadata_discovery.json
   service_resource_inference.json:
     kind: file
     spec:
@@ -71,13 +67,6 @@ actions:
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
 
 targets:
-  container_metadata_discovery.json:
-    name: container_metadata_discovery.json
-    scmid: default
-    sourceid: container_metadata_discovery.json
-    kind: file
-    spec:
-      file: internal/testdata/json-specs/container_metadata_discovery.json
   service_resource_inference.json:
     name: service_resource_inference.json
     scmid: default


### PR DESCRIPTION
Removing the newly introduced tests for `container_metadata_discovery.json` until changes from https://github.com/elastic/apm/pull/807 are implemented. 