### PR TITLE
github-actions: use ephemeral tokens with the right permissions

### DIFF
--- a/.github/workflows/addToAPMProject.yml
+++ b/.github/workflows/addToAPMProject.yml
@@ -11,6 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign issues to APM Project for the Server Team
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: elastic
+          permissions: >-
+            {
+              "organization_projects": "write",
+              "issues": "read"
+            }
+
       - uses: octokit/graphql-action@v2.x
         id: add_to_project
         with:
@@ -28,7 +42,8 @@ jobs:
           contentid: ${{ github.event.issue.node_id }}
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+
       - uses: octokit/graphql-action@v2.x
         id: label_team
         with:
@@ -51,4 +66,4 @@ jobs:
           value: "6c538d8a"
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
I somehow used the wrong permissions set in https://github.com/elastic/apm-agent-go/pull/1660

### Test

I tested it in my playground, and it worked as [expected](https://github.com/orgs/elastic/projects/629/views/1?filterQuery=test+add+project+6+&pane=issue&itemId=82591771&issue=elastic%7Cobservability-robots-playground%7C83)

<img width="516" alt="image" src="https://github.com/user-attachments/assets/971f3135-6b4e-4add-a34e-7351fdecff01">


