### PR TITLE
Avoid `nil` values when unwrapping errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -470,7 +470,11 @@ func (b *exceptionDataBuilder) init(e *exceptionData, err error) bool {
 		}
 	case interface{ Unwrap() []error }:
 		if causes := err.Unwrap(); causes != nil {
-			e.ErrorDetails.Cause = append(e.ErrorDetails.Cause, causes...)
+			for _, cause := range causes {
+				if cause != nil {
+					e.ErrorDetails.Cause = append(e.ErrorDetails.Cause, cause)
+				}
+			}
 		}
 	case interface{ Cause() error }:
 		if cause := err.Cause(); cause != nil {
@@ -492,9 +496,6 @@ func (b *exceptionDataBuilder) init(e *exceptionData, err error) bool {
 	e.stacktrace = stacktrace.AppendErrorStacktrace(e.stacktrace, err, b.stackTraceLimit)
 
 	for _, err := range e.ErrorDetails.Cause {
-		if err == nil {
-			break
-		}
 		if b.errorCount >= maxErrorTreeNodes {
 			break
 		}

--- a/error.go
+++ b/error.go
@@ -492,6 +492,9 @@ func (b *exceptionDataBuilder) init(e *exceptionData, err error) bool {
 	e.stacktrace = stacktrace.AppendErrorStacktrace(e.stacktrace, err, b.stackTraceLimit)
 
 	for _, err := range e.ErrorDetails.Cause {
+		if err == nil {
+			break
+		}
 		if b.errorCount >= maxErrorTreeNodes {
 			break
 		}


### PR DESCRIPTION
We sometimes see Buildkite fail to add annotations to a build and when this happens, it fails with the following error:

```
{"log.level":"error","ecs.version":"1.6.0","gobld.version":"7.25.2","gobld.gitCommit":"8eae7d1","error.message":"Message: An error occurred while executing your GraphQL query. Please contact hello@buildkite.com for help and provide this query in the email., Locations: [], Extensions: map[], Path: []","error":[{"message":"An error occurred while executing your GraphQL query. Please contact hello@buildkite.com for help and provide this query in the email.","extensions":null,"locations":null,"path":null}],"@timestamp":"2024-11-22T20:25:12.306Z","log.origin":{"file.name":"/go/src/gobld/buildkite/buildkite.go","file.line":157},"trace.id":"d9ab02ae11e462233dfbcdb189fc043a","transaction.id":"d9ab02ae11e46223","trace.id":"325cf6b488e72c6e7457be8ecaf46eca","transaction.id":"325cf6b488e72c6e","span.id":"af9de4294dd6daf0","message":"Failed to annotate build"}
panic: reflect: call of reflect.Value.Type on zero Value

goroutine 319 [running]:
reflect.Value.typeSlow({0x0?, 0x0?, 0x40eb9f?})
	/usr/local/go/src/reflect/value.go:2699 +0x113
reflect.Value.Type(...)
	/usr/local/go/src/reflect/value.go:2694
go.elastic.co/apm/v2.(*exceptionDataBuilder).init(0xc0010eef50, 0xc004a800a0, {0x0, 0x0})
	/root/go/pkg/mod/go.elastic.co/apm/v2@v2.6.2/error.go:414 +0xf6
go.elastic.co/apm/v2.(*exceptionDataBuilder).init(0xc0010eef50, 0xc00af0a020, {0x343fcc0, 0xc001316588})
	/root/go/pkg/mod/go.elastic.co/apm/v2@v2.6.2/error.go:499 +0x8e5
go.elastic.co/apm/v2.initException(...)
	/root/go/pkg/mod/go.elastic.co/apm/v2@v2.6.2/error.go:402
go.elastic.co/apm/v2.(*Tracer).NewError(0x3461720?, {0x343fcc0, 0xc001316588})
	/root/go/pkg/mod/go.elastic.co/apm/v2@v2.6.2/error.go:103 +0xec
go.elastic.co/apm/v2.CaptureError({0x3461720, 0xc0008022d0}, {0x343fcc0, 0xc001316588})
	/root/go/pkg/mod/go.elastic.co/apm/v2@v2.6.2/gocontext.go:132 +0xed
http://github.com/elastic/gobld/buildkite.(*buildkite ).AnnotateBuild(0xc0006a0c20, {0x3461720?, 0xc00a55b080?}, {0xc0009d1440, 0x3c}, {0x2ce4a15, 0x11}, {0xc000969880, 0x370}, {0x2cce7a8, ...}, ...)
	/go/src/gobld/buildkite/buildkite.go:158 +0x585
http://github.com/elastic/gobld/creator.ProcessJob ({_, }, , {{0x343ee20, 0xc00a4ccb40}, {0xc00073e260, 0xd}, {0x3462308, 0xc0006a0c20}, {0xc000a14540, ...}, ...}, ...)
	/go/src/gobld/creator/creator.go:356 +0xfad
http://github.com/elastic/gobld/creator.ProcessJobs (, {, _}, {{0x343ee20, 0xc00a4ccb40}, {0xc00073e260, 0xd}, {0x3462308, 0xc0006a0c20}, {0xc000a14540, ...}, ...})
	/go/src/gobld/creator/creator.go:257 +0x3ae
created by http://github.com/elastic/gobld/creator.(*creator ).StartWorkers in goroutine 321
	/go/src/gobld/creator/creator.go:218 +0x151
```

One hunch of mine is that, somehow, the `err` passed in to `init(e *exceptionData, err error)` is nil and therefor, the `reflectValue.Type()` call on its value returns an error "Type on zero Value". If that supposition is correct, then changing the following block to confirm `err` isn't nil before passing it in would obviate the problem:

```
for _, err := range e.ErrorDetails.Cause {
  if b.errorCount >= maxErrorTreeNodes {
    break
  }
  var data exceptionData
  if b.init(&data, err) {
    e.cause = append(e.cause, data)
  }
}
```

However, I may well be (very) wrong about this so I'd welcome any feedback from people more knowledgeable around this code than I am. For one thing, I have not been able to run this modified code to confirm it has any effect on the above Buildkite crash.