### PR TITLE
CVE-2024-8805 - update docker image

### DIFF
--- a/internal/tracecontexttest/Dockerfile-harness
+++ b/internal/tracecontexttest/Dockerfile-harness
@@ -3,7 +3,7 @@ WORKDIR /w3c
 RUN apk add --no-cache git
 RUN git clone https://github.com/w3c/trace-context.git
 
-FROM python:3.11
+FROM python:3.12.5-slim-bookworm
 RUN pip install aiohttp
 WORKDIR /w3c/trace-context
 COPY --from=0 /w3c/trace-context .


### PR DESCRIPTION
Follow snyk suggestion and update docker image to mitigate CVE-2024-8805.