### PR TITLE
Add apm/sqlserver module to apmsql doc

### DIFF
--- a/docs/instrumenting.asciidoc
+++ b/docs/instrumenting.asciidoc
@@ -408,6 +408,7 @@ with apmsql.Register:
 - module/apmsql/pgxv4 (github.com/jackc/pgx/v4/stdlib)
 - module/apmsql/mysql (github.com/go-sql-driver/mysql)
 - module/apmsql/sqlite3 (github.com/mattn/go-sqlite3)
+- module/apmsql/sqlserver (github.com/microsoft/mssqldb)
 
 [source,go]
 ----


### PR DESCRIPTION
As reported in https://github.com/elastic/apm-agent-go/pull/1569#issuecomment-1999315749