### PR TITLE
Temporarily ignore folders that are not actual modules in coverage check

### DIFF
--- a/scripts/moduledirs.sh
+++ b/scripts/moduledirs.sh
@@ -6,5 +6,9 @@
 if test -z "$(go env GOMOD)"; then
     pwd
 else
-    find . -type f -not -path '*/tools/*' -name go.mod -exec dirname '{}' \;
+    # Remove the folder internal/scripts ignore once
+    # https://github.com/golang/go/issues/65653 has been fixed
+    find . -type f -not -path '*/tools/*' \
+      -not -path '*/internal/*' -not -path '*/scripts/*' \
+      -name go.mod -exec dirname '{}' \;
 fi


### PR DESCRIPTION
The coverage check is currently broken because of https://github.com/golang/go/issues/65653.

This change fixes the CI test by ignoring packages which aren't publicly available within `-coverpkg`.
This is a temporary fix, and we should revert this PR once the Go fix lands, either in 1.23, or with the cherry-pick for 1.22 in https://github.com/golang/go/issues/66137.