### PR TITLE
dependabot: enable github and composite actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+
+  # GitHub actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    reviewers:
+      - "elastic/observablt-ci"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What does this PR do?

* Update dependabot to run on [Sundays](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) and use [groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).
* Add dependabot for github actions.
* Add dependabot for github composite actions.

Unfortunately it's not possible to pass different directories yet, see https://github.com/dependabot/dependabot-core/issues/2178

## Why is it important?

Reduce the noise during the week and create one PR with all the changes per package ecosystem