### PR TITLE
ci: support updatecli version required for the new oblt updatecli policies

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -38,12 +38,18 @@ jobs:
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose diff
+          # TODO: update to the latest version so the policies can work as expected.
+          #       latest changes in the policies require to use the dependson feature.
+          version: "v0.88.0"
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose apply
+          # TODO: update to the latest version so the policies can work as expected.
+          #       latest changes in the policies require to use the dependson feature.
+          version: "v0.88.0"
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 


### PR DESCRIPTION
### What

Fix the version to be used to the latest one for now

### Why

Otherwise, https://github.com/elastic/apm-agent-go/pull/1671 won't work

🐔 🥚  since https://github.com/updatecli/updatecli/releases/tag/v0.86.0

> Sources were always executed before conditions and then targets.
With this change, sources, conditions, and targets can now depend on any other resource type to allow an advanced update scenario.

And there are errors like

```
target: target#agent-json-specs
-----------------------

**Dry Run enabled**

The shell 🐚 command "/bin/sh /tmp/updatecli/bin/68b2939c124c411192667268d8f6edefbaa79f085494796eb8122c21afdb37bf.sh" exited on error (exit code 2) with the following output:
----
----

command stderr output was:
----
tar (child): /home/runner/work/apm-agent-go/apm-agent-go/json-specs.tgz: Cannot open: No such file or directory
```

### Test

See https://github.com/elastic/apm-agent-go/actions/runs/12117285213