### PR TITLE
capturebody: clamp negative remaining length so limitedBuffer.Write can't panic

### DIFF
--- a/capturebody.go
+++ b/capturebody.go
@@ -207,6 +207,11 @@ type limitedBuffer struct {
 func (b *limitedBuffer) Write(p []byte) (n int, err error) {
 	rem := (stringLengthLimit * utf8.UTFMax) - b.Len()
 	n = len(p)
+	if rem < 0 {
+		// The underlying buffer can grow past our cap if callers reuse
+		// it; clamp so p[:rem] stays in-bounds and doesn't panic.
+		rem = 0
+	}
 	if n > rem {
 		p = p[:rem]
 	}

--- a/capturebody_buffer_test.go
+++ b/capturebody_buffer_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Elasticsearch B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+package apm
+
+import "testing"
+
+// Regression for #1719: when the underlying bytes.Buffer is reused and
+// grows past the configured cap, limitedBuffer.Write must not panic on
+// the negative remaining-bytes math.
+func TestLimitedBufferOverfullDoesNotPanic(t *testing.T) {
+	b := &limitedBuffer{}
+	// Push the underlying buffer past the cap by hand.
+	for b.Len() <= stringLengthLimit*4 {
+		_, _ = b.Buffer.Write(make([]byte, 1024))
+	}
+	if _, err := b.Write(make([]byte, 512)); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1719.

When the underlying `bytes.Buffer` is reused and grows past the `stringLengthLimit*utf8.UTFMax` cap, `(cap - b.Len())` goes negative. The subsequent `p[:rem]` then panics with *slice bounds out of range* - the exact symptom on the apmfasthttp/apmfiber path in the issue.

Clamp `rem` at 0 so the slicing stays in bounds; the write itself becomes a no-op past the cap, which is the intended behaviour.