### PR TITLE
prepare release v2.7.10

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -26,6 +26,13 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % ### Fixes [elastic-apm-go-agent-versionext-fixes]
 
+## 2.7.10
+**Release date:** June 01, 2026
+
+### Fixes [elastic-apm-go-agent-2-7-10-fixes]
+* Update golang.org/x/net in apmgin to v0.55.0 to fix CVE-2026-25680,
+CVE-2026-25681, CVE-2026-42502, CVE-2026-27136 and CVE-2026-42506
+
 ## 2.7.9
 **Release date:** May 13, 2026
 

--- a/internal/apmgodog/go.mod
+++ b/internal/apmgodog/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/cucumber/godog v0.12.2
-	go.elastic.co/apm/module/apmgrpc/v2 v2.7.9
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmgrpc/v2 v2.7.10
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 	go.elastic.co/fastjson v1.5.1
 	google.golang.org/grpc v1.79.3
 	google.golang.org/grpc/examples v0.0.0-20230831183909-e498bbc9bd37

--- a/internal/apmschema/go.mod
+++ b/internal/apmschema/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/santhosh-tekuri/jsonschema v1.2.4
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/internal/apmversion/version.go
+++ b/internal/apmversion/version.go
@@ -19,5 +19,5 @@ package apmversion
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "2.7.9"
+	AgentVersion = "2.7.10"
 )

--- a/internal/tracecontexttest/go.mod
+++ b/internal/tracecontexttest/go.mod
@@ -1,6 +1,6 @@
 module tracecontexttest/v2
 
-require go.elastic.co/apm/module/apmhttp/v2 v2.7.9
+require go.elastic.co/apm/module/apmhttp/v2 v2.7.10
 
 require (
 	github.com/armon/go-radix v1.0.0 // indirect
@@ -9,7 +9,7 @@ require (
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0 // indirect
-	go.elastic.co/apm/v2 v2.7.9 // indirect
+	go.elastic.co/apm/v2 v2.7.10 // indirect
 	go.elastic.co/fastjson v1.5.1 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect

--- a/module/apmawssdkgo/go.mod
+++ b/module/apmawssdkgo/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go v1.38.14
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmazure/go.mod
+++ b/module/apmazure/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/Azure/azure-storage-file-go v0.8.0
 	github.com/Azure/azure-storage-queue-go v0.0.0-20191125232315-636801874cdd
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmbeego/go.mod
+++ b/module/apmbeego/go.mod
@@ -3,9 +3,9 @@ module go.elastic.co/apm/module/apmbeego/v2
 require (
 	github.com/astaxie/beego v1.12.3
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/module/apmsql/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/module/apmsql/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmchi/go.mod
+++ b/module/apmchi/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmchi/v2
 require (
 	github.com/go-chi/chi v1.5.1
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmchiv5/go.mod
+++ b/module/apmchiv5/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmchiv5/v2
 require (
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmecho/go.mod
+++ b/module/apmecho/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmechov4/go.mod
+++ b/module/apmechov4/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmelasticsearch/go.mod
+++ b/module/apmelasticsearch/go.mod
@@ -2,8 +2,8 @@ module go.elastic.co/apm/module/apmelasticsearch/v2
 
 require (
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmelasticsearch/internal/integration/go.mod
+++ b/module/apmelasticsearch/internal/integration/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.5.0
 	github.com/olivere/elastic v6.2.16+incompatible
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmelasticsearch/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (
@@ -20,7 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0 // indirect
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9 // indirect
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10 // indirect
 	go.elastic.co/fastjson v1.5.1 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/module/apmfasthttp/go.mod
+++ b/module/apmfasthttp/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.34.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmfiber/go.mod
+++ b/module/apmfiber/go.mod
@@ -5,9 +5,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	github.com/valyala/fasthttp v1.51.0
-	go.elastic.co/apm/module/apmfasthttp/v2 v2.7.9
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmfasthttp/v2 v2.7.10
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgin/go.mod
+++ b/module/apmgin/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgocql/go.mod
+++ b/module/apmgocql/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmgocql/v2
 require (
 	github.com/gocql/gocql v0.0.0-20181124151448-70385f88b28b
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgokit/go.mod
+++ b/module/apmgokit/go.mod
@@ -4,9 +4,9 @@ require (
 	github.com/go-kit/kit v0.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmgrpc/v2 v2.7.9
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmgrpc/v2 v2.7.10
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 	google.golang.org/grpc v1.79.3
 	google.golang.org/grpc/examples v0.0.0-20230831183909-e498bbc9bd37
 )

--- a/module/apmgometrics/go.mod
+++ b/module/apmgometrics/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmgometrics/v2
 require (
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgopg/go.mod
+++ b/module/apmgopg/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmgopg/v2
 require (
 	github.com/go-pg/pg v8.0.7+incompatible
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmsql/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmsql/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgopgv10/go.mod
+++ b/module/apmgopgv10/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/go-pg/pg/v10 v10.15.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmsql/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmsql/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgoredis/go.mod
+++ b/module/apmgoredis/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgoredisv8/go.mod
+++ b/module/apmgoredisv8/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgorilla/go.mod
+++ b/module/apmgorilla/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmgorilla/v2
 require (
 	github.com/gorilla/mux v1.6.2
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgorm/go.mod
+++ b/module/apmgorm/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/jinzhu/gorm v1.9.10
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmsql/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmsql/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmgormv2/go.mod
+++ b/module/apmgormv2/go.mod
@@ -2,8 +2,8 @@ module go.elastic.co/apm/module/apmgormv2/v2
 
 require (
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmsql/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmsql/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 	gorm.io/driver/mysql v1.5.2
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/driver/sqlite v1.5.4

--- a/module/apmgrpc/go.mod
+++ b/module/apmgrpc/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 	google.golang.org/grpc v1.79.3
 	google.golang.org/grpc/examples v0.0.0-20230831183909-e498bbc9bd37
 	google.golang.org/protobuf v1.36.10

--- a/module/apmhttp/go.mod
+++ b/module/apmhttp/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmhttp/v2
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmhttprouter/go.mod
+++ b/module/apmhttprouter/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmhttprouter/v2
 require (
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmlambda/go.mod
+++ b/module/apmlambda/go.mod
@@ -2,7 +2,7 @@ module go.elastic.co/apm/module/apmlambda/v2
 
 require (
 	github.com/aws/aws-lambda-go v1.8.0
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmlogrus/go.mod
+++ b/module/apmlogrus/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.3
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmmongo/go.mod
+++ b/module/apmmongo/go.mod
@@ -2,7 +2,7 @@ module go.elastic.co/apm/module/apmmongo/v2
 
 require (
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 	go.mongodb.org/mongo-driver v1.5.1
 )
 

--- a/module/apmnegroni/go.mod
+++ b/module/apmnegroni/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/negroni v1.0.0
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmot/go.mod
+++ b/module/apmot/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmot/v2
 require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmotel/go.mod
+++ b/module/apmotel/go.mod
@@ -2,8 +2,8 @@ module go.elastic.co/apm/module/apmotel/v2
 
 require (
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/module/apmpgx/go.mod
+++ b/module/apmpgx/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmsql/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmsql/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmpgxv5/go.mod
+++ b/module/apmpgxv5/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/module/apmsql/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmsql/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmprometheus/go.mod
+++ b/module/apmprometheus/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmredigo/go.mod
+++ b/module/apmredigo/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmredigo/v2
 require (
 	github.com/gomodule/redigo v1.8.2
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmrestful/go.mod
+++ b/module/apmrestful/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmrestful/v2
 require (
 	github.com/emicklei/go-restful/v3 v3.12.0
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmrestfulv3/go.mod
+++ b/module/apmrestfulv3/go.mod
@@ -3,8 +3,8 @@ module go.elastic.co/apm/module/apmrestfulv3/v2
 require (
 	github.com/emicklei/go-restful/v3 v3.8.0
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/module/apmhttp/v2 v2.7.9
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/module/apmhttp/v2 v2.7.10
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmslog/go.mod
+++ b/module/apmslog/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmslog/v2
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmsql/go.mod
+++ b/module/apmsql/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/microsoft/go-mssqldb v1.6.0
 	github.com/stretchr/testify v1.11.1
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/module/apmzap/go.mod
+++ b/module/apmzap/go.mod
@@ -3,7 +3,7 @@ module go.elastic.co/apm/module/apmzap/v2
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 	go.uber.org/zap v1.9.1
 )
 

--- a/module/apmzerolog/go.mod
+++ b/module/apmzerolog/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.14.3
 	github.com/stretchr/testify v1.8.4
-	go.elastic.co/apm/v2 v2.7.9
+	go.elastic.co/apm/v2 v2.7.10
 )
 
 require (

--- a/scripts/genmod/go.mod
+++ b/scripts/genmod/go.mod
@@ -1,6 +1,6 @@
 module genmod/v2
 
-require go.elastic.co/apm/v2 v2.7.9
+require go.elastic.co/apm/v2 v2.7.10
 
 require (
 	github.com/armon/go-radix v1.0.0 // indirect

--- a/version.go
+++ b/version.go
@@ -19,5 +19,5 @@ package apm // import "go.elastic.co/apm/v2"
 
 const (
 	// AgentVersion is the Elastic APM Go Agent version.
-	AgentVersion = "2.7.9"
+	AgentVersion = "2.7.10"
 )


### PR DESCRIPTION
**NOTE**: This repository is in maintenance mode. Bug fixes will continue to be
applied, but no new features will be implemented. To replace this agent, we
recommend you to [migrate to the OpenTelemetry Go API and
SDK](https://www.elastic.co/blog/elastic-go-apm-agent-to-opentelemetry-go-sdk),
which provides similar features. In order to help you do a seamless migration,
we recommend using our [OpenTelemetry
Bridge](https://www.elastic.co/guide/en/apm/agent/go/current/opentelemetry.html).
Please refer to the blog post above for further details.
