### PR TITLE
github-action: use wildcards for discovering all the workflows

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,13 +1,15 @@
 ---
+# Look up results at https://ela.st/oblt-ci-cd-stats.
+# There will be one service per GitHub repository, including the org name, and one Transaction per Workflow.
 name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
-    workflows:
-      - ci
-      - microbenchmark
-      - updatecli
+    workflows: [ "*" ]
     types: [completed]
+
+permissions:
+  contents: read
 
 jobs:
   otel-export-trace:


### PR DESCRIPTION
No need to maintain the static list of GitHub Workflows to be monitored with the CI/CD Observability using Opentelemetry