### PR TITLE
action: support GitHub check in branch protection

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,26 @@
+# This workflow sets the test / all status check to success in case it's a docs only PR and test.yml is not triggered
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: ci # The name must be the same as in ci.yml
+
+on:
+  pull_request:
+    paths-ignore: # This expression needs to match the paths ignored on ci.yml.
+      - '**'
+      - '!**/*.md'
+      - '!**/*.asciidoc'
+
+permissions:
+  contents: read
+
+## Concurrency only allowed in the main branch.
+## So old builds running for old commits within the same Pull Request are cancelled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # dummy steps that allow to bypass those mandatory checks for tests
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required for docs"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,21 @@ jobs:
           cache-dependency-path: '**/go.sum'
       - name: Unit tests
         run: make test
+
+  # Very last job to create a GitHub check with the status. This is handy to centralise the
+  # GitHub check validation in the Branch protection and to support the ci-docs.yml
+  ci:
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - check-update-modules
+      - precheck
+      - test
+      - test-macos
+      - test-windows
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.isSuccess }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: read
 
+## Concurrency only allowed in the main branch.
+## So old builds running for old commits within the same Pull Request are cancelled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   precheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable the GitHub check validation in the branch protection using a synthetic job in GitHub actions in charge of reporting any failures.

CI docs is required so changes related to docs can benefit from the new proposal in the branch protection.