### PR TITLE
Add applies_to statements

### DIFF
--- a/docs/reference/api-documentation.md
+++ b/docs/reference/api-documentation.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/api.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # API documentation [api]

--- a/docs/reference/builtin-modules.md
+++ b/docs/reference/builtin-modules.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/builtin-modules.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Built-in instrumentation modules [builtin-modules]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/configuration.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Configuration [configuration]

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/contributing.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Contributing [contributing]

--- a/docs/reference/custom-instrumentation-propagation.md
+++ b/docs/reference/custom-instrumentation-propagation.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/custom-instrumentation-propagation.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Context propagation [custom-instrumentation-propagation]

--- a/docs/reference/custom-instrumentation.md
+++ b/docs/reference/custom-instrumentation.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/custom-instrumentation.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Custom instrumentation [custom-instrumentation]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,16 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/introduction.html
   - https://www.elastic.co/guide/en/apm/agent/go/current/index.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # APM Go agent [introduction]

--- a/docs/reference/log-correlation.md
+++ b/docs/reference/log-correlation.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/log-correlation-ids.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Log correlation [log-correlation-ids]

--- a/docs/reference/logs.md
+++ b/docs/reference/logs.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/logs.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Logs [logs]

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/metrics.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Metrics [metrics]

--- a/docs/reference/opentelemetry-api.md
+++ b/docs/reference/opentelemetry-api.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/opentelemetry.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # OpenTelemetry API [opentelemetry]

--- a/docs/reference/opentracing-api.md
+++ b/docs/reference/opentracing-api.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/opentracing.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # OpenTracing API [opentracing]

--- a/docs/reference/set-up-apm-go-agent.md
+++ b/docs/reference/set-up-apm-go-agent.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/getting-started.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Set up the APM Go Agent [getting-started]

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/supported-tech.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Supported technologies [supported-tech]

--- a/docs/reference/upgrading.md
+++ b/docs/reference/upgrading.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/upgrading.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Upgrading [upgrading]

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -1,5 +1,15 @@
 ---
 navigation_title: "Deprecations"
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM deprecations

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -3,6 +3,16 @@ navigation_title: "Elastic APM Go Agent"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/go/current/release-notes-2.x.html
   - https://www.elastic.co/guide/en/apm/agent/go/current/release-notes.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm  
 ---
 
 # Elastic APM Go Agent release notes [elastic-apm-go-agent-release-notes]

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,6 +1,15 @@
 ---
 navigation_title: "Known issues"
-
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_go: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM Go Agent known issues [elastic-apm-go-agent-known-issues]


### PR DESCRIPTION
Adds ` applies_to` metadata for cumulative docs. See https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies

Contributes to https://github.com/elastic/docs-content-internal/issues/253