### PR TITLE
feat: add extra goos support

### DIFF
--- a/error.go
+++ b/error.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"os"
 	"reflect"
-	"syscall"
 	"time"
 
 	"go.elastic.co/apm/v2/model"
@@ -595,13 +594,6 @@ func init() {
 		syscallErr := err.(*os.SyscallError)
 		details.SetAttr("syscall", syscallErr.Syscall)
 		details.Cause = append(details.Cause, syscallErr.Err)
-	}))
-	RegisterTypeErrorDetailer(reflect.TypeOf(syscall.Errno(0)), ErrorDetailerFunc(func(err error, details *ErrorDetails) {
-		errno := err.(syscall.Errno)
-		details.Code.String = errnoName(errno)
-		if details.Code.String == "" {
-			details.Code.Number = float64(errno)
-		}
 	}))
 }
 

--- a/error_unix.go
+++ b/error_unix.go
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !windows
-// +build !windows
+//go:build unix
 
 package apm // import "go.elastic.co/apm/v2"
 

--- a/error_windows.go
+++ b/error_windows.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build windows
+
 package apm // import "go.elastic.co/apm/v2"
 
 import (


### PR DESCRIPTION
syscall.Errno is not available is some GOOS causing compile errors 

Move syscall specific code to separate file behind build tags making it future proof and adding support for all goos supported by the go runtime

delete go120_test since we require go 1.21+