### PR TITLE
Add write permission to labeler job

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   triage:


### PR DESCRIPTION
The labeler needs to have the `pull-request: write` permission, so it can assign labels on PRs.

See https://github.com/elastic/apm-agent-go/actions/runs/8246861649/job/22553967383?pr=1580