### PR TITLE
Fix Kafka Producer transactions shown as unknown on kibana apm dashboard 

### DIFF
--- a/module/apmotel/span.go
+++ b/module/apmotel/span.go
@@ -384,7 +384,7 @@ func (s *span) setTransactionAttributes() {
 	if s.tx.Type == "" {
 		if s.spanKind == trace.SpanKindServer && (isHTTP || isRPC) {
 			s.tx.Type = "request"
-		} else if s.spanKind == trace.SpanKindConsumer && isMessaging {
+		} else if (s.spanKind == trace.SpanKindConsumer || s.spanKind == trace.SpanKindProducer) && isMessaging {
 			s.tx.Type = "messaging"
 		} else {
 			s.tx.Type = "unknown"


### PR DESCRIPTION
Transactions with kakfa producers are shown as unknown on elastic apm kibana dashboard, while transaction with kafka consumer are shown as messaging. This pull request adds changes to fixes the issue.


Opentelemetry Instrumentation code for instrumenting **producing** message on kafka:
<img width="951" alt="image" src="https://github.com/user-attachments/assets/02af8a3d-10b1-4263-8195-735c914ad630">

Producer Transactions visible as **unknown** on Kibana Dashboard:
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/5aa6a2ee-4ac5-400d-90c1-e1859df18367">


Opentelemetry Instrumentation code for instrumenting **consuming** message from kafka:
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/73cad4c2-2bb8-47c8-a954-ea31a5143a07">



Consumer Transactions visible as **messaging** on Kibana Dashboard:
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/7353105e-7c04-4ed8-861e-358cdc20f625">

After the Pull request changes:
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/a03cf985-a5e0-4106-886e-21e8df0c63ad">



