### PR TITLE
docs: update apmschema url to use apm-data

### DIFF
--- a/internal/apmschema/update.sh
+++ b/internal/apmschema/update.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-BRANCH=master
+BRANCH=main
 
 FILES=( \
     "error.json" \
@@ -14,5 +14,5 @@ FILES=( \
 
 for i in "${FILES[@]}"; do
   o=jsonschema/$i
-  curl -sf https://raw.githubusercontent.com/elastic/apm-server/${BRANCH}/docs/spec/v2/${i} --compressed -o $o
+  curl -sf https://raw.githubusercontent.com/elastic/apm-data/${BRANCH}/input/elasticapm/docs/spec/v2/${i} --compressed -o $o
 done


### PR DESCRIPTION
apm schema was moved to apm-data a long time ago and the apm-server files are just a mirror

update the script to use apm-data files to we can stop mirroring them in apm-server

Related to https://github.com/elastic/apm-server/issues/17707