### PR TITLE
apmfiber: update github.com/gofiber/fiber/v2 to v2.52.13

### DIFF
--- a/module/apmfiber/go.mod
+++ b/module/apmfiber/go.mod
@@ -1,7 +1,7 @@
 module go.elastic.co/apm/module/apmfiber/v2
 
 require (
-	github.com/gofiber/fiber/v2 v2.52.12
+	github.com/gofiber/fiber/v2 v2.52.13
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	github.com/valyala/fasthttp v1.51.0

--- a/module/apmfiber/go.sum
+++ b/module/apmfiber/go.sum
@@ -9,8 +9,8 @@ github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
-github.com/gofiber/fiber/v2 v2.52.12 h1:0LdToKclcPOj8PktUdIKo9BUohjjwfnQl42Dhw8/WUw=
-github.com/gofiber/fiber/v2 v2.52.12/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/gofiber/fiber/v2 v2.52.13 h1:TOKP64iqC9b5P49VrBW5tHhUOvDyrtJ0xePEfzJbCbk=
+github.com/gofiber/fiber/v2 v2.52.13/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
**NOTE**: This repository is in maintenance mode. Bug fixes will continue to be
applied, but no new features will be implemented. To replace this agent, we
recommend you to [migrate to the OpenTelemetry Go API and
SDK](https://www.elastic.co/blog/elastic-go-apm-agent-to-opentelemetry-go-sdk),
which provides similar features. In order to help you do a seamless migration,
we recommend using our [OpenTelemetry
Bridge](https://www.elastic.co/guide/en/apm/agent/go/current/opentelemetry.html).
Please refer to the blog post above for further details.
