### PR TITLE
ci: use macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: go test -v ./...
 
   test-macos:
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
> the macOS 12 runner image will be removed by December 3rd, 2024

I guess we can use `latest` as we normally are using the latest OS version
