### PR TITLE
make use of the SpanIDFieldName constant in apmzerolog

### DIFF
--- a/module/apmzerolog/context.go
+++ b/module/apmzerolog/context.go
@@ -56,6 +56,6 @@ func (h traceContextHook) Run(e *zerolog.Event, level zerolog.Level, message str
 	e.Hex(TransactionIDFieldName, traceContext.Span[:])
 	if span := apm.SpanFromContext(h.ctx); span != nil {
 		spanTraceContext := span.TraceContext()
-		e.Hex("span.id", spanTraceContext.Span[:])
+		e.Hex(SpanIDFieldName, spanTraceContext.Span[:])
 	}
 }


### PR DESCRIPTION
To improve code maintainability and follow the same pattern in traceContextHook.Run of using other constants.