### PR TITLE
fixed typo in apmgrpc/client.go

### DIFF
--- a/module/apmgrpc/client.go
+++ b/module/apmgrpc/client.go
@@ -91,7 +91,7 @@ func NewUnaryClientInterceptor(o ...ClientOption) grpc.UnaryClientInterceptor {
 	}
 }
 
-// NewStreamClientInterceptor returns a grpc.UnaryClientInterceptor that
+// NewStreamClientInterceptor returns a grpc.StreamClientInterceptor that
 // traces gRPC requests with the given options.
 //
 // The interceptor will trace spans with the "external.grpc" type for each


### PR DESCRIPTION
"fixed typo from
 grpc.UnaryClientInterceptor to grpc.StreamClientInterceptor in  the comments for NewStreamClientInterceptor  apmgrpc/client.go"