### PR TITLE
fix: pin python 3.11 for coverage testing

### DIFF
--- a/internal/tracecontexttest/Dockerfile-harness
+++ b/internal/tracecontexttest/Dockerfile-harness
@@ -3,7 +3,7 @@ WORKDIR /w3c
 RUN apk add --no-cache git
 RUN git clone https://github.com/w3c/trace-context.git
 
-FROM python:3
+FROM python:3.11
 RUN pip install aiohttp
 WORKDIR /w3c/trace-context
 COPY --from=0 /w3c/trace-context .


### PR DESCRIPTION
aiohttp is not compatible with python 3.12 yet

Closes https://github.com/elastic/apm-agent-go/issues/1516