### PR TITLE
[DOC+] Change example from elastic.com to elastic.co

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -991,7 +991,7 @@ Example with pool:
 import (
     "github.com/jackc/pgx/v4/pgxpool"
 
-    "go.elastic.com/apm/module/apmpgx/v2"
+    "go.elastic.co/apm/module/apmpgx/v2"
 )
 
 func main() {


### PR DESCRIPTION
Per Elastic docs websites' feedback, changes elastic domain from ".com" to ".co" to match other examples.