### PR TITLE
Specify `go get` needs to run within go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ sending performance metrics and errors to the Elastic APM server.
 
 ## Installation
 
+Within a Go module:
+
 ```bash
 go get go.elastic.co/apm/v2
 ```

--- a/docs/set-up.asciidoc
+++ b/docs/set-up.asciidoc
@@ -11,7 +11,7 @@ To start reporting your Go application's performance to Elastic APM, you need to
 [[installation]]
 == Install the Agent
 
-Install the Elastic APM Go agent package using `go get`:
+Within a Go module, install the Elastic APM Go agent package using `go get`:
 
 [source,bash]
 ----


### PR DESCRIPTION
Closes #1598.