### PR TITLE
ci: use gvm instead of gimme 

### DIFF
--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -15,9 +15,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: stable
-
 jobs:
   microbenchmark:
     runs-on: ubuntu-latest
@@ -38,7 +35,6 @@ jobs:
             script=scripts/ci/bench.sh
             repo=apm-agent-go
             sha=${{ github.sha }}
-            GO_VERSION=${{ env.GO_VERSION }}
 
       - if: ${{ failure() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/scripts/ci/bench.sh
+++ b/scripts/ci/bench.sh
@@ -40,5 +40,6 @@ make test | tee ${OUT_FILE}
 if [ "$CI" == "true" ] ; then
 	set +x
 	set +u
+	echo "Sending data with gobench"
 	go run -modfile=scripts/ci/ci.go.mod github.com/elastic/gobench -index "benchmark-go" -es "${APM_AGENT_GO_CLOUD_SECRET}" < ${OUT_FILE}
 fi

--- a/scripts/ci/bench.sh
+++ b/scripts/ci/bench.sh
@@ -23,6 +23,9 @@ if [ "$CI" == "true" ] ; then
 	trap clean_up EXIT
 fi
 
+## Fetch the latest stable goversion
+export GO_VERSION=$(curl 'https://go.dev/VERSION?m=text' | grep 'go' | sed 's#go##g')
+
 ## Bench specific
 set -u
 source ./scripts/ci/setenv.sh

--- a/scripts/ci/setenv.sh
+++ b/scripts/ci/setenv.sh
@@ -1,9 +1,47 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install Go using the same travis approach
-echo "Installing ${GO_VERSION} with gimme."
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=${GO_VERSION} bash)"
+# Install Golang using gvm
+echo "Installing ${GO_VERSION} with gvm."
+MSG="environment variable missing"
+GO_VERSION=${GO_VERSION:?$MSG}
+HOME=${HOME:?$MSG}
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+GVM_CMD="${HOME}/bin/gvm"
+
+if command -v go ; then
+    set +e
+    echo "Found Go. Checking version.."
+    FOUND_GO_VERSION=$(go version|awk '{print $3}'|sed s/go//)
+    if [ "$FOUND_GO_VERSION" == "$GO_VERSION" ]
+    then
+        echo "Versions match. No need to install Go. Exiting."
+        exit 0
+    fi
+    set -e
+fi
+
+if [ "${ARCH}" == "aarch64" ] ; then
+    GVM_ARCH_SUFFIX=arm64
+elif [ "${ARCH}" == "x86_64" ] ; then
+    GVM_ARCH_SUFFIX=amd64
+elif [ "${ARCH}" == "i686" ] ; then
+    GVM_ARCH_SUFFIX=386
+elif [ "${ARCH}" == "arm64" ] ; then
+    GVM_ARCH_SUFFIX=arm64
+else
+    GVM_ARCH_SUFFIX=arm
+fi
+
+echo "UNMET DEP: Installing Go"
+mkdir -p "${HOME}/bin"
+
+curl -sSLo "${GVM_CMD}" "https://github.com/andrewkroh/gvm/releases/download/v0.5.2/gvm-${OS}-${GVM_ARCH_SUFFIX}"
+chmod +x "${GVM_CMD}"
+
+eval "$("${GVM_CMD}" "${GO_VERSION}")"
+
 
 # Install tools used only in CI using a local go.mod file.
 GO_INSTALL_FLAGS="-modfile=$PWD/scripts/ci/ci.go.mod"

--- a/scripts/ci/setenv.sh
+++ b/scripts/ci/setenv.sh
@@ -42,7 +42,6 @@ chmod +x "${GVM_CMD}"
 
 eval "$("${GVM_CMD}" "${GO_VERSION}")"
 
-
 # Install tools used only in CI using a local go.mod file.
 GO_INSTALL_FLAGS="-modfile=$PWD/scripts/ci/ci.go.mod"
 


### PR DESCRIPTION
uses the script from https://github.com/elastic/beats/blob/024a9cec6608c6f371ad1cb769649e024124ff92/.ci/scripts/install-go.sh

`gimme` is not much maintained these days and 1.21 is not supported as per https://github.com/travis-ci/gimme/issues/210

I ran this [build ](https://buildkite.com/elastic/apm-agent-microbenchmark/builds/1002#018ba3c0-89a0-459f-bdf0-cccb4cd184a9) manually (it can only be accessed by Elastic) and so far it installed go using https://github.com/andrewkroh/gvm